### PR TITLE
Add Actuator endpoints with database stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,7 @@ Todos os recursos (exceto autenticação) usam o prefixo `/api/v1` e exigem um t
 2. Rodar testes: `./mvnw test`
 3. Executar aplicação: `./mvnw spring-boot:run`
 
+## Monitoramento
+- `GET /actuator/health` – verificar status da aplicação.
+- `GET /actuator/info` – informações adicionais incluindo contagem de clientes e produtos.
+

--- a/pom.xml
+++ b/pom.xml
@@ -38,15 +38,19 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-jersey</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-actuator</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/java/com/AIT/Optimanage/Config/DatabaseStatsInfoContributor.java
+++ b/src/main/java/com/AIT/Optimanage/Config/DatabaseStatsInfoContributor.java
@@ -1,0 +1,28 @@
+package com.AIT.Optimanage.Config;
+
+import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.boot.actuate.info.Info.Builder;
+import org.springframework.stereotype.Component;
+
+import com.AIT.Optimanage.Repositories.Cliente.ClienteRepository;
+import com.AIT.Optimanage.Repositories.ProdutoRepository;
+
+@Component
+public class DatabaseStatsInfoContributor implements InfoContributor {
+
+    private final ClienteRepository clienteRepository;
+    private final ProdutoRepository produtoRepository;
+
+    public DatabaseStatsInfoContributor(
+            ClienteRepository clienteRepository,
+            ProdutoRepository produtoRepository) {
+        this.clienteRepository = clienteRepository;
+        this.produtoRepository = produtoRepository;
+    }
+
+    @Override
+    public void contribute(Builder builder) {
+        builder.withDetail("clientes", clienteRepository.count())
+               .withDetail("produtos", produtoRepository.count());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,4 +17,5 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
 springdoc.swagger-ui.path=/swagger-ui.html
+management.endpoints.web.exposure.include=health,info
 


### PR DESCRIPTION
## Summary
- expose Spring Boot Actuator for health and info
- include database statistics in info endpoint
- document monitoring endpoints

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68addf8f79888324baadd9199cbaed77