### PR TITLE
Respect user active flag in isEnabled method and add tests

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/User/User.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/User.java
@@ -76,6 +76,6 @@ public class User implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return Boolean.TRUE.equals(ativo);
     }
 }

--- a/src/test/java/com/AIT/Optimanage/Models/User/UserTest.java
+++ b/src/test/java/com/AIT/Optimanage/Models/User/UserTest.java
@@ -1,0 +1,28 @@
+package com.AIT.Optimanage.Models.User;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserTest {
+
+    @Test
+    void isEnabledReturnsFalseWhenAtivoIsFalse() {
+        User user = new User();
+        user.setAtivo(false);
+        assertFalse(user.isEnabled());
+    }
+
+    @Test
+    void isEnabledReturnsTrueWhenAtivoIsTrue() {
+        User user = new User();
+        user.setAtivo(true);
+        assertTrue(user.isEnabled());
+    }
+
+    @Test
+    void isEnabledReturnsFalseWhenAtivoIsNull() {
+        User user = new User();
+        user.setAtivo(null);
+        assertFalse(user.isEnabled());
+    }
+}


### PR DESCRIPTION
## Summary
- Use `Boolean.TRUE.equals(ativo)` in `User.isEnabled` to properly handle inactive or null users
- Add unit tests covering active, inactive, and null `ativo` states

## Testing
- `mvn -q test` *(fails: Network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ce6cad808324a5a76aac92a5b74e