### PR TITLE
Add private password field to AuthenticationRequest

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Auth/AuthenticationRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Auth/AuthenticationRequest.java
@@ -12,5 +12,5 @@ import lombok.NoArgsConstructor;
 public class AuthenticationRequest {
 
     private String email;
-    String senha;
+    private String senha;
 }


### PR DESCRIPTION
## Summary
- define password field as private in AuthenticationRequest for proper encapsulation

## Testing
- `mvn -q compile` *(fails: Non-resolvable parent POM: Could not transfer artifact from central; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ada8e66e88832488ce1236f85954e3