### PR TITLE
Atualiza base path de endereços de fornecedor para plural

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorEnderecoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorEnderecoController.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
-@RequestMapping("/fornecedor")
+@RequestMapping("/fornecedores")
 @RequiredArgsConstructor
 @Tag(name = "Fornecedores - Endereços", description = "Gerenciamento de endereços de fornecedores")
 public class FornecedorEnderecoController extends V1BaseController {


### PR DESCRIPTION
## Summary
- Use `/fornecedores` como base path para o controlador de endereços

## Testing
- `mvn -q test` *(falha: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ae64a7d720832490ce55a68f100844