### PR TITLE
Add pagination to product and service listings

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/ProdutoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/ProdutoController.java
@@ -3,14 +3,16 @@ package com.AIT.Optimanage.Controllers;
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
 import com.AIT.Optimanage.Controllers.dto.ProdutoRequest;
 import com.AIT.Optimanage.Controllers.dto.ProdutoResponse;
+import com.AIT.Optimanage.Models.Search;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.ProdutoService;
 import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import java.util.List;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,8 +28,18 @@ public class ProdutoController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar produtos", description = "Retorna uma lista de produtos")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public List<ProdutoResponse> listarProdutos(@AuthenticationPrincipal User loggedUser) {
-        return produtoService.listarProdutos(loggedUser);
+    public Page<ProdutoResponse> listarProdutos(@AuthenticationPrincipal User loggedUser,
+                                                @RequestParam(value = "page") Integer page,
+                                                @RequestParam(value = "pageSize") Integer pageSize,
+                                                @RequestParam(value = "sort", required = false) String sort,
+                                                @RequestParam(value = "order", required = false) Sort.Direction order) {
+        var pesquisa = Search.builder()
+                .page(page)
+                .pageSize(pageSize)
+                .sort(sort)
+                .order(order)
+                .build();
+        return produtoService.listarProdutos(loggedUser, pesquisa);
     }
 
     @GetMapping("/{idProduto}")

--- a/src/main/java/com/AIT/Optimanage/Controllers/ServicoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/ServicoController.java
@@ -3,15 +3,16 @@ package com.AIT.Optimanage.Controllers;
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
 import com.AIT.Optimanage.Controllers.dto.ServicoRequest;
 import com.AIT.Optimanage.Controllers.dto.ServicoResponse;
+import com.AIT.Optimanage.Models.Search;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.ServicoService;
 import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,8 +28,18 @@ public class ServicoController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar serviços", description = "Retorna uma lista de serviços")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public List<ServicoResponse> listarServicos(@AuthenticationPrincipal User loggedUser) {
-        return servicoService.listarServicos(loggedUser);
+    public Page<ServicoResponse> listarServicos(@AuthenticationPrincipal User loggedUser,
+                                                @RequestParam(value = "page") Integer page,
+                                                @RequestParam(value = "pageSize") Integer pageSize,
+                                                @RequestParam(value = "sort", required = false) String sort,
+                                                @RequestParam(value = "order", required = false) Sort.Direction order) {
+        var pesquisa = Search.builder()
+                .page(page)
+                .pageSize(pageSize)
+                .sort(sort)
+                .order(order)
+                .build();
+        return servicoService.listarServicos(loggedUser, pesquisa);
     }
 
     @GetMapping("/{idServico}")

--- a/src/main/java/com/AIT/Optimanage/Repositories/ProdutoRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/ProdutoRepository.java
@@ -2,16 +2,17 @@ package com.AIT.Optimanage.Repositories;
 
 import com.AIT.Optimanage.Models.Produto;
 import com.AIT.Optimanage.Models.User.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ProdutoRepository extends JpaRepository<Produto, Integer> {
 
-    List<Produto> findAllByOwnerUserAndAtivoTrue(User loggedUser);
+    Page<Produto> findAllByOwnerUserAndAtivoTrue(User loggedUser, Pageable pageable);
 
     Optional<Produto> findByIdAndOwnerUserAndAtivoTrue(Integer idProduto, User loggedUser);
 

--- a/src/main/java/com/AIT/Optimanage/Repositories/ServicoRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/ServicoRepository.java
@@ -2,16 +2,17 @@ package com.AIT.Optimanage.Repositories;
 
 import com.AIT.Optimanage.Models.Servico;
 import com.AIT.Optimanage.Models.User.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ServicoRepository extends JpaRepository<Servico, Integer> {
 
-    List<Servico> findAllByOwnerUserAndAtivoTrue(User ownerUser);
+    Page<Servico> findAllByOwnerUserAndAtivoTrue(User ownerUser, Pageable pageable);
 
     Optional<Servico> findByIdAndOwnerUserAndAtivoTrue(Integer idServico, User ownerUser);
 


### PR DESCRIPTION
## Summary
- support pageable queries in ProdutoRepository and ServicoRepository
- allow ProdutoService and ServicoService to accept `Search` parameters and return paged results
- expose page/pageSize request params in ProdutoController and ServicoController

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af2fcc56508324abfe907db1d731cd