### PR TITLE
Handle null in ID getters across models

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Atividade.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Atividade.java
@@ -25,7 +25,7 @@ public class Atividade {
 
     @JsonProperty("owner_user_id")
     public Integer getOwnerUserId() {
-        return ownerUser.getId();
+        return ownerUser != null ? ownerUser.getId() : null;
     }
 
     @Column(nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
@@ -28,7 +28,7 @@ public class Cliente {
 
     @JsonProperty("owner_user_id")
     public Integer getOwnerUserId() {
-        return ownerUser.getId();
+        return ownerUser != null ? ownerUser.getId() : null;
     }
 
     @JsonIgnore
@@ -38,7 +38,7 @@ public class Cliente {
 
     @JsonProperty("atividade_id")
     public Integer getAtividadeId() {
-        return atividade.getId();
+        return atividade != null ? atividade.getId() : null;
     }
 
     @Column(nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/ClienteContato.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/ClienteContato.java
@@ -22,7 +22,7 @@ public class ClienteContato {
 
     @JsonProperty("cliente_id")
     public Integer getClienteId() {
-        return cliente.getId();
+        return cliente != null ? cliente.getId() : null;
     }
 
     @Column(nullable = false, length = 64)

--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/ClienteEndereco.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/ClienteEndereco.java
@@ -22,7 +22,7 @@ public class ClienteEndereco {
 
     @JsonProperty("cliente_id")
     public Integer getClienteId() {
-        return cliente.getId();
+        return cliente != null ? cliente.getId() : null;
     }
 
     @Column(nullable = false, length = 64)

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
@@ -29,7 +29,7 @@ public class Compra {
 
     @JsonProperty("owner_user_id")
     public Integer getOwnerUserId() {
-        return ownerUser.getId();
+        return ownerUser != null ? ownerUser.getId() : null;
     }
 
     @JsonIgnore
@@ -38,7 +38,7 @@ public class Compra {
 
     @JsonProperty("fornecedor_id")
     public Integer getFornecedorId() {
-        return fornecedor.getId();
+        return fornecedor != null ? fornecedor.getId() : null;
     }
 
 

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/CompraProduto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/CompraProduto.java
@@ -23,7 +23,7 @@ public class CompraProduto {
 
     @JsonProperty("compra_id")
     public Integer getCompraId() {
-        return compra.getId();
+        return compra != null ? compra.getId() : null;
     }
 
     @JsonIgnore
@@ -33,7 +33,7 @@ public class CompraProduto {
 
     @JsonProperty("produto_id")
     public Integer getProdutoId() {
-        return produto.getId();
+        return produto != null ? produto.getId() : null;
     }
 
     @Column(length = 10, precision = 2, nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/CompraServico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/CompraServico.java
@@ -23,7 +23,7 @@ public class CompraServico {
 
     @JsonProperty("compra_id")
     public Integer getCompraId() {
-        return compra.getId();
+        return compra != null ? compra.getId() : null;
     }
 
     @JsonIgnore
@@ -33,7 +33,7 @@ public class CompraServico {
 
     @JsonProperty("servico_id")
     public Integer getServicoId() {
-        return servico.getId();
+        return servico != null ? servico.getId() : null;
     }
 
     @Column(length = 10, precision = 2, nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
@@ -30,7 +30,7 @@ public class Fornecedor {
 
     @JsonProperty("owner_user_id")
     public Integer getOwnerUserId() {
-        return ownerUser.getId();
+        return ownerUser != null ? ownerUser.getId() : null;
     }
 
     @JsonIgnore
@@ -40,7 +40,7 @@ public class Fornecedor {
 
     @JsonProperty("atividade_id")
     public Integer getAtividadeId() {
-        return atividade.getId();
+        return atividade != null ? atividade.getId() : null;
     }
 
     @Column(nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Fornecedor/FornecedorContato.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Fornecedor/FornecedorContato.java
@@ -22,7 +22,7 @@ public class FornecedorContato {
 
     @JsonProperty("fornecedor_id")
     public Integer getFornecedorId() {
-        return fornecedor.getId();
+        return fornecedor != null ? fornecedor.getId() : null;
     }
 
     @Column(nullable = false, length = 64)

--- a/src/main/java/com/AIT/Optimanage/Models/Fornecedor/FornecedorEndereco.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Fornecedor/FornecedorEndereco.java
@@ -22,7 +22,7 @@ public class FornecedorEndereco {
 
     @JsonProperty("fornecedor_id")
     public Integer getFornecedorId() {
-        return fornecedor.getId();
+        return fornecedor != null ? fornecedor.getId() : null;
     }
 
     @Column(nullable = false, length = 64)

--- a/src/main/java/com/AIT/Optimanage/Models/Funcionario.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Funcionario.java
@@ -23,7 +23,7 @@ public class Funcionario {
 
     @JsonProperty("owner_user_id")
     public Integer getOwnerUserId() {
-        return ownerUser.getId();
+        return ownerUser != null ? ownerUser.getId() : null;
     }
 
     @Column(nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Produto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Produto.java
@@ -28,7 +28,7 @@ public class Produto {
 
     @JsonProperty("owner_user_id")
     public Integer getOwnerUserId() {
-        return ownerUser.getId();
+        return ownerUser != null ? ownerUser.getId() : null;
     }
 
     @JsonIgnore

--- a/src/main/java/com/AIT/Optimanage/Models/Servico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Servico.java
@@ -27,7 +27,7 @@ public class Servico {
 
     @JsonProperty("owner_user_id")
     public Integer getOwnerUserId() {
-        return ownerUser.getId();
+        return ownerUser != null ? ownerUser.getId() : null;
     }
 
     @JsonIgnore
@@ -37,7 +37,7 @@ public class Servico {
 
     @JsonProperty("fornecedor_id")
     public Integer getFornecedorId() {
-        return fornecedor.getId();
+        return fornecedor != null ? fornecedor.getId() : null;
     }
 
     @Column(nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
@@ -22,7 +22,7 @@ public class Contador {
 
     @JsonProperty("owner_user_id")
     public Integer getOwnerUserId() {
-        return ownerUser.getId();
+        return ownerUser != null ? ownerUser.getId() : null;
     }
 
     @Column(nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/User/UserInfo.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/UserInfo.java
@@ -28,7 +28,7 @@ public class UserInfo {
 
     @JsonProperty("owner_user_id")
     public Integer getOwnerUserId() {
-        return ownerUser.getId();
+        return ownerUser != null ? ownerUser.getId() : null;
     }
 
     @JsonIgnore
@@ -38,7 +38,7 @@ public class UserInfo {
 
     @JsonProperty("tipo_acesso_id")
     public Integer getPlanoAtivoId() {
-        return planoAtivoId.getId();
+        return planoAtivoId != null ? planoAtivoId.getId() : null;
     }
 
     @Column(nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Related/Alteracao.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Related/Alteracao.java
@@ -27,7 +27,7 @@ public class Alteracao {
 
     @JsonProperty("venda_id")
     public Integer getVendaId() {
-        return venda.getId();
+        return venda != null ? venda.getId() : null;
     }
 
     @Column(nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
@@ -30,7 +30,7 @@ public class Venda {
 
     @JsonProperty("owner_user_id")
     public Integer getOwnerUserId() {
-        return ownerUser.getId();
+        return ownerUser != null ? ownerUser.getId() : null;
     }
 
     @JsonIgnore
@@ -40,7 +40,7 @@ public class Venda {
 
     @JsonProperty("cliente_id")
     public Integer getClienteId() {
-        return cliente.getId();
+        return cliente != null ? cliente.getId() : null;
     }
 
     @Min(1)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/VendaProduto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/VendaProduto.java
@@ -23,7 +23,7 @@ public class VendaProduto {
 
     @JsonProperty("venda_id")
     public Integer getVendaId() {
-        return venda.getId();
+        return venda != null ? venda.getId() : null;
     }
 
     @JsonIgnore
@@ -33,7 +33,7 @@ public class VendaProduto {
 
     @JsonProperty("produto_id")
     public Integer getProdutoId() {
-        return produto.getId();
+        return produto != null ? produto.getId() : null;
     }
 
     @Column(length = 10, precision = 2, nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/VendaServico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/VendaServico.java
@@ -23,7 +23,7 @@ public class VendaServico {
 
     @JsonProperty("venda_id")
     public Integer getVendaId() {
-        return venda.getId();
+        return venda != null ? venda.getId() : null;
     }
 
     @JsonIgnore
@@ -33,7 +33,7 @@ public class VendaServico {
 
     @JsonProperty("servico_id")
     public Integer getServicoId() {
-        return servico.getId();
+        return servico != null ? servico.getId() : null;
     }
 
     @Column(nullable = false)


### PR DESCRIPTION
## Summary
- Avoid NullPointerExceptions by returning null when related entities are absent in `getOwnerUserId` and `getAtividadeId` of `Cliente`
- Apply the same null-safe pattern to similar ID getters across model classes

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af445ab6948324a79db4ef4945217b