### PR TITLE
Use BigDecimal for product monetary fields

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoRequest.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -27,13 +29,13 @@ public class ProdutoRequest {
 
     @NotNull
     @PositiveOrZero
-    private Double custo;
+    private BigDecimal custo;
 
     private Boolean disponivelVenda;
 
     @NotNull
     @PositiveOrZero
-    private Double valorVenda;
+    private BigDecimal valorVenda;
 
     @NotNull
     private Integer qtdEstoque;

--- a/src/main/java/com/AIT/Optimanage/Models/Produto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Produto.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Data
@@ -37,7 +38,7 @@ public class Produto {
 
     @JsonProperty("fornecedor_id")
     public Integer getFornecedorId() {
-        return fornecedor.getId();
+        return fornecedor != null ? fornecedor.getId() : null;
     }
 
     @Column(nullable = false)
@@ -47,11 +48,11 @@ public class Produto {
     @Column(nullable = false)
     private String nome;
     private String descricao;
-    @Column(nullable = false, length = 10, precision = 2)
-    private Double custo;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal custo;
     private Boolean disponivelVenda;
-    @Column(nullable = false, length = 10, precision = 2)
-    private Double valorVenda;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorVenda;
     @Column(nullable = false)
     private Integer qtdEstoque;
     private Boolean terceirizado;

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -256,14 +257,15 @@ public class CompraService {
         return produtosDTO.stream()
                 .map(produtoDTO -> {
                     Produto produto = produtoService.listarUmProduto(compra.getOwnerUser(), produtoDTO.getProdutoId());
-                    double valorFinalProduto = produto.getValorVenda() * produtoDTO.getQuantidade();
+                    BigDecimal valorFinalProduto = produto.getValorVenda()
+                            .multiply(BigDecimal.valueOf(produtoDTO.getQuantidade()));
 
                     return CompraProduto.builder()
                             .compra(compra)
                             .produto(produto)
-                            .valorUnitario(produto.getValorVenda())
+                            .valorUnitario(produto.getValorVenda().doubleValue())
                             .quantidade(produtoDTO.getQuantidade())
-                            .valorTotal(valorFinalProduto)
+                            .valorTotal(valorFinalProduto.doubleValue())
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -36,6 +36,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -305,17 +306,18 @@ public class VendaService {
         return produtosDTO.stream()
                 .map(produtoDTO -> {
                     Produto produto = produtoService.listarUmProduto(venda.getOwnerUser(), produtoDTO.getProdutoId());
-                    double valorProduto = produto.getValorVenda() * produtoDTO.getQuantidade();
-                    double descontoProduto = (produtoDTO.getDesconto() / 100.0) * valorProduto;
-                    double valorFinalProduto = valorProduto - descontoProduto;
+                    BigDecimal valorProduto = produto.getValorVenda().multiply(BigDecimal.valueOf(produtoDTO.getQuantidade()));
+                    BigDecimal descontoProduto = valorProduto
+                            .multiply(BigDecimal.valueOf(produtoDTO.getDesconto()).divide(BigDecimal.valueOf(100)));
+                    BigDecimal valorFinalProduto = valorProduto.subtract(descontoProduto);
 
                     return VendaProduto.builder()
                             .venda(venda)
                             .produto(produto)
-                            .valorUnitario(produto.getValorVenda())
+                            .valorUnitario(produto.getValorVenda().doubleValue())
                             .quantidade(produtoDTO.getQuantidade())
                             .desconto(produtoDTO.getDesconto())
-                            .valorFinal(valorFinalProduto)
+                            .valorFinal(valorFinalProduto.doubleValue())
                             .build();
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
## Summary
- store Produto `custo` and `valorVenda` using `BigDecimal`
- return supplier id only when present
- adjust requests and services for new monetary type

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.AIT:Optimanage)*

------
https://chatgpt.com/codex/tasks/task_e_68ada90765088324b12e071af4f8ebc8