### PR TITLE
Include user-scoped cache keys and evict on mutations

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
@@ -7,6 +7,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Repositories.Cliente.ClienteRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -29,7 +30,7 @@ public class ClienteService {
         return clienteRepository.findByOwnerUser(usuario);
     }
 
-    @Cacheable("clientes")
+    @Cacheable(value = "clientes", key = "#loggedUser.id + '-' + #pesquisa.hashCode()")
     @Transactional(readOnly = true)
     public List<Cliente> listarClientes(User loggedUser, ClienteSearch pesquisa) {
         // Configuração de paginação e ordenação
@@ -61,6 +62,7 @@ public class ClienteService {
                 .orElseThrow(() -> new EntityNotFoundException("Cliente não encontrado"));
     }
 
+    @CacheEvict(value = "clientes", allEntries = true)
     public Cliente criarCliente(User loggedUser, Cliente cliente) {
         cliente.setId(null);
         cliente.setOwnerUser(loggedUser);
@@ -69,6 +71,7 @@ public class ClienteService {
         return clienteRepository.save(cliente);
     }
 
+    @CacheEvict(value = "clientes", allEntries = true)
     public Cliente editarCliente(User loggedUser, Integer idCliente, Cliente cliente) {
         Cliente clienteSalvo = listarUmCliente(loggedUser, idCliente);
         cliente.setId(clienteSalvo.getId());
@@ -78,6 +81,7 @@ public class ClienteService {
         return clienteRepository.save(cliente);
     }
 
+    @CacheEvict(value = "clientes", allEntries = true)
     public void inativarCliente(User loggedUser, Integer idCliente) {
         Cliente cliente = listarUmCliente(loggedUser, idCliente);
         cliente.setAtivo(false);

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -25,6 +25,7 @@ import com.AIT.Optimanage.Services.ProdutoService;
 import com.AIT.Optimanage.Services.ServicoService;
 import com.AIT.Optimanage.Services.User.ContadorService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -51,7 +52,7 @@ public class CompraService {
     private final CompraServicoRepository compraServicoRepository;
     private final PagamentoCompraService pagamentoCompraService;
 
-    @Cacheable("compras")
+    @Cacheable(value = "compras", key = "#loggedUser.id + '-' + #pesquisa.hashCode()")
     @Transactional(readOnly = true)
     public List<Compra> listarCompras(User loggedUser, CompraSearch pesquisa) {
         // Configuração de paginação e ordenação
@@ -83,6 +84,7 @@ public class CompraService {
     }
 
     @Transactional
+    @CacheEvict(value = "compras", allEntries = true)
     public Compra criarCompra(User loggedUser, CompraDTO compraDTO) {
         validarCompra(compraDTO, loggedUser);
 
@@ -122,6 +124,7 @@ public class CompraService {
     }
 
     @Transactional
+    @CacheEvict(value = "compras", allEntries = true)
     public Compra editarCompra(User loggedUser, Integer idCompra, CompraDTO compraDTO) {
         validarCompra(compraDTO, loggedUser);
 
@@ -242,6 +245,7 @@ public class CompraService {
         return compraRepository.save(compra);
     }
 
+    @CacheEvict(value = "compras", allEntries = true)
     public Compra cancelarCompra(User loggedUser, Integer idCompra) {
         Compra compra = listarUmaCompra(loggedUser, idCompra);
         atualizarStatus(compra, StatusCompra.CANCELADO);

--- a/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
@@ -8,6 +8,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Repositories.Fornecedor.FornecedorRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,7 +27,7 @@ public class FornecedorService {
 
     private final FornecedorRepository fornecedorRepository;
 
-    @Cacheable("fornecedores")
+    @Cacheable(value = "fornecedores", key = "#loggedUser.id + '-' + #pesquisa.hashCode()")
     @Transactional(readOnly = true)
     public List<Fornecedor> listarFornecedores(User loggedUser, FornecedorSearch pesquisa) {
         // Configuração de paginação e ordenação
@@ -58,6 +59,7 @@ public class FornecedorService {
                 .orElseThrow(() -> new EntityNotFoundException("Fornecedor não encontrado"));
     }
 
+    @CacheEvict(value = "fornecedores", allEntries = true)
     public Fornecedor criarFornecedor(User loggedUser, Fornecedor fornecedor) {
         fornecedor.setOwnerUser(loggedUser);
         fornecedor.setDataCadastro(LocalDate.now());
@@ -65,6 +67,7 @@ public class FornecedorService {
         return fornecedorRepository.save(fornecedor);
     }
 
+    @CacheEvict(value = "fornecedores", allEntries = true)
     public Fornecedor editarFornecedor(User loggedUser, Integer idFornecedor, Fornecedor fornecedor) {
         Fornecedor fornecedorSalvo = listarUmFornecedor(loggedUser, idFornecedor);
 
@@ -75,6 +78,7 @@ public class FornecedorService {
         return fornecedorRepository.save(fornecedorSalvo);
     }
 
+    @CacheEvict(value = "fornecedores", allEntries = true)
     public void inativarFornecedor(User loggedUser, Integer idFornecedor) {
         Fornecedor fornecedor = listarUmFornecedor(loggedUser, idFornecedor);
         fornecedor.setAtivo(false);

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -26,6 +26,7 @@ import com.AIT.Optimanage.Services.ServicoService;
 import com.AIT.Optimanage.Services.User.ContadorService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -52,7 +53,7 @@ public class VendaService {
     private final ContadorService contadorService;
     private final PagamentoVendaService pagamentoVendaService;
 
-    @Cacheable("vendas")
+    @Cacheable(value = "vendas", key = "#loggedUser.id + '-' + #pesquisa.hashCode()")
     @Transactional(readOnly = true)
     public List<Venda> listarVendas(User loggedUser, VendaSearch pesquisa) {
         // Configuração de paginação e ordenação
@@ -83,6 +84,7 @@ public class VendaService {
     }
 
     @Transactional
+    @CacheEvict(value = "vendas", allEntries = true)
     public Venda registrarVenda(User loggedUser, VendaDTO vendaDTO) {
         validarVenda(vendaDTO, loggedUser);
 
@@ -127,6 +129,7 @@ public class VendaService {
     }
 
     @Transactional
+    @CacheEvict(value = "vendas", allEntries = true)
     public Venda atualizarVenda(User loggedUser, Integer vendaId, VendaDTO vendaDTO) {
         validarVenda(vendaDTO, loggedUser);
 
@@ -287,6 +290,7 @@ public class VendaService {
         return vendaRepository.save(venda);
     }
 
+    @CacheEvict(value = "vendas", allEntries = true)
     public Venda cancelarVenda(User loggedUser, Integer idVenda) {
         Venda venda = listarUmaVenda(loggedUser, idVenda);
         if (venda.getStatus() == StatusVenda.CONCRETIZADA) {


### PR DESCRIPTION
## Summary
- scope cache entries by user ID and search hash for clients, suppliers, purchases, and sales
- clear respective caches when creating, editing, or deactivating entities

## Testing
- `bash ./mvnw -q test` *(fails: wget failed to fetch Maven due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a89c77e7388324ab546a0d9faf56b4