### PR TITLE
Add analytics service with summary and forecasting endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,12 +111,17 @@
 			<artifactId>jjwt-jackson</artifactId>
 			<version>0.12.3</version>
 		</dependency>
-		<dependency>
-			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.0.2</version>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.0.2</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-math3</artifactId>
+                        <version>3.6.1</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
@@ -1,0 +1,30 @@
+package com.AIT.Optimanage.Analytics;
+
+import com.AIT.Optimanage.Analytics.DTOs.PrevisaoDTO;
+import com.AIT.Optimanage.Analytics.DTOs.ResumoDTO;
+import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
+import com.AIT.Optimanage.Models.User.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/analytics")
+@RequiredArgsConstructor
+public class AnalyticsController extends V1BaseController {
+
+    private final AnalyticsService analyticsService;
+
+    @GetMapping("/resumo")
+    public ResumoDTO resumo(@AuthenticationPrincipal User user) {
+        return analyticsService.obterResumo(user);
+    }
+
+    @GetMapping("/previsao")
+    public PrevisaoDTO previsao(@AuthenticationPrincipal User user) {
+        return analyticsService.preverDemanda(user);
+    }
+}
+

--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
@@ -1,0 +1,60 @@
+package com.AIT.Optimanage.Analytics;
+
+import com.AIT.Optimanage.Analytics.DTOs.PrevisaoDTO;
+import com.AIT.Optimanage.Analytics.DTOs.ResumoDTO;
+import com.AIT.Optimanage.Models.Compra.Compra;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Models.Venda.Venda;
+import com.AIT.Optimanage.Repositories.Compra.CompraRepository;
+import com.AIT.Optimanage.Repositories.Venda.VendaRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.math3.stat.regression.SimpleRegression;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AnalyticsService {
+
+    private final VendaRepository vendaRepository;
+    private final CompraRepository compraRepository;
+
+    public ResumoDTO obterResumo(User user) {
+        double totalVendas = vendaRepository.findAll().stream()
+                .filter(v -> v.getOwnerUser().getId().equals(user.getId()))
+                .mapToDouble(Venda::getValorFinal)
+                .sum();
+
+        double totalCompras = compraRepository.findAll().stream()
+                .filter(c -> c.getOwnerUser().getId().equals(user.getId()))
+                .mapToDouble(Compra::getValorFinal)
+                .sum();
+
+        return new ResumoDTO(totalVendas, totalCompras);
+    }
+
+    public PrevisaoDTO preverDemanda(User user) {
+        List<Venda> vendas = vendaRepository.findAll().stream()
+                .filter(v -> v.getOwnerUser().getId().equals(user.getId()))
+                .sorted(Comparator.comparing(Venda::getDataEfetuacao))
+                .toList();
+
+        if (vendas.size() < 2) {
+            return new PrevisaoDTO(0.0);
+        }
+
+        // Forecast using a simple linear regression from Apache Commons Math.
+        // This placeholder approach can be replaced by an AI-based model in the future.
+        SimpleRegression regression = new SimpleRegression();
+        int i = 0;
+        for (Venda venda : vendas) {
+            regression.addData(i++, venda.getValorFinal());
+        }
+
+        double forecast = regression.predict(i);
+        return new PrevisaoDTO(forecast);
+    }
+}
+

--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PrevisaoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PrevisaoDTO.java
@@ -1,0 +1,13 @@
+package com.AIT.Optimanage.Analytics.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PrevisaoDTO {
+    private double valorPrevisto;
+}
+

--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/ResumoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/ResumoDTO.java
@@ -1,0 +1,14 @@
+package com.AIT.Optimanage.Analytics.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResumoDTO {
+    private double totalVendas;
+    private double totalCompras;
+}
+


### PR DESCRIPTION
## Summary
- add analytics package with summary and forecast endpoints
- implement service leveraging Apache Commons Math for linear regression
- document placeholder for future AI integration

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ada9a4727883248b6ee60d1c744460