### PR TITLE
feat: introduce MapStruct for produto mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,10 @@
 		<tag/>
 		<url/>
 	</scm>
-	<properties>
-		<java.version>21</java.version>
-	</properties>
+        <properties>
+                <java.version>21</java.version>
+                <mapstruct.version>1.6.2.Final</mapstruct.version>
+        </properties>
 	<dependencies>
 		<dependency>
 				<groupId>org.springframework.boot</groupId>
@@ -99,18 +100,47 @@
 			<artifactId>commons-math3</artifactId>
 			<version>3.6.1</version>
 		</dependency>
-		<dependency>
-			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.8.11</version>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.8.11</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.mapstruct</groupId>
+                        <artifactId>mapstruct</artifactId>
+                        <version>${mapstruct.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.mapstruct</groupId>
+                        <artifactId>mapstruct-processor</artifactId>
+                        <version>${mapstruct.version}</version>
+                        <scope>provided</scope>
+                </dependency>
+        </dependencies>
 
 <build>
   <plugins>
     <plugin>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-maven-plugin</artifactId>
+    </plugin>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-compiler-plugin</artifactId>
+      <configuration>
+        <annotationProcessorPaths>
+          <path>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.32</version>
+          </path>
+          <path>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+          </path>
+        </annotationProcessorPaths>
+      </configuration>
     </plugin>
   </plugins>
 </build>

--- a/src/main/java/com/AIT/Optimanage/Mappers/ProdutoMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/ProdutoMapper.java
@@ -1,0 +1,19 @@
+package com.AIT.Optimanage.Mappers;
+
+import com.AIT.Optimanage.Controllers.dto.ProdutoRequest;
+import com.AIT.Optimanage.Models.Produto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface ProdutoMapper {
+
+    @Mapping(target = "fornecedor.id", source = "fornecedorId")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "ownerUser", ignore = true)
+    Produto toEntity(ProdutoRequest request);
+
+    @Mapping(target = "fornecedorId", source = "fornecedor.id")
+    ProdutoRequest toRequest(Produto produto);
+}

--- a/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
@@ -2,13 +2,14 @@ package com.AIT.Optimanage.Services;
 
 import com.AIT.Optimanage.Controllers.dto.ProdutoRequest;
 import com.AIT.Optimanage.Controllers.dto.ProdutoResponse;
-import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
 import com.AIT.Optimanage.Models.Produto;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Repositories.ProdutoRepository;
+import com.AIT.Optimanage.Mappers.ProdutoMapper;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
@@ -16,6 +17,7 @@ import java.util.List;
 public class ProdutoService {
 
     private final ProdutoRepository produtoRepository;
+    private final ProdutoMapper produtoMapper;
 
     public List<ProdutoResponse> listarProdutos(User loggedUser) {
         return produtoRepository.findAllByOwnerUser(loggedUser)
@@ -29,45 +31,29 @@ public class ProdutoService {
         return toResponse(produto);
     }
 
+    @Transactional
     public ProdutoResponse cadastrarProduto(User loggedUser, ProdutoRequest request) {
-        Produto produto = fromRequest(request);
+        Produto produto = produtoMapper.toEntity(request);
         produto.setId(null);
         produto.setOwnerUser(loggedUser);
         Produto salvo = produtoRepository.save(produto);
         return toResponse(salvo);
     }
 
+    @Transactional
     public ProdutoResponse editarProduto(User loggedUser, Integer idProduto, ProdutoRequest request) {
         Produto produtoSalvo = buscarProduto(loggedUser, idProduto);
-        Produto produto = fromRequest(request);
+        Produto produto = produtoMapper.toEntity(request);
         produto.setId(produtoSalvo.getId());
         produto.setOwnerUser(produtoSalvo.getOwnerUser());
         Produto atualizado = produtoRepository.save(produto);
         return toResponse(atualizado);
     }
 
+    @Transactional
     public void excluirProduto(User loggedUser, Integer idProduto) {
         Produto produto = buscarProduto(loggedUser, idProduto);
         produtoRepository.delete(produto);
-    }
-
-    private Produto fromRequest(ProdutoRequest request) {
-        Produto produto = new Produto();
-        if (request.getFornecedorId() != null) {
-            Fornecedor fornecedor = new Fornecedor();
-            fornecedor.setId(request.getFornecedorId());
-            produto.setFornecedor(fornecedor);
-        }
-        produto.setSequencialUsuario(request.getSequencialUsuario());
-        produto.setCodigoReferencia(request.getCodigoReferencia());
-        produto.setNome(request.getNome());
-        produto.setDescricao(request.getDescricao());
-        produto.setCusto(request.getCusto());
-        produto.setDisponivelVenda(request.getDisponivelVenda());
-        produto.setValorVenda(request.getValorVenda());
-        produto.setQtdEstoque(request.getQtdEstoque());
-        produto.setTerceirizado(request.getTerceirizado());
-        return produto;
     }
 
     private Produto buscarProduto(User loggedUser, Integer idProduto) {


### PR DESCRIPTION
## Summary
- add MapStruct dependency and compiler configuration
- create ProdutoMapper for ProdutoRequest ↔ Produto conversions
- refactor ProdutoService to use mapper and add @Transactional annotations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6200ab7083249c43a33299be548a