### PR TITLE
feat: add request DTOs and validation

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteController.java
@@ -1,9 +1,9 @@
 package com.AIT.Optimanage.Controllers.Cliente;
 
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
+import com.AIT.Optimanage.Controllers.dto.ClienteRequest;
 import com.AIT.Optimanage.Models.Cliente.Cliente;
 import com.AIT.Optimanage.Models.Cliente.Search.ClienteSearch;
-import com.AIT.Optimanage.Models.Enums.PageOrder;
 import com.AIT.Optimanage.Models.Enums.TipoPessoa;
 import com.AIT.Optimanage.Models.User.User;
 
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 
@@ -63,13 +64,16 @@ public class ClienteController extends V1BaseController {
     }
 
     @PostMapping
-    public Cliente criarCliente(@AuthenticationPrincipal User loggedUser, @RequestBody Cliente cliente) {
-        return clienteService.criarCliente(loggedUser, cliente);
+    public Cliente criarCliente(@AuthenticationPrincipal User loggedUser,
+                                @RequestBody @Valid ClienteRequest request) {
+        return clienteService.criarCliente(loggedUser, request);
     }
 
     @PutMapping("/{idCliente}")
-    public Cliente editarCliente(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idCliente, @RequestBody Cliente cliente) {
-        return clienteService.editarCliente(loggedUser, idCliente, cliente);
+    public Cliente editarCliente(@AuthenticationPrincipal User loggedUser,
+                                 @PathVariable Integer idCliente,
+                                 @RequestBody @Valid ClienteRequest request) {
+        return clienteService.editarCliente(loggedUser, idCliente, request);
     }
 
     @DeleteMapping("/{idCliente}")

--- a/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorController.java
@@ -1,6 +1,7 @@
 package com.AIT.Optimanage.Controllers.Fornecedor;
 
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
+import com.AIT.Optimanage.Controllers.dto.FornecedorRequest;
 import com.AIT.Optimanage.Models.Enums.TipoPessoa;
 import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
 import com.AIT.Optimanage.Models.Fornecedor.Search.FornecedorSearch;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 
@@ -55,13 +57,16 @@ public class FornecedorController extends V1BaseController {
     }
 
     @PostMapping
-    public Fornecedor criarFornecedor(@AuthenticationPrincipal User loggedUser, @RequestBody Fornecedor fornecedor) {
-        return fornecedorService.criarFornecedor(loggedUser, fornecedor);
+    public Fornecedor criarFornecedor(@AuthenticationPrincipal User loggedUser,
+                                     @RequestBody @Valid FornecedorRequest request) {
+        return fornecedorService.criarFornecedor(loggedUser, request);
     }
 
     @PutMapping("/{idFornecedor}")
-    public Fornecedor editarFornecedor(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idFornecedor, @RequestBody Fornecedor fornecedor) {
-        return fornecedorService.editarFornecedor(loggedUser, idFornecedor, fornecedor);
+    public Fornecedor editarFornecedor(@AuthenticationPrincipal User loggedUser,
+                                       @PathVariable Integer idFornecedor,
+                                       @RequestBody @Valid FornecedorRequest request) {
+        return fornecedorService.editarFornecedor(loggedUser, idFornecedor, request);
     }
 
     @DeleteMapping("/{idFornecedor}")

--- a/src/main/java/com/AIT/Optimanage/Controllers/ProdutoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/ProdutoController.java
@@ -1,10 +1,12 @@
 package com.AIT.Optimanage.Controllers;
 
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
+import com.AIT.Optimanage.Controllers.dto.ProdutoRequest;
 import com.AIT.Optimanage.Models.Produto;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.ProdutoService;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -27,13 +29,16 @@ public class ProdutoController extends V1BaseController {
     }
 
     @PostMapping
-    public Produto cadastrarProduto(@AuthenticationPrincipal User loggedUser, @RequestBody Produto produto) {
-        return produtoService.cadastrarProduto(loggedUser, produto);
+    public Produto cadastrarProduto(@AuthenticationPrincipal User loggedUser,
+                                    @RequestBody @Valid ProdutoRequest request) {
+        return produtoService.cadastrarProduto(loggedUser, request);
     }
 
     @PutMapping("/{idProduto}")
-    public Produto editarProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto, @RequestBody Produto produto) {
-        return produtoService.editarProduto(loggedUser, idProduto, produto);
+    public Produto editarProduto(@AuthenticationPrincipal User loggedUser,
+                                 @PathVariable Integer idProduto,
+                                 @RequestBody @Valid ProdutoRequest request) {
+        return produtoService.editarProduto(loggedUser, idProduto, request);
     }
 
     @DeleteMapping("/{idProduto}")

--- a/src/main/java/com/AIT/Optimanage/Controllers/ServicoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/ServicoController.java
@@ -1,10 +1,12 @@
 package com.AIT.Optimanage.Controllers;
 
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
+import com.AIT.Optimanage.Controllers.dto.ServicoRequest;
 import com.AIT.Optimanage.Models.Servico;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.ServicoService;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,13 +30,16 @@ public class ServicoController extends V1BaseController {
     }
 
     @PostMapping
-    public Servico cadastrarServico(@AuthenticationPrincipal User loggedUser, @RequestBody Servico servico) {
-        return servicoService.cadastrarServico(loggedUser, servico);
+    public Servico cadastrarServico(@AuthenticationPrincipal User loggedUser,
+                                    @RequestBody @Valid ServicoRequest request) {
+        return servicoService.cadastrarServico(loggedUser, request);
     }
 
     @PutMapping("/{idServico}")
-    public Servico editarServico(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idServico, @RequestBody Servico servico) {
-        return servicoService.editarServico(loggedUser, idServico, servico);
+    public Servico editarServico(@AuthenticationPrincipal User loggedUser,
+                                 @PathVariable Integer idServico,
+                                 @RequestBody @Valid ServicoRequest request) {
+        return servicoService.editarServico(loggedUser, idServico, request);
     }
 
     @DeleteMapping("/{idServico}")

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteRequest.java
@@ -1,0 +1,53 @@
+package com.AIT.Optimanage.Controllers.dto;
+
+import com.AIT.Optimanage.Models.Enums.TipoPessoa;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClienteRequest {
+
+    @NotNull
+    private Integer atividadeId;
+
+    @NotNull
+    private TipoPessoa tipoPessoa;
+
+    @NotBlank
+    private String origem;
+
+    private Boolean ativo;
+
+    @Size(max = 64)
+    private String nome;
+
+    @Size(max = 55)
+    private String nomeFantasia;
+
+    @Size(max = 64)
+    private String razaoSocial;
+
+    @Size(max = 14)
+    private String cpf;
+
+    @Size(max = 18)
+    private String cnpj;
+
+    @Size(max = 18)
+    private String inscricaoEstadual;
+
+    @Size(max = 18)
+    private String inscricaoMunicipal;
+
+    @Size(max = 64)
+    private String site;
+
+    @Size(max = 256)
+    private String informacoesAdicionais;
+}

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/FornecedorRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/FornecedorRequest.java
@@ -1,0 +1,53 @@
+package com.AIT.Optimanage.Controllers.dto;
+
+import com.AIT.Optimanage.Models.Enums.TipoPessoa;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FornecedorRequest {
+
+    @NotNull
+    private Integer atividadeId;
+
+    @NotNull
+    private TipoPessoa tipoPessoa;
+
+    @NotBlank
+    private String origem;
+
+    private Boolean ativo;
+
+    @Size(max = 64)
+    private String nome;
+
+    @Size(max = 55)
+    private String nomeFantasia;
+
+    @Size(max = 64)
+    private String razaoSocial;
+
+    @Size(max = 14)
+    private String cpf;
+
+    @Size(max = 18)
+    private String cnpj;
+
+    @Size(max = 18)
+    private String inscricaoEstadual;
+
+    @Size(max = 18)
+    private String inscricaoMunicipal;
+
+    @Size(max = 64)
+    private String site;
+
+    @Size(max = 256)
+    private String informacoesAdicionais;
+}

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoRequest.java
@@ -1,0 +1,42 @@
+package com.AIT.Optimanage.Controllers.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProdutoRequest {
+
+    private Integer fornecedorId;
+
+    @NotNull
+    private Integer sequencialUsuario;
+
+    @NotBlank
+    private String codigoReferencia;
+
+    @NotBlank
+    private String nome;
+
+    private String descricao;
+
+    @NotNull
+    @PositiveOrZero
+    private Double custo;
+
+    private Boolean disponivelVenda;
+
+    @NotNull
+    @PositiveOrZero
+    private Double valorVenda;
+
+    @NotNull
+    private Integer qtdEstoque;
+
+    private Boolean terceirizado;
+}

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ServicoRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ServicoRequest.java
@@ -1,0 +1,39 @@
+package com.AIT.Optimanage.Controllers.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ServicoRequest {
+
+    private Integer fornecedorId;
+
+    @NotNull
+    private Integer sequencialUsuario;
+
+    @NotBlank
+    private String nome;
+
+    private String descricao;
+
+    @NotNull
+    @PositiveOrZero
+    private Double custo;
+
+    private Boolean disponivelVenda;
+
+    @NotNull
+    @PositiveOrZero
+    private Double valorVenda;
+
+    @NotNull
+    private Integer tempoExecucao;
+
+    private Boolean terceirizado;
+}

--- a/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
@@ -1,5 +1,7 @@
 package com.AIT.Optimanage.Services.Cliente;
 
+import com.AIT.Optimanage.Controllers.dto.ClienteRequest;
+import com.AIT.Optimanage.Models.Atividade;
 import com.AIT.Optimanage.Models.Cliente.Cliente;
 import com.AIT.Optimanage.Models.Cliente.Search.ClienteSearch;
 import com.AIT.Optimanage.Models.Enums.TipoPessoa;
@@ -61,7 +63,8 @@ public class ClienteService {
                 .orElseThrow(() -> new EntityNotFoundException("Cliente não encontrado"));
     }
 
-    public Cliente criarCliente(User loggedUser, Cliente cliente) {
+    public Cliente criarCliente(User loggedUser, ClienteRequest request) {
+        Cliente cliente = fromRequest(request);
         cliente.setId(null);
         cliente.setOwnerUser(loggedUser);
         cliente.setDataCadastro(LocalDate.now());
@@ -69,8 +72,9 @@ public class ClienteService {
         return clienteRepository.save(cliente);
     }
 
-    public Cliente editarCliente(User loggedUser, Integer idCliente, Cliente cliente) {
+    public Cliente editarCliente(User loggedUser, Integer idCliente, ClienteRequest request) {
         Cliente clienteSalvo = listarUmCliente(loggedUser, idCliente);
+        Cliente cliente = fromRequest(request);
         cliente.setId(clienteSalvo.getId());
         cliente.setOwnerUser(clienteSalvo.getOwnerUser());
         cliente.setDataCadastro(clienteSalvo.getDataCadastro());
@@ -100,5 +104,25 @@ public class ClienteService {
             cliente.setCpf(null);
         }
 
+    }
+
+    private Cliente fromRequest(ClienteRequest request) {
+        Cliente cliente = new Cliente();
+        Atividade atividade = new Atividade();
+        atividade.setId(request.getAtividadeId());
+        cliente.setAtividade(atividade);
+        cliente.setTipoPessoa(request.getTipoPessoa());
+        cliente.setOrigem(request.getOrigem());
+        cliente.setAtivo(request.getAtivo() != null ? request.getAtivo() : true);
+        cliente.setNome(request.getNome());
+        cliente.setNomeFantasia(request.getNomeFantasia());
+        cliente.setRazaoSocial(request.getRazaoSocial());
+        cliente.setCpf(request.getCpf());
+        cliente.setCnpj(request.getCnpj());
+        cliente.setInscricaoEstadual(request.getInscricaoEstadual());
+        cliente.setInscricaoMunicipal(request.getInscricaoMunicipal());
+        cliente.setSite(request.getSite());
+        cliente.setInformacoesAdicionais(request.getInformacoesAdicionais());
+        return cliente;
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
@@ -1,5 +1,7 @@
 package com.AIT.Optimanage.Services.Fornecedor;
 
+import com.AIT.Optimanage.Controllers.dto.FornecedorRequest;
+import com.AIT.Optimanage.Models.Atividade;
 import com.AIT.Optimanage.Models.Cliente.Cliente;
 import com.AIT.Optimanage.Models.Enums.TipoPessoa;
 import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
@@ -58,21 +60,22 @@ public class FornecedorService {
                 .orElseThrow(() -> new EntityNotFoundException("Fornecedor não encontrado"));
     }
 
-    public Fornecedor criarFornecedor(User loggedUser, Fornecedor fornecedor) {
+    public Fornecedor criarFornecedor(User loggedUser, FornecedorRequest request) {
+        Fornecedor fornecedor = fromRequest(request);
         fornecedor.setOwnerUser(loggedUser);
         fornecedor.setDataCadastro(LocalDate.now());
         validarFornecedor(loggedUser, fornecedor);
         return fornecedorRepository.save(fornecedor);
     }
 
-    public Fornecedor editarFornecedor(User loggedUser, Integer idFornecedor, Fornecedor fornecedor) {
+    public Fornecedor editarFornecedor(User loggedUser, Integer idFornecedor, FornecedorRequest request) {
         Fornecedor fornecedorSalvo = listarUmFornecedor(loggedUser, idFornecedor);
-
+        Fornecedor fornecedor = fromRequest(request);
         fornecedor.setId(fornecedorSalvo.getId());
         fornecedor.setOwnerUser(fornecedorSalvo.getOwnerUser());
         fornecedor.setDataCadastro(fornecedorSalvo.getDataCadastro());
         validarFornecedor(loggedUser, fornecedor);
-        return fornecedorRepository.save(fornecedorSalvo);
+        return fornecedorRepository.save(fornecedor);
     }
 
     public void inativarFornecedor(User loggedUser, Integer idFornecedor) {
@@ -96,5 +99,25 @@ public class FornecedorService {
             fornecedor.setCpf(null);
         }
 
+    }
+
+    private Fornecedor fromRequest(FornecedorRequest request) {
+        Fornecedor fornecedor = new Fornecedor();
+        Atividade atividade = new Atividade();
+        atividade.setId(request.getAtividadeId());
+        fornecedor.setAtividade(atividade);
+        fornecedor.setTipoPessoa(request.getTipoPessoa());
+        fornecedor.setOrigem(request.getOrigem());
+        fornecedor.setAtivo(request.getAtivo() != null ? request.getAtivo() : true);
+        fornecedor.setNome(request.getNome());
+        fornecedor.setNomeFantasia(request.getNomeFantasia());
+        fornecedor.setRazaoSocial(request.getRazaoSocial());
+        fornecedor.setCpf(request.getCpf());
+        fornecedor.setCnpj(request.getCnpj());
+        fornecedor.setInscricaoEstadual(request.getInscricaoEstadual());
+        fornecedor.setInscricaoMunicipal(request.getInscricaoMunicipal());
+        fornecedor.setSite(request.getSite());
+        fornecedor.setInformacoesAdicionais(request.getInformacoesAdicionais());
+        return fornecedor;
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
@@ -1,5 +1,7 @@
 package com.AIT.Optimanage.Services;
 
+import com.AIT.Optimanage.Controllers.dto.ProdutoRequest;
+import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
 import com.AIT.Optimanage.Models.Produto;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Repositories.ProdutoRepository;
@@ -24,14 +26,16 @@ public class ProdutoService {
         );
     }
 
-    public Produto cadastrarProduto(User loggedUser, Produto produto) {
+    public Produto cadastrarProduto(User loggedUser, ProdutoRequest request) {
+        Produto produto = fromRequest(request);
         produto.setId(null);
         produto.setOwnerUser(loggedUser);
         return produtoRepository.save(produto);
     }
 
-    public Produto editarProduto(User loggedUser, Integer idProduto, Produto produto) {
+    public Produto editarProduto(User loggedUser, Integer idProduto, ProdutoRequest request) {
         Produto produtoSalvo = listarUmProduto(loggedUser, idProduto);
+        Produto produto = fromRequest(request);
         produto.setId(produtoSalvo.getId());
         produto.setOwnerUser(produtoSalvo.getOwnerUser());
         return produtoRepository.save(produto);
@@ -40,5 +44,24 @@ public class ProdutoService {
     public void excluirProduto(User loggedUser, Integer idProduto) {
         Produto produto = listarUmProduto(loggedUser, idProduto);
         produtoRepository.delete(produto);
+    }
+
+    private Produto fromRequest(ProdutoRequest request) {
+        Produto produto = new Produto();
+        if (request.getFornecedorId() != null) {
+            Fornecedor fornecedor = new Fornecedor();
+            fornecedor.setId(request.getFornecedorId());
+            produto.setFornecedor(fornecedor);
+        }
+        produto.setSequencialUsuario(request.getSequencialUsuario());
+        produto.setCodigoReferencia(request.getCodigoReferencia());
+        produto.setNome(request.getNome());
+        produto.setDescricao(request.getDescricao());
+        produto.setCusto(request.getCusto());
+        produto.setDisponivelVenda(request.getDisponivelVenda());
+        produto.setValorVenda(request.getValorVenda());
+        produto.setQtdEstoque(request.getQtdEstoque());
+        produto.setTerceirizado(request.getTerceirizado());
+        return produto;
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Services/ServicoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ServicoService.java
@@ -1,5 +1,7 @@
 package com.AIT.Optimanage.Services;
 
+import com.AIT.Optimanage.Controllers.dto.ServicoRequest;
+import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
 import com.AIT.Optimanage.Models.Servico;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Repositories.ServicoRepository;
@@ -26,14 +28,16 @@ public class ServicoService {
         );
     }
 
-    public Servico cadastrarServico(User loggedUser, Servico servico) {
+    public Servico cadastrarServico(User loggedUser, ServicoRequest request) {
+        Servico servico = fromRequest(request);
         servico.setId(null);
         servico.setOwnerUser(loggedUser);
         return servicoRepository.save(servico);
     }
 
-    public Servico editarServico(User loggedUser, Integer idServico, Servico servico) {
+    public Servico editarServico(User loggedUser, Integer idServico, ServicoRequest request) {
         Servico servicoSalvo = listarUmServico(loggedUser, idServico);
+        Servico servico = fromRequest(request);
         servico.setId(servicoSalvo.getId());
         servico.setOwnerUser(servicoSalvo.getOwnerUser());
         return servicoRepository.save(servico);
@@ -42,5 +46,23 @@ public class ServicoService {
     public void excluirServico(User loggedUser, Integer idServico) {
         Servico servico = listarUmServico(loggedUser, idServico);
         servicoRepository.delete(servico);
+    }
+
+    private Servico fromRequest(ServicoRequest request) {
+        Servico servico = new Servico();
+        if (request.getFornecedorId() != null) {
+            Fornecedor fornecedor = new Fornecedor();
+            fornecedor.setId(request.getFornecedorId());
+            servico.setFornecedor(fornecedor);
+        }
+        servico.setSequencialUsuario(request.getSequencialUsuario());
+        servico.setNome(request.getNome());
+        servico.setDescricao(request.getDescricao());
+        servico.setCusto(request.getCusto());
+        servico.setDisponivelVenda(request.getDisponivelVenda());
+        servico.setValorVenda(request.getValorVenda());
+        servico.setTempoExecucao(request.getTempoExecucao());
+        servico.setTerceirizado(request.getTerceirizado());
+        return servico;
     }
 }


### PR DESCRIPTION
## Summary
- add request DTO classes with bean validation for Produto, Servico, Cliente and Fornecedor
- update controllers to accept `@Valid` DTOs instead of entities
- convert DTOs to entities within service layer

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a89c5dc7b88324a560c9a99c0744cd