### PR TITLE
chore: remove legacy javax dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,6 @@
 	</properties>
 	<dependencies>
 		<dependency>
-			<groupId>javax.persistence</groupId>
-			<artifactId>javax.persistence-api</artifactId>
-			<version>2.2</version>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
@@ -84,12 +79,6 @@
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
 			<version>3.19.2</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.3</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## Summary
- drop old javax.persistence-api and servlet-api dependencies

## Testing
- `mvn -q compile` *(fails: Network is unreachable)*
- `mvn -q dependency:tree` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a89ce2d15483249ee65fbd503b488c