### PR TITLE
Corrigir busca de produto para compra e venda

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -256,7 +256,7 @@ public class CompraService {
     private List<CompraProduto> criarListaProdutos(List<CompraProdutoDTO> produtosDTO, Compra compra) {
         return produtosDTO.stream()
                 .map(produtoDTO -> {
-                    Produto produto = produtoService.listarUmProduto(compra.getOwnerUser(), produtoDTO.getProdutoId());
+                    Produto produto = produtoService.buscarProdutoAtivo(compra.getOwnerUser(), produtoDTO.getProdutoId());
                     BigDecimal valorFinalProduto = produto.getValorVenda()
                             .multiply(BigDecimal.valueOf(produtoDTO.getQuantidade()));
 

--- a/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
@@ -89,7 +89,7 @@ public class ProdutoService {
                 .orElseThrow(() -> new EntityNotFoundException("Produto não encontrado"));
     }
 
-    private Produto buscarProdutoAtivo(User loggedUser, Integer idProduto) {
+    public Produto buscarProdutoAtivo(User loggedUser, Integer idProduto) {
         return produtoRepository.findByIdAndOwnerUserAndAtivoTrue(idProduto, loggedUser)
                 .orElseThrow(() -> new EntityNotFoundException("Produto não encontrado"));
     }

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/CompatibilidadeService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/CompatibilidadeService.java
@@ -30,7 +30,7 @@ public class CompatibilidadeService {
         ContextoCompatibilidade contexto = contextoCompatibilidadeService.listarUmContexto(logedUser, request.getContextoId());
 
         Compatibilidade compatibilidade = Compatibilidade.builder()
-                .produto(request.getProdutoId() != null ? produtoService.listarUmProduto(logedUser, request.getProdutoId()) : null)
+                .produto(request.getProdutoId() != null ? produtoService.buscarProdutoAtivo(logedUser, request.getProdutoId()) : null)
                 .servico(request.getServicoId() != null ? servicoService.listarUmServico(logedUser, request.getServicoId()) : null)
                 .contexto(contexto)
                 .compativel(request.getCompativel())

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -305,7 +305,7 @@ public class VendaService {
     private List<VendaProduto> criarListaProdutos(List<VendaProdutoDTO> produtosDTO, Venda venda) {
         return produtosDTO.stream()
                 .map(produtoDTO -> {
-                    Produto produto = produtoService.listarUmProduto(venda.getOwnerUser(), produtoDTO.getProdutoId());
+                    Produto produto = produtoService.buscarProdutoAtivo(venda.getOwnerUser(), produtoDTO.getProdutoId());
                     BigDecimal valorProduto = produto.getValorVenda().multiply(BigDecimal.valueOf(produtoDTO.getQuantidade()));
                     BigDecimal descontoProduto = valorProduto
                             .multiply(BigDecimal.valueOf(produtoDTO.getDesconto()).divide(BigDecimal.valueOf(100)));


### PR DESCRIPTION
## Summary
- Expor método `buscarProdutoAtivo` em `ProdutoService` para recuperar entidades de produtos ativos
- Ajustar serviços de compra, venda e compatibilidade para utilizar a busca de produtos em vez de resposta DTO

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68ae70b80c648324bfecc23b65187cec