### PR TITLE
feat: add soft delete support

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteController.java
@@ -10,6 +10,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.Cliente.ClienteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
@@ -95,6 +96,24 @@ public class ClienteController extends V1BaseController {
     public void inativarCliente(@AuthenticationPrincipal User loggedUser,
                                 @PathVariable("idCliente") Integer idCliente) {
         clienteService.inativarCliente(loggedUser, idCliente);
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @PutMapping("/{idCliente}/restaurar")
+    @Operation(summary = "Restaurar cliente", description = "Reativa um cliente inativo")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public Cliente restaurarCliente(@AuthenticationPrincipal User loggedUser,
+                                    @PathVariable("idCliente") Integer idCliente) {
+        return clienteService.reativarCliente(loggedUser, idCliente);
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @DeleteMapping("/{idCliente}/permanente")
+    @Operation(summary = "Remover cliente permanentemente", description = "Exclui definitivamente um cliente")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public void removerCliente(@AuthenticationPrincipal User loggedUser,
+                               @PathVariable("idCliente") Integer idCliente) {
+        clienteService.removerCliente(loggedUser, idCliente);
     }
 
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorController.java
@@ -9,6 +9,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.Fornecedor.FornecedorService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
@@ -88,5 +89,23 @@ public class FornecedorController extends V1BaseController {
     public void inativarFornecedor(@AuthenticationPrincipal User loggedUser,
                                    @PathVariable("idFornecedor") Integer idFornecedor) {
         fornecedorService.inativarFornecedor(loggedUser, idFornecedor);
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @PutMapping("/{idFornecedor}/restaurar")
+    @Operation(summary = "Restaurar fornecedor", description = "Reativa um fornecedor inativo")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public Fornecedor restaurarFornecedor(@AuthenticationPrincipal User loggedUser,
+                                          @PathVariable("idFornecedor") Integer idFornecedor) {
+        return fornecedorService.reativarFornecedor(loggedUser, idFornecedor);
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @DeleteMapping("/{idFornecedor}/permanente")
+    @Operation(summary = "Remover fornecedor permanentemente", description = "Exclui definitivamente um fornecedor")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public void removerFornecedor(@AuthenticationPrincipal User loggedUser,
+                                  @PathVariable("idFornecedor") Integer idFornecedor) {
+        fornecedorService.removerFornecedor(loggedUser, idFornecedor);
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/ProdutoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/ProdutoController.java
@@ -7,6 +7,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.ProdutoService;
 import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -58,5 +59,21 @@ public class ProdutoController extends V1BaseController {
     @ApiResponse(responseCode = "200", description = "Sucesso")
     public void excluirProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
         produtoService.excluirProduto(loggedUser, idProduto);
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @PutMapping("/{idProduto}/restaurar")
+    @Operation(summary = "Restaurar produto", description = "Restaura um produto inativo")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public ProdutoResponse restaurarProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
+        return produtoService.restaurarProduto(loggedUser, idProduto);
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @DeleteMapping("/{idProduto}/permanente")
+    @Operation(summary = "Remover produto permanentemente", description = "Exclui definitivamente um produto")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public void removerProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
+        produtoService.removerProduto(loggedUser, idProduto);
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/ServicoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/ServicoController.java
@@ -7,6 +7,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.ServicoService;
 import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -59,5 +60,21 @@ public class ServicoController extends V1BaseController {
     @ApiResponse(responseCode = "200", description = "Sucesso")
     public void excluirServico(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idServico) {
         servicoService.excluirServico(loggedUser, idServico);
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @PutMapping("/{idServico}/restaurar")
+    @Operation(summary = "Restaurar serviço", description = "Restaura um serviço inativo")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public Servico restaurarServico(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idServico) {
+        return servicoService.restaurarServico(loggedUser, idServico);
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @DeleteMapping("/{idServico}/permanente")
+    @Operation(summary = "Remover serviço permanentemente", description = "Exclui definitivamente um serviço")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public void removerServico(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idServico) {
+        servicoService.removerServico(loggedUser, idServico);
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoRequest.java
@@ -41,4 +41,5 @@ public class ProdutoRequest {
     private Integer qtdEstoque;
 
     private Boolean terceirizado;
+    private Boolean ativo;
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoResponse.java
@@ -25,4 +25,5 @@ public class ProdutoResponse {
     private BigDecimal valorVenda;
     private Integer qtdEstoque;
     private Boolean terceirizado;
+    private Boolean ativo;
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ServicoRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ServicoRequest.java
@@ -36,4 +36,5 @@ public class ServicoRequest {
     private Integer tempoExecucao;
 
     private Boolean terceirizado;
+    private Boolean ativo;
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Produto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Produto.java
@@ -56,6 +56,8 @@ public class Produto {
     @Column(nullable = false)
     private Integer qtdEstoque;
     private Boolean terceirizado;
+    @Column(nullable = false)
+    private Boolean ativo = true;
 
     @OneToMany(mappedBy = "produto", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Compatibilidade> compatibilidades;

--- a/src/main/java/com/AIT/Optimanage/Models/Servico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Servico.java
@@ -53,6 +53,8 @@ public class Servico {
     @Column(nullable = false)
     private Integer tempoExecucao;
     private Boolean terceirizado;
+    @Column(nullable = false)
+    private Boolean ativo = true;
 
     @OneToMany(mappedBy = "servico", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Compatibilidade> compatibilidades;

--- a/src/main/java/com/AIT/Optimanage/Repositories/Cliente/ClienteRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Cliente/ClienteRepository.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @Repository
 public interface ClienteRepository extends JpaRepository<Cliente, Integer> {
 
-    List<Cliente> findByOwnerUser(User ownerUser);
+    List<Cliente> findByOwnerUserAndAtivoTrue(User ownerUser);
 
     @Query("SELECT DISTINCT c FROM Cliente c " +
             "LEFT JOIN c.enderecos e " +
@@ -43,6 +43,8 @@ public interface ClienteRepository extends JpaRepository<Cliente, Integer> {
             @Param("ativo") Boolean ativo,
             Pageable pageable
     );
+
+    Optional<Cliente> findByIdAndOwnerUserAndAtivoTrue(Integer idCliente, User loggedUser);
 
     Optional<Cliente> findByIdAndOwnerUser(Integer idCliente, User loggedUser);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Fornecedor/FornecedorRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Fornecedor/FornecedorRepository.java
@@ -43,5 +43,7 @@ public interface FornecedorRepository extends JpaRepository<Fornecedor, Integer>
             Pageable pageable
     );
 
+    Optional<Fornecedor> findByIdAndOwnerUserAndAtivoTrue(Integer idFornecedor, User loggedUser);
+
     Optional<Fornecedor> findByIdAndOwnerUser(Integer idFornecedor, User loggedUser);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/ProdutoRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/ProdutoRepository.java
@@ -11,7 +11,9 @@ import java.util.Optional;
 @Repository
 public interface ProdutoRepository extends JpaRepository<Produto, Integer> {
 
-    List<Produto> findAllByOwnerUser(User loggedUser);
+    List<Produto> findAllByOwnerUserAndAtivoTrue(User loggedUser);
+
+    Optional<Produto> findByIdAndOwnerUserAndAtivoTrue(Integer idProduto, User loggedUser);
 
     Optional<Produto> findByIdAndOwnerUser(Integer idProduto, User loggedUser);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/ServicoRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/ServicoRepository.java
@@ -11,7 +11,9 @@ import java.util.Optional;
 @Repository
 public interface ServicoRepository extends JpaRepository<Servico, Integer> {
 
-    List<Servico> findAllByOwnerUser(User ownerUser);
+    List<Servico> findAllByOwnerUserAndAtivoTrue(User ownerUser);
+
+    Optional<Servico> findByIdAndOwnerUserAndAtivoTrue(Integer idServico, User ownerUser);
 
     Optional<Servico> findByIdAndOwnerUser(Integer idServico, User ownerUser);
 }

--- a/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
@@ -49,7 +49,7 @@ public class FornecedorService {
                 pesquisa.getAtividade(),
                 pesquisa.getEstado(),
                 pesquisa.getTipoPessoa(),
-                pesquisa.getAtivo(),
+                pesquisa.getAtivo() != null ? pesquisa.getAtivo() : true,
                 pageable
         );
 
@@ -57,7 +57,7 @@ public class FornecedorService {
     }
 
     public Fornecedor listarUmFornecedor(User loggedUser, Integer idFornecedor) {
-        return fornecedorRepository.findByIdAndOwnerUser(idFornecedor, loggedUser)
+        return fornecedorRepository.findByIdAndOwnerUserAndAtivoTrue(idFornecedor, loggedUser)
                 .orElseThrow(() -> new EntityNotFoundException("Fornecedor não encontrado"));
     }
 
@@ -86,6 +86,21 @@ public class FornecedorService {
         Fornecedor fornecedor = listarUmFornecedor(loggedUser, idFornecedor);
         fornecedor.setAtivo(false);
         fornecedorRepository.save(fornecedor);
+    }
+
+    @CacheEvict(value = "fornecedores", allEntries = true)
+    public Fornecedor reativarFornecedor(User loggedUser, Integer idFornecedor) {
+        Fornecedor fornecedor = fornecedorRepository.findByIdAndOwnerUser(idFornecedor, loggedUser)
+                .orElseThrow(() -> new EntityNotFoundException("Fornecedor não encontrado"));
+        fornecedor.setAtivo(true);
+        return fornecedorRepository.save(fornecedor);
+    }
+
+    @CacheEvict(value = "fornecedores", allEntries = true)
+    public void removerFornecedor(User loggedUser, Integer idFornecedor) {
+        Fornecedor fornecedor = fornecedorRepository.findByIdAndOwnerUser(idFornecedor, loggedUser)
+                .orElseThrow(() -> new EntityNotFoundException("Fornecedor não encontrado"));
+        fornecedorRepository.delete(fornecedor);
     }
 
     public void validarFornecedor(User loggedUser, Fornecedor fornecedor) {


### PR DESCRIPTION
## Summary
- add `ativo` flag to Produtos and Serviços for soft delete
- default repository queries to `ativo = true`
- add admin endpoints to restore or permanently delete records

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae61dd1e38832488b2f648acf75a57