### PR TITLE
feat: add ProdutoResponse DTO and update product endpoints

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/ProdutoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/ProdutoController.java
@@ -2,7 +2,7 @@ package com.AIT.Optimanage.Controllers;
 
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
 import com.AIT.Optimanage.Controllers.dto.ProdutoRequest;
-import com.AIT.Optimanage.Models.Produto;
+import com.AIT.Optimanage.Controllers.dto.ProdutoResponse;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.ProdutoService;
 import lombok.RequiredArgsConstructor;
@@ -25,31 +25,31 @@ public class ProdutoController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar produtos", description = "Retorna uma lista de produtos")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public List<Produto> listarProdutos(@AuthenticationPrincipal User loggedUser) {
+    public List<ProdutoResponse> listarProdutos(@AuthenticationPrincipal User loggedUser) {
         return produtoService.listarProdutos(loggedUser);
     }
 
     @GetMapping("/{idProduto}")
     @Operation(summary = "Listar produto", description = "Retorna um produto pelo ID")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Produto listarUmProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
+    public ProdutoResponse listarUmProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
         return produtoService.listarUmProduto(loggedUser, idProduto);
     }
 
     @PostMapping
     @Operation(summary = "Cadastrar produto", description = "Cria um novo produto")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Produto cadastrarProduto(@AuthenticationPrincipal User loggedUser,
-                                    @RequestBody @Valid ProdutoRequest request) {
+    public ProdutoResponse cadastrarProduto(@AuthenticationPrincipal User loggedUser,
+                                            @RequestBody @Valid ProdutoRequest request) {
         return produtoService.cadastrarProduto(loggedUser, request);
     }
 
     @PutMapping("/{idProduto}")
     @Operation(summary = "Editar produto", description = "Atualiza um produto existente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Produto editarProduto(@AuthenticationPrincipal User loggedUser,
-                                 @PathVariable Integer idProduto,
-                                 @RequestBody @Valid ProdutoRequest request) {
+    public ProdutoResponse editarProduto(@AuthenticationPrincipal User loggedUser,
+                                         @PathVariable Integer idProduto,
+                                         @RequestBody @Valid ProdutoRequest request) {
         return produtoService.editarProduto(loggedUser, idProduto, request);
     }
 

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoResponse.java
@@ -1,0 +1,28 @@
+package com.AIT.Optimanage.Controllers.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProdutoResponse {
+
+    private Integer id;
+    private Integer ownerUserId;
+    private Integer fornecedorId;
+    private Integer sequencialUsuario;
+    private String codigoReferencia;
+    private String nome;
+    private String descricao;
+    private BigDecimal custo;
+    private Boolean disponivelVenda;
+    private BigDecimal valorVenda;
+    private Integer qtdEstoque;
+    private Boolean terceirizado;
+}


### PR DESCRIPTION
## Summary
- add ProdutoResponse DTO
- map Produto entities to ProdutoResponse in service
- return ProdutoResponse from product endpoints

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0d06308083248b3001c883d7853a