### PR TITLE
feat(jwt): support runtime key rotation

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Config/JwtProperties.java
+++ b/src/main/java/com/AIT/Optimanage/Config/JwtProperties.java
@@ -1,0 +1,25 @@
+package com.AIT.Optimanage.Config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.jwt")
+public class JwtProperties {
+
+    private String primaryKey;
+    private String rotationKey;
+    private long expiration;
+    private long refreshExpiration;
+
+    /**
+     * Switch the primary key to the rotation key.
+     */
+    public void switchKeys() {
+        this.primaryKey = this.rotationKey;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,8 @@ spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 
-app.jwtSecret=${JWT_SECRET}
+app.jwt.primary-key=${JWT_PRIMARY_KEY}
+app.jwt.rotation-key=${JWT_ROTATION_KEY}
 app.jwt.expiration=${JWT_EXPIRATION}
 app.jwt.refresh-expiration=${JWT_REFRESH_EXPIRATION}
 


### PR DESCRIPTION
## Summary
- load JWT keys using `@ConfigurationProperties`
- remove unused variable in `getSignInKey`
- allow switching to rotation key at runtime

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0cc8fc4c8324ad30afadf209f6ab