### PR TITLE
feat: add Plano CRUD service and endpoints

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/PlanoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/PlanoController.java
@@ -1,12 +1,53 @@
 package com.AIT.Optimanage.Controllers;
 
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
+import com.AIT.Optimanage.Controllers.dto.PlanoRequest;
+import com.AIT.Optimanage.Controllers.dto.PlanoResponse;
+import com.AIT.Optimanage.Services.PlanoService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/planos")
+@RequiredArgsConstructor
 @Tag(name = "Planos", description = "Operações relacionadas a planos")
 public class PlanoController extends V1BaseController {
+
+    private final PlanoService planoService;
+
+    @GetMapping
+    @Operation(summary = "Listar planos", description = "Retorna uma lista de planos")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public List<PlanoResponse> listarPlanos() {
+        return planoService.listarPlanos();
+    }
+
+    @PostMapping
+    @Operation(summary = "Cadastrar plano", description = "Cria um novo plano")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public PlanoResponse criarPlano(@RequestBody @Valid PlanoRequest request) {
+        return planoService.criarPlano(request);
+    }
+
+    @PutMapping("/{idPlano}")
+    @Operation(summary = "Atualizar plano", description = "Atualiza um plano existente")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public PlanoResponse atualizarPlano(@PathVariable Integer idPlano,
+                                        @RequestBody @Valid PlanoRequest request) {
+        return planoService.atualizarPlano(idPlano, request);
+    }
+
+    @DeleteMapping("/{idPlano}")
+    @Operation(summary = "Remover plano", description = "Remove um plano")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public void removerPlano(@PathVariable Integer idPlano) {
+        planoService.removerPlano(idPlano);
+    }
 }
+

--- a/src/main/java/com/AIT/Optimanage/Controllers/PlanoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/PlanoController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,6 +22,7 @@ public class PlanoController extends V1BaseController {
 
     private final PlanoService planoService;
 
+    @PreAuthorize("hasAuthority('ADMIN')")
     @GetMapping
     @Operation(summary = "Listar planos", description = "Retorna uma lista de planos")
     @ApiResponse(responseCode = "200", description = "Sucesso")
@@ -28,6 +30,7 @@ public class PlanoController extends V1BaseController {
         return planoService.listarPlanos();
     }
 
+    @PreAuthorize("hasAuthority('ADMIN')")
     @PostMapping
     @Operation(summary = "Cadastrar plano", description = "Cria um novo plano")
     @ApiResponse(responseCode = "200", description = "Sucesso")
@@ -35,6 +38,7 @@ public class PlanoController extends V1BaseController {
         return planoService.criarPlano(request);
     }
 
+    @PreAuthorize("hasAuthority('ADMIN')")
     @PutMapping("/{idPlano}")
     @Operation(summary = "Atualizar plano", description = "Atualiza um plano existente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
@@ -43,6 +47,7 @@ public class PlanoController extends V1BaseController {
         return planoService.atualizarPlano(idPlano, request);
     }
 
+    @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping("/{idPlano}")
     @Operation(summary = "Remover plano", description = "Remove um plano")
     @ApiResponse(responseCode = "200", description = "Sucesso")

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoRequest.java
@@ -1,0 +1,30 @@
+package com.AIT.Optimanage.Controllers.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlanoRequest {
+
+    @NotBlank
+    private String nome;
+
+    @NotNull
+    @PositiveOrZero
+    private Float valor;
+
+    @NotNull
+    @Positive
+    private Integer duracaoDias;
+
+    @NotNull
+    @Positive
+    private Integer qtdAcessos;
+}
+

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoResponse.java
@@ -1,0 +1,20 @@
+package com.AIT.Optimanage.Controllers.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlanoResponse {
+
+    private Integer id;
+    private String nome;
+    private Float valor;
+    private Integer duracaoDias;
+    private Integer qtdAcessos;
+}
+

--- a/src/main/java/com/AIT/Optimanage/Services/PlanoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/PlanoService.java
@@ -1,0 +1,71 @@
+package com.AIT.Optimanage.Services;
+
+import com.AIT.Optimanage.Controllers.dto.PlanoRequest;
+import com.AIT.Optimanage.Controllers.dto.PlanoResponse;
+import com.AIT.Optimanage.Models.Plano;
+import com.AIT.Optimanage.Repositories.PlanoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlanoService {
+
+    private final PlanoRepository planoRepository;
+
+    public List<PlanoResponse> listarPlanos() {
+        return planoRepository.findAll()
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public PlanoResponse criarPlano(PlanoRequest request) {
+        Plano plano = fromRequest(request);
+        plano.setId(null);
+        Plano salvo = planoRepository.save(plano);
+        return toResponse(salvo);
+    }
+
+    @Transactional
+    public PlanoResponse atualizarPlano(Integer idPlano, PlanoRequest request) {
+        Plano existente = planoRepository.findById(idPlano)
+                .orElseThrow(() -> new EntityNotFoundException("Plano não encontrado"));
+        Plano plano = fromRequest(request);
+        plano.setId(existente.getId());
+        Plano atualizado = planoRepository.save(plano);
+        return toResponse(atualizado);
+    }
+
+    @Transactional
+    public void removerPlano(Integer idPlano) {
+        Plano plano = planoRepository.findById(idPlano)
+                .orElseThrow(() -> new EntityNotFoundException("Plano não encontrado"));
+        planoRepository.delete(plano);
+    }
+
+    private Plano fromRequest(PlanoRequest request) {
+        return Plano.builder()
+                .nome(request.getNome())
+                .valor(request.getValor())
+                .duracaoDias(request.getDuracaoDias())
+                .qtdAcessos(request.getQtdAcessos())
+                .build();
+    }
+
+    private PlanoResponse toResponse(Plano plano) {
+        return PlanoResponse.builder()
+                .id(plano.getId())
+                .nome(plano.getNome())
+                .valor(plano.getValor())
+                .duracaoDias(plano.getDuracaoDias())
+                .qtdAcessos(plano.getQtdAcessos())
+                .build();
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement PlanoService with list/create/update/remove operations
- expose Plano endpoints returning DTOs
- add PlanoRequest and PlanoResponse DTOs

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aeea0d5b2083248f54ba3259fa55f9