### PR TITLE
feat: log exceptions with correlation id

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/ExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/ExceptionHandler/GlobalExceptionHandler.java
@@ -1,31 +1,43 @@
 package com.AIT.Optimanage.Controllers.ExceptionHandler;
 
 import jakarta.persistence.EntityNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.util.UUID;
+
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-    public record ErrorResponse(String message, int status) {}
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    public record ErrorResponse(String message, int status, String correlationId) {}
 
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex) {
+        String correlationId = UUID.randomUUID().toString();
+        log.warn("Entity not found: {} - correlationId: {}", ex.getMessage(), correlationId);
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse(ex.getMessage(), HttpStatus.NOT_FOUND.value()));
+                .body(new ErrorResponse(ex.getMessage(), HttpStatus.NOT_FOUND.value(), correlationId));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
+        String correlationId = UUID.randomUUID().toString();
+        log.warn("Illegal argument: {} - correlationId: {}", ex.getMessage(), correlationId);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST.value()));
+                .body(new ErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST.value(), correlationId));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGeneral(Exception ex) {
+        String correlationId = UUID.randomUUID().toString();
+        log.error("Internal server error - correlationId: {}", correlationId, ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponse("Internal server error", HttpStatus.INTERNAL_SERVER_ERROR.value()));
+                .body(new ErrorResponse("Internal server error", HttpStatus.INTERNAL_SERVER_ERROR.value(), correlationId));
     }
 }


### PR DESCRIPTION
## Summary
- add SLF4J logger to `GlobalExceptionHandler`
- log client errors as warnings and internal errors as errors
- include correlation IDs in error responses for traceability

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0cd74ba88324979106aedadf878c