### PR TITLE
Add user DTOs and RESTful user endpoints

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/User/UsuarioController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/User/UsuarioController.java
@@ -1,15 +1,16 @@
 package com.AIT.Optimanage.Controllers.User;
 
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
-import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Controllers.User.dto.UserRequest;
+import com.AIT.Optimanage.Controllers.User.dto.UserResponse;
 import com.AIT.Optimanage.Services.User.UsuarioService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
@@ -22,32 +23,32 @@ public class UsuarioController extends V1BaseController {
 
     private final UsuarioService usuarioService;
 
-    @PostMapping("/criar")
-    public ResponseEntity<User> criarUsuario(@RequestBody @Valid User usuario) {
-        User novoUsuario = usuarioService.salvarUsuario(usuario);
+    @PostMapping
+    public ResponseEntity<UserResponse> criarUsuario(@RequestBody @Valid UserRequest request) {
+        UserResponse novoUsuario = usuarioService.salvarUsuario(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(novoUsuario);
     }
 
-    @GetMapping("/listar")
-    public ResponseEntity<List<User>> listarUsuarios() {
-        List<User> usuarios = usuarioService.listarUsuarios();
+    @GetMapping
+    public ResponseEntity<List<UserResponse>> listarUsuarios() {
+        List<UserResponse> usuarios = usuarioService.listarUsuarios();
         return ResponseEntity.ok(usuarios);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<User> buscarUsuario(@PathVariable Integer id) {
-        User usuario = usuarioService.buscarUsuario(id);
+    public ResponseEntity<UserResponse> buscarUsuario(@PathVariable Integer id) {
+        UserResponse usuario = usuarioService.buscarUsuario(id);
         return ResponseEntity.ok(usuario);
     }
 
-    @PutMapping("/{id}/atualizar-plano")
-    public ResponseEntity<User> atualizarPlanoAtivo(@PathVariable Integer id,
-                                                    @RequestParam Integer novoPlanoId) {
-        User usuarioAtualizado = usuarioService.atualizarPlanoAtivo(id, novoPlanoId);
+    @PutMapping("/{id}/plano")
+    public ResponseEntity<UserResponse> atualizarPlanoAtivo(@PathVariable Integer id,
+                                                            @RequestParam Integer novoPlanoId) {
+        UserResponse usuarioAtualizado = usuarioService.atualizarPlanoAtivo(id, novoPlanoId);
         return ResponseEntity.ok(usuarioAtualizado);
     }
 
-    @DeleteMapping("/{id}/desativar")
+    @DeleteMapping("/{id}")
     public ResponseEntity<Void> desativarUsuario(@PathVariable Integer id) {
         usuarioService.desativarUsuario(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/AIT/Optimanage/Controllers/User/dto/UserRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/User/dto/UserRequest.java
@@ -1,0 +1,31 @@
+package com.AIT.Optimanage.Controllers.User.dto;
+
+import com.AIT.Optimanage.Models.User.Role;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRequest {
+
+    @NotBlank
+    private String nome;
+
+    @NotBlank
+    private String sobrenome;
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String senha;
+
+    @NotNull
+    private Role role;
+}

--- a/src/main/java/com/AIT/Optimanage/Controllers/User/dto/UserResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/User/dto/UserResponse.java
@@ -1,0 +1,21 @@
+package com.AIT.Optimanage.Controllers.User.dto;
+
+import com.AIT.Optimanage.Models.User.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponse {
+
+    private Integer id;
+    private String nome;
+    private String sobrenome;
+    private String email;
+    private Boolean ativo;
+    private Role role;
+}

--- a/src/main/java/com/AIT/Optimanage/Services/User/UsuarioService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/User/UsuarioService.java
@@ -1,5 +1,7 @@
 package com.AIT.Optimanage.Services.User;
 
+import com.AIT.Optimanage.Controllers.User.dto.UserRequest;
+import com.AIT.Optimanage.Controllers.User.dto.UserResponse;
 import com.AIT.Optimanage.Models.Plano;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Models.User.UserInfo;
@@ -23,37 +25,63 @@ public class UsuarioService {
     private final PlanoRepository planoRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
-    public User salvarUsuario(User usuario) {
-        usuario.setSenha(passwordEncoder.encode(usuario.getSenha()));
-        usuario.setAtivo(true);
-        return userRepository.save(usuario);
+    public UserResponse salvarUsuario(UserRequest request) {
+        User usuario = User.builder()
+                .nome(request.getNome())
+                .sobrenome(request.getSobrenome())
+                .email(request.getEmail())
+                .senha(passwordEncoder.encode(request.getSenha()))
+                .role(request.getRole())
+                .ativo(true)
+                .build();
+        User salvo = userRepository.save(usuario);
+        return toResponse(salvo);
     }
 
-    public List<User> listarUsuarios() {
-        return userRepository.findAll();
+    public List<UserResponse> listarUsuarios() {
+        return userRepository.findAll()
+                .stream()
+                .map(this::toResponse)
+                .toList();
     }
 
-    public User buscarUsuario(Integer id) {
-        return userRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Usuário não encontrado"));
+    public UserResponse buscarUsuario(Integer id) {
+        User usuario = getUsuario(id);
+        return toResponse(usuario);
     }
 
     @Transactional
-    public User atualizarPlanoAtivo(Integer id, Integer novoPlanoId) {
-        User usuario = buscarUsuario(id);
+    public UserResponse atualizarPlanoAtivo(Integer id, Integer novoPlanoId) {
+        User usuario = getUsuario(id);
         UserInfo userInfo = userInfoRepository.findByOwnerUser(usuario)
                 .orElseThrow(() -> new EntityNotFoundException("Informações do usuário não encontradas"));
         Plano plano = planoRepository.findById(novoPlanoId)
                 .orElseThrow(() -> new EntityNotFoundException("Plano não encontrado"));
         userInfo.setPlanoAtivoId(plano);
         userInfoRepository.save(userInfo);
-        return usuario;
+        return toResponse(usuario);
     }
 
     public void desativarUsuario(Integer id) {
-        User usuario = buscarUsuario(id);
+        User usuario = getUsuario(id);
         usuario.setAtivo(false);
         userRepository.save(usuario);
+    }
+
+    private User getUsuario(Integer id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Usuário não encontrado"));
+    }
+
+    private UserResponse toResponse(User usuario) {
+        return UserResponse.builder()
+                .id(usuario.getId())
+                .nome(usuario.getNome())
+                .sobrenome(usuario.getSobrenome())
+                .email(usuario.getEmail())
+                .ativo(usuario.getAtivo())
+                .role(usuario.getRole())
+                .build();
     }
 }
 


### PR DESCRIPTION
## Summary
- add UserRequest and UserResponse DTOs
- update UsuarioService and UsuarioController to use DTOs and follow REST conventions
- hide user password in responses

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aeea4eff7883248ae995614ecf787d