### PR TITLE
Add scheduled cleanup for expired refresh tokens

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Auth/RefreshTokenCleanupScheduler.java
+++ b/src/main/java/com/AIT/Optimanage/Auth/RefreshTokenCleanupScheduler.java
@@ -1,0 +1,21 @@
+package com.AIT.Optimanage.Auth;
+
+import java.time.Instant;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenCleanupScheduler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Scheduled(cron = "${schedule.token-cleanup.cron}")
+    public void removeExpiredTokens() {
+        refreshTokenRepository.deleteByExpiryDateBefore(Instant.now());
+    }
+}
+

--- a/src/main/java/com/AIT/Optimanage/Auth/RefreshTokenRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Auth/RefreshTokenRepository.java
@@ -3,9 +3,11 @@ package com.AIT.Optimanage.Auth;
 import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Instant;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Integer> {
     Optional<RefreshToken> findByToken(String token);
     void deleteByUser(User user);
+    void deleteByExpiryDateBefore(Instant expiryDate);
 }

--- a/src/main/java/com/AIT/Optimanage/OptimanageApplication.java
+++ b/src/main/java/com/AIT/Optimanage/OptimanageApplication.java
@@ -2,8 +2,10 @@ package com.AIT.Optimanage;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class OptimanageApplication {
 
 	public static void main(String[] args) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,4 +20,4 @@ springdoc.swagger-ui.path=/swagger-ui.html
 management.endpoints.web.exposure.include=health,info
 
 spring.cache.type=caffeine
-
+schedule.token-cleanup.cron=0 0 0 * * *


### PR DESCRIPTION
## Summary
- enable scheduling in main application
- schedule daily task to remove expired refresh tokens
- configure cron expression in `application.properties`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aeed0dc9e48324824177bb36387f33