### PR TITLE
Ensure refresh token operations are transactional

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Auth/AuthenticationService.java
+++ b/src/main/java/com/AIT/Optimanage/Auth/AuthenticationService.java
@@ -11,11 +11,13 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class AuthenticationService {
 
     private final UserRepository userRepository;


### PR DESCRIPTION
## Summary
- annotate `AuthenticationService` with `@Transactional` to wrap refresh token operations in a transaction and avoid `TransactionRequiredException`

## Testing
- `mvn -q -e test` *(fails: Network is unreachable for Maven dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68addb22bb18832480c0a3ae8b3f553f