### PR TITLE
Validate CPF and CNPJ formats

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteRequest.java
@@ -34,9 +34,11 @@ public class ClienteRequest {
     private String razaoSocial;
 
     @Size(max = 14)
+    @Pattern(regexp = "^(\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}|\\d{11})$", message = "CPF inválido")
     private String cpf;
 
     @Size(max = 18)
+    @Pattern(regexp = "^(\\d{2}\\.\\d{3}\\.\\d{3}/\\d{4}-\\d{2}|\\d{14})$", message = "CNPJ inválido")
     private String cnpj;
 
     @Size(max = 18)

--- a/src/test/java/com/AIT/Optimanage/Controllers/Cliente/ClienteControllerValidationTest.java
+++ b/src/test/java/com/AIT/Optimanage/Controllers/Cliente/ClienteControllerValidationTest.java
@@ -1,0 +1,47 @@
+package com.AIT.Optimanage.Controllers.Cliente;
+
+import com.AIT.Optimanage.Controllers.ExceptionHandler.GlobalExceptionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ClienteController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+class ClienteControllerValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private com.AIT.Optimanage.Services.Cliente.ClienteService clienteService;
+
+    @Test
+    void whenCpfInvalid_thenReturnsBadRequest() throws Exception {
+        String payload = "{\"atividadeId\":1,\"tipoPessoa\":\"FISICA\",\"origem\":\"SITE\",\"cpf\":\"123\"}";
+        mockMvc.perform(post("/clientes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[0]").exists());
+    }
+
+    @Test
+    void whenCnpjInvalid_thenReturnsBadRequest() throws Exception {
+        String payload = "{\"atividadeId\":1,\"tipoPessoa\":\"JURIDICA\",\"origem\":\"SITE\",\"cnpj\":\"123\"}";
+        mockMvc.perform(post("/clientes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[0]").exists());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure CPF and CNPJ follow expected regex patterns
- test ClienteController for invalid CPF and CNPJ formats

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.AIT:Optimanage:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.4.1 (absent))*

------
https://chatgpt.com/codex/tasks/task_e_68af44881a908324bf156b416fa4ed95