### PR TITLE
Fix PF municipal registration validation

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
@@ -107,7 +107,7 @@ public class ClienteService {
             cliente.setRazaoSocial(null);
             cliente.setCnpj(null);
             cliente.setInscricaoEstadual(null);
-            cliente.setInscricaoEstadual(null);
+            cliente.setInscricaoMunicipal(null);
         } else {
             if (cliente.getCnpj() == null || cliente.getCnpj().isEmpty()) {
                 throw new IllegalArgumentException("CNPJ é obrigatório");

--- a/src/test/java/com/AIT/Optimanage/Services/Cliente/ClienteServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/Cliente/ClienteServiceTest.java
@@ -1,0 +1,23 @@
+package com.AIT.Optimanage.Services.Cliente;
+
+import com.AIT.Optimanage.Models.Cliente.Cliente;
+import com.AIT.Optimanage.Models.Enums.TipoPessoa;
+import com.AIT.Optimanage.Models.User.User;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClienteServiceTest {
+
+    @Test
+    void validarClientePessoaFisicaDeveRemoverInscricaoMunicipal() {
+        Cliente cliente = new Cliente();
+        cliente.setTipoPessoa(TipoPessoa.PF);
+        cliente.setInscricaoMunicipal("12345");
+
+        ClienteService service = new ClienteService(null);
+        service.validarCliente(new User(), cliente);
+
+        assertNull(cliente.getInscricaoMunicipal());
+    }
+}


### PR DESCRIPTION
## Summary
- Ensure `validarCliente` clears municipal registration for PF clients
- Add unit test for PF municipal registration being null

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.AIT:Optimanage:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68af446f18e08324b429e9ba4ce27e08