### PR TITLE
feat: add profit metric to analytics summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Todos os recursos (exceto autenticação) usam o prefixo `/api/v1` e exigem um t
 - `GET /api/v1/compatibilidades/{contexto}` &ndash; buscar compatibilidades.
 - `POST /api/v1/compatibilidades` &ndash; adicionar compatibilidade.
 
+### Analytics
+- `GET /api/v1/analytics/resumo` &ndash; resumo de vendas, compras e lucro.
+- `GET /api/v1/analytics/previsao` &ndash; previsão de demanda com regressão linear.
+
 ## Execução
 1. Requisitos: Java 17+ e Maven.
 2. Rodar testes: `./mvnw test`

--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
@@ -32,7 +32,8 @@ public class AnalyticsService {
                 .mapToDouble(Compra::getValorFinal)
                 .sum();
 
-        return new ResumoDTO(totalVendas, totalCompras);
+        double lucro = totalVendas - totalCompras;
+        return new ResumoDTO(totalVendas, totalCompras, lucro);
     }
 
     public PrevisaoDTO preverDemanda(User user) {

--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/ResumoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/ResumoDTO.java
@@ -10,5 +10,6 @@ import lombok.NoArgsConstructor;
 public class ResumoDTO {
     private double totalVendas;
     private double totalCompras;
+    private double lucro;
 }
 


### PR DESCRIPTION
## Summary
- extend analytics summary with lucro (profit) calculation
- document analytics endpoints in the project README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.AIT:Optimanage:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68addf8f79888324baadd9199cbaed77