### PR TITLE
Add Flyway for database migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ Todos os recursos (exceto autenticação) usam o prefixo `/api/v1` e exigem um t
 2. Rodar testes: `./mvnw test`
 3. Executar aplicação: `./mvnw spring-boot:run`
 
+## Migrações de Banco de Dados
+As migrações de esquema são gerenciadas pelo [Flyway](https://flywaydb.org/). Os scripts SQL ficam em `src/main/resources/db/migration` e são aplicados automaticamente na inicialização da aplicação.
+
+Para executar as migrações manualmente, utilize o Maven especificando a conexão com o banco:
+
+```
+./mvnw flyway:migrate \
+    -Dflyway.url=jdbc:mariadb://localhost:3307/optimanage \
+    -Dflyway.user=<usuario> \
+    -Dflyway.password=<senha>
+```
+
 ## Monitoramento
 - `GET /actuator/health` – verificar status da aplicação.
 - `GET /actuator/info` – informações adicionais incluindo contagem de clientes e produtos.

--- a/pom.xml
+++ b/pom.xml
@@ -60,15 +60,19 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jdbc</artifactId>
-		</dependency>
-		<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-test</artifactId>
-				<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jdbc</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.flywaydb</groupId>
+                        <artifactId>flyway-core</artifactId>
+                </dependency>
+                <dependency>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-starter-test</artifactId>
+                                <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>

--- a/src/main/resources/db/migration/V1__create_tables.sql
+++ b/src/main/resources/db/migration/V1__create_tables.sql
@@ -1,0 +1,6 @@
+-- Initial Flyway migration
+CREATE TABLE fornecedor (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nome VARCHAR(64) NOT NULL
+);
+


### PR DESCRIPTION
## Summary
- add Flyway core dependency for schema migrations
- seed migration directory with initial table script
- document how to run Flyway migrations

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af31cce0d88324a191ffc59d16fe1b