### PR TITLE
feat: enhance global exception handling

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/ExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/ExceptionHandler/GlobalExceptionHandler.java
@@ -5,9 +5,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.validation.DefaultMessageSourceResolvable;
 
+import com.AIT.Optimanage.Exceptions.CustomRuntimeException;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 @ControllerAdvice
@@ -15,14 +23,16 @@ public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    public record ErrorResponse(String message, int status, String correlationId) {}
+    public record ErrorResponse(LocalDateTime timestamp, int code, String message,
+                                String correlationId, List<String> errors) {}
 
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex) {
         String correlationId = UUID.randomUUID().toString();
         log.warn("Entity not found: {} - correlationId: {}", ex.getMessage(), correlationId);
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse(ex.getMessage(), HttpStatus.NOT_FOUND.value(), correlationId));
+                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.NOT_FOUND.value(),
+                        ex.getMessage(), correlationId, Collections.emptyList()));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
@@ -30,7 +40,38 @@ public class GlobalExceptionHandler {
         String correlationId = UUID.randomUUID().toString();
         log.warn("Illegal argument: {} - correlationId: {}", ex.getMessage(), correlationId);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST.value(), correlationId));
+                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.BAD_REQUEST.value(),
+                        ex.getMessage(), correlationId, Collections.emptyList()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        String correlationId = UUID.randomUUID().toString();
+        List<String> errors = ex.getBindingResult().getFieldErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .toList();
+        log.warn("Validation failed: {} - correlationId: {}", errors, correlationId);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.BAD_REQUEST.value(),
+                        "Validation failed", correlationId, errors));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex) {
+        String correlationId = UUID.randomUUID().toString();
+        log.warn("Access denied: {} - correlationId: {}", ex.getMessage(), correlationId);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.FORBIDDEN.value(),
+                        ex.getMessage(), correlationId, Collections.emptyList()));
+    }
+
+    @ExceptionHandler(CustomRuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleCustomRuntime(CustomRuntimeException ex) {
+        String correlationId = UUID.randomUUID().toString();
+        log.warn("Runtime exception: {} - correlationId: {}", ex.getMessage(), correlationId);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.BAD_REQUEST.value(),
+                        ex.getMessage(), correlationId, Collections.emptyList()));
     }
 
     @ExceptionHandler(Exception.class)
@@ -38,6 +79,7 @@ public class GlobalExceptionHandler {
         String correlationId = UUID.randomUUID().toString();
         log.error("Internal server error - correlationId: {}", correlationId, ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponse("Internal server error", HttpStatus.INTERNAL_SERVER_ERROR.value(), correlationId));
+                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                        "Internal server error", correlationId, Collections.emptyList()));
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Exceptions/CustomRuntimeException.java
+++ b/src/main/java/com/AIT/Optimanage/Exceptions/CustomRuntimeException.java
@@ -1,0 +1,7 @@
+package com.AIT.Optimanage.Exceptions;
+
+public class CustomRuntimeException extends RuntimeException {
+    public CustomRuntimeException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/AIT/Optimanage/Controllers/ExceptionHandler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/AIT/Optimanage/Controllers/ExceptionHandler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,77 @@
+package com.AIT.Optimanage.Controllers.ExceptionHandler;
+
+import com.AIT.Optimanage.Exceptions.CustomRuntimeException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = GlobalExceptionHandlerTest.TestController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @RestController
+    static class TestController {
+        @GetMapping("/access-denied")
+        public void accessDenied() {
+            throw new AccessDeniedException("Forbidden");
+        }
+
+        @GetMapping("/runtime")
+        public void runtime() {
+            throw new CustomRuntimeException("Custom error");
+        }
+
+        @PostMapping("/validate")
+        public void validate(@RequestBody @Valid DummyRequest request) {
+        }
+    }
+
+    static class DummyRequest {
+        @NotBlank
+        public String name;
+    }
+
+    @Test
+    void whenValidationFails_thenReturnsBadRequest() throws Exception {
+        mockMvc.perform(post("/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.errors[0]").exists());
+    }
+
+    @Test
+    void whenAccessDenied_thenReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/access-denied"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(403));
+    }
+
+    @Test
+    void whenCustomRuntime_thenReturnsBadRequest() throws Exception {
+        mockMvc.perform(get("/runtime"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400));
+    }
+}


### PR DESCRIPTION
## Summary
- add handlers for validation, access-denied, and custom runtime errors
- standardize ErrorResponse with timestamp, code, and error list
- introduce tests covering new exception responses

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae62b18fd08324af647c9eab2659c5