### PR TITLE
feat: add JWT key rotation scheduler

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Config/JwtKeyRotationScheduler.java
+++ b/src/main/java/com/AIT/Optimanage/Config/JwtKeyRotationScheduler.java
@@ -1,0 +1,25 @@
+package com.AIT.Optimanage.Config;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Scheduler responsible for rotating the JWT signing keys.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtKeyRotationScheduler {
+
+    private final JwtService jwtService;
+
+    /**
+     * Rotate the primary and secondary JWT signing keys according to the
+     * configured cron expression.
+     */
+    @Scheduled(cron = "${schedule.key-rotation.cron}")
+    public void rotateKeys() {
+        jwtService.switchKeys();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,5 @@ management.endpoints.web.exposure.include=health,info
 
 spring.cache.type=caffeine
 schedule.token-cleanup.cron=0 0 0 * * *
+
+schedule.key-rotation.cron=0 0 0 * * *


### PR DESCRIPTION
## Summary
- rotate JWT signing keys at a configurable schedule
- expose cron property for key rotation

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af2f9e1e8c8324ae9ef23c013a64d6