### PR TITLE
Replace Double with BigDecimal in financial models

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PrevisaoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PrevisaoDTO.java
@@ -4,10 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class PrevisaoDTO {
-    private double valorPrevisto;
+    private BigDecimal valorPrevisto;
 }
 

--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/ResumoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/ResumoDTO.java
@@ -4,12 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class ResumoDTO {
-    private double totalVendas;
-    private double totalCompras;
-    private double lucro;
+    private BigDecimal totalVendas;
+    private BigDecimal totalCompras;
+    private BigDecimal lucro;
 }
 

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ServicoRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ServicoRequest.java
@@ -1,6 +1,7 @@
 package com.AIT.Optimanage.Controllers.dto;
 
 import jakarta.validation.constraints.*;
+import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -23,14 +24,14 @@ public class ServicoRequest {
     private String descricao;
 
     @NotNull
-    @PositiveOrZero
-    private Double custo;
+    @DecimalMin(value = "0.0")
+    private BigDecimal custo;
 
     private Boolean disponivelVenda;
 
     @NotNull
-    @PositiveOrZero
-    private Double valorVenda;
+    @DecimalMin(value = "0.0")
+    private BigDecimal valorVenda;
 
     @NotNull
     private Integer tempoExecucao;

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ServicoResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ServicoResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
 
 @Data
 @Builder
@@ -17,9 +18,9 @@ public class ServicoResponse {
     private Integer sequencialUsuario;
     private String nome;
     private String descricao;
-    private Double custo;
+    private BigDecimal custo;
     private Boolean disponivelVenda;
-    private Double valorVenda;
+    private BigDecimal valorVenda;
     private Integer tempoExecucao;
     private Boolean terceirizado;
     private Boolean ativo;

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
@@ -6,9 +6,10 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.*;
 import lombok.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -48,13 +49,13 @@ public class Compra {
     @Column(nullable = false)
     private LocalDate dataEfetuacao;
     private LocalDate dataAgendada;
-    @Min(0)
-    @Column(nullable = false)
-    private Double valorFinal;
+    @DecimalMin(value = "0.0")
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorFinal;
     private String condicaoPagamento;
-    @Min(0)
-    @Column(nullable = false)
-    private Double valorPendente;
+    @DecimalMin(value = "0.0")
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorPendente;
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private StatusCompra status = StatusCompra.ORCAMENTO;

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/CompraPagamento.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/CompraPagamento.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @Data
@@ -24,8 +25,8 @@ public class CompraPagamento {
     @JoinColumn(name = "compra_id", nullable = false)
     private Compra compra;
 
-    @Column(nullable = false)
-    private Double valorPago;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorPago;
 
     @Column(nullable = false)
     private LocalDate dataPagamento;

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/CompraProduto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/CompraProduto.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -36,13 +38,13 @@ public class CompraProduto {
         return produto.getId();
     }
 
-    @Column(length = 10, precision = 2, nullable = false)
-    private Double valorUnitario;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorUnitario;
 
     @Column(nullable = false)
     private Integer quantidade;
 
-    @Column(nullable = false)
-    private Double valorTotal;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorTotal;
 
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/CompraServico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/CompraServico.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -36,13 +38,13 @@ public class CompraServico {
         return servico.getId();
     }
 
-    @Column(length = 10, precision = 2, nullable = false)
-    private Double valorUnitario;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorUnitario;
 
     @Column(nullable = false)
     private Integer quantidade;
 
-    @Column(nullable = false)
-    private Double valorTotal;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorTotal;
 
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraDTO.java
@@ -2,13 +2,13 @@ package com.AIT.Optimanage.Models.Compra.DTOs;
 
 import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
 import com.AIT.Optimanage.Models.PagamentoDTO;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -23,9 +23,9 @@ public class CompraDTO {
     private LocalDate dataEfetuacao = LocalDate.now();
     private LocalDate dataAgendada = null;
     private LocalDate dataCobranca;
-    @Min(0)
+    @DecimalMin(value = "0.0")
     @NotNull
-    private Double valorFinal;
+    private BigDecimal valorFinal;
     private String condicaoPagamento;
     @NotNull
     private StatusCompra status = StatusCompra.ORCAMENTO;

--- a/src/main/java/com/AIT/Optimanage/Models/PagamentoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/PagamentoDTO.java
@@ -2,12 +2,13 @@ package com.AIT.Optimanage.Models;
 
 import com.AIT.Optimanage.Models.Enums.FormaPagamento;
 import com.AIT.Optimanage.Models.Enums.StatusPagamento;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @Data
@@ -16,7 +17,8 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class PagamentoDTO {
     @NotNull
-    private Double valorPago;
+    @DecimalMin(value = "0.0", inclusive = false)
+    private BigDecimal valorPago;
     @NotNull
     private LocalDate dataPagamento;
     @NotNull

--- a/src/main/java/com/AIT/Optimanage/Models/Servico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Servico.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Data
@@ -45,11 +46,11 @@ public class Servico {
     @Column(nullable = false)
     private String nome;
     private String descricao;
-    @Column(nullable = false, length = 10, precision = 2)
-    private Double custo;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal custo;
     private Boolean disponivelVenda;
-    @Column(nullable = false, length = 10, precision = 2)
-    private Double valorVenda;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorVenda;
     @Column(nullable = false)
     private Integer tempoExecucao;
     private Boolean terceirizado;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaDTO.java
@@ -2,13 +2,13 @@ package com.AIT.Optimanage.Models.Venda.DTOs;
 
 import com.AIT.Optimanage.Models.PagamentoDTO;
 import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -23,8 +23,8 @@ public class VendaDTO {
     private LocalDate dataEfetuacao = LocalDate.now();
     private LocalDate dataAgendada = null;
     private LocalDate dataCobranca;
-    @Min(0)
-    private Double descontoGeral = 0.0;
+    @DecimalMin(value = "0.0")
+    private BigDecimal descontoGeral = BigDecimal.ZERO;
     private String condicaoPagamento;
     @Min(0)
     private Integer alteracoesPermitidas = 0;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaProdutoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaProdutoDTO.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,5 +17,5 @@ public class VendaProdutoDTO {
     @Min(1)
     private Integer quantidade;
 
-    private Double desconto = 0.0;
+    private BigDecimal desconto = BigDecimal.ZERO;
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaServicoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaServicoDTO.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -17,5 +19,5 @@ public class VendaServicoDTO {
     @Min(1)
     private Integer quantidade;
 
-    private Double desconto = 0.0;
+    private BigDecimal desconto = BigDecimal.ZERO;
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
@@ -7,9 +7,10 @@ import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.*;
 import lombok.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -51,22 +52,22 @@ public class Venda {
     private LocalDate dataAgendada;
     @Column(nullable = false)
     private LocalDate dataCobranca;
-    @Min(0)
-    @Column(nullable = false)
-    private Double valorTotal;
-    @Min(0)
-    @Column(nullable = false)
-    private Double descontoGeral;
-    @Min(0)
-    @Column(nullable = false)
-    private Double valorFinal;
+    @DecimalMin(value = "0.0")
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorTotal;
+    @DecimalMin(value = "0.0")
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal descontoGeral;
+    @DecimalMin(value = "0.0")
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorFinal;
     private String condicaoPagamento;
     @Min(0)
     @Column(nullable = false)
     private Integer alteracoesPermitidas = 0;
-    @Min(0)
-    @Column(nullable = false)
-    private Double valorPendente;
+    @DecimalMin(value = "0.0")
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorPendente;
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private StatusVenda status = StatusVenda.PENDENTE;
@@ -89,7 +90,7 @@ public class Venda {
     }
 
     public boolean isPago() {
-        return this.valorPendente == 0.0;
+        return this.valorPendente.compareTo(BigDecimal.ZERO) == 0;
     }
 
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/VendaPagamento.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/VendaPagamento.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @Data
@@ -24,8 +25,8 @@ public class VendaPagamento {
     @JoinColumn(name = "venda_id", nullable = false)
     private Venda venda;
 
-    @Column(nullable = false)
-    private Double valorPago;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorPago;
 
     @Column(nullable = false)
     private LocalDate dataPagamento;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/VendaProduto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/VendaProduto.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -36,16 +38,16 @@ public class VendaProduto {
         return produto.getId();
     }
 
-    @Column(length = 10, precision = 2, nullable = false)
-    private Double valorUnitario;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorUnitario;
 
     @Column(nullable = false)
     private Integer quantidade;
 
     @Column(length = 3)
-    private Double desconto = 0.0;
+    private BigDecimal desconto = BigDecimal.ZERO;
 
-    @Column(length = 10,precision = 2)
-    private Double valorFinal;
+    @Column(precision = 10, scale = 2)
+    private BigDecimal valorFinal;
 
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/VendaServico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/VendaServico.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -39,13 +41,13 @@ public class VendaServico {
     @Column(nullable = false)
     private Integer quantidade;
 
-    @Column(length = 10, precision = 2, nullable = false)
-    private Double valorUnitario;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorUnitario;
 
     @Column(length = 3)
-    private Double desconto = 0.0;
+    private BigDecimal desconto = BigDecimal.ZERO;
 
-    @Column(length = 10,precision = 2)
-    private Double valorFinal;
+    @Column(precision = 10, scale = 2)
+    private BigDecimal valorFinal;
 
 }

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -95,9 +95,9 @@ public class CompraService {
                 .sequencialUsuario(contador.getContagemAtual())
                 .dataEfetuacao(compraDTO.getDataEfetuacao())
                 .dataAgendada(compraDTO.getDataAgendada())
-                .valorFinal(0.0)
+                .valorFinal(BigDecimal.ZERO)
                 .condicaoPagamento(compraDTO.getCondicaoPagamento())
-                .valorPendente(0.0)
+                .valorPendente(BigDecimal.ZERO)
                 .status(compraDTO.getStatus())
                 .observacoes(compraDTO.getObservacoes())
                 .build();
@@ -107,12 +107,17 @@ public class CompraService {
         novaCompra.setCompraProdutos(compraProdutos);
         novaCompra.setCompraServicos(compraServicos);
 
-        double valorTotal = compraProdutos.stream().mapToDouble(CompraProduto::getValorTotal).sum()
-                + compraServicos.stream().mapToDouble(CompraServico::getValorTotal).sum();
-        double valorPago = 0.0;
+        BigDecimal valorProdutos = compraProdutos.stream()
+                .map(CompraProduto::getValorTotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal valorServicos = compraServicos.stream()
+                .map(CompraServico::getValorTotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal valorTotal = valorProdutos.add(valorServicos);
+        BigDecimal valorPago = BigDecimal.ZERO;
 
         novaCompra.setValorFinal(valorTotal);
-        novaCompra.setValorPendente(valorTotal - valorPago);
+        novaCompra.setValorPendente(valorTotal.subtract(valorPago));
 
         
         compraRepository.save(novaCompra);
@@ -134,9 +139,9 @@ public class CompraService {
                 .sequencialUsuario(compra.getSequencialUsuario())
                 .dataEfetuacao(compraDTO.getDataEfetuacao())
                 .dataAgendada(compraDTO.getDataAgendada())
-                .valorFinal(0.0)
+                .valorFinal(BigDecimal.ZERO)
                 .condicaoPagamento(compraDTO.getCondicaoPagamento())
-                .valorPendente(0.0)
+                .valorPendente(BigDecimal.ZERO)
                 .status(compraDTO.getStatus())
                 .observacoes(compraDTO.getObservacoes())
                 .build();
@@ -149,15 +154,20 @@ public class CompraService {
         compraAtualizada.setCompraProdutos(compraProdutos);
         compraAtualizada.setCompraServicos(compraServicos);
 
-        double valorTotal = compraProdutos.stream().mapToDouble(CompraProduto::getValorTotal).sum()
-                + compraServicos.stream().mapToDouble(CompraServico::getValorTotal).sum();
+        BigDecimal valorProdutos = compraProdutos.stream()
+                .map(CompraProduto::getValorTotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal valorServicos = compraServicos.stream()
+                .map(CompraServico::getValorTotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal valorTotal = valorProdutos.add(valorServicos);
 
-        double valorPago = compra.getPagamentos() == null
-                ? 0.0
-                : compra.getPagamentos().stream().mapToDouble(CompraPagamento::getValorPago).sum();
+        BigDecimal valorPago = compra.getPagamentos() == null
+                ? BigDecimal.ZERO
+                : compra.getPagamentos().stream().map(CompraPagamento::getValorPago).reduce(BigDecimal.ZERO, BigDecimal::add);
 
         compraAtualizada.setValorFinal(valorTotal);
-        compraAtualizada.setValorPendente(valorTotal - valorPago);
+        compraAtualizada.setValorPendente(valorTotal.subtract(valorPago));
         atualizarStatus(compra, compraAtualizada.getStatus());
 
         compraProdutoRepository.saveAll(compraProdutos);
@@ -191,7 +201,7 @@ public class CompraService {
         podePagarCompra(compra);
 
         for (PagamentoDTO pagamento : pagamentoDTO) {
-            if (pagamento.getValorPago() <= 0) {
+            if (pagamento.getValorPago().compareTo(BigDecimal.ZERO) <= 0) {
                 throw new IllegalArgumentException("Valor de pagamento deve ser maior que zero");
             } else if (pagamento.getStatusPagamento() == StatusPagamento.PAGO && pagamento.getDataPagamento().isAfter(LocalDate.now())) {
                 throw new IllegalArgumentException("Um pagamento realizado não pode ser no futuro");
@@ -226,13 +236,15 @@ public class CompraService {
         } else {
             throw new IllegalArgumentException("O pagamento informado não pode ser estornado");
         }
-        double valorPago = compra.getPagamentos().stream().mapToDouble(CompraPagamento::getValorPago).sum();
-        compra.setValorPendente(compra.getValorFinal() - valorPago);
-        if (compra.getValorPendente() <= 0) {
+        BigDecimal valorPago = compra.getPagamentos().stream()
+                .map(CompraPagamento::getValorPago)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        compra.setValorPendente(compra.getValorFinal().subtract(valorPago));
+        if (compra.getValorPendente().compareTo(BigDecimal.ZERO) <= 0) {
             if (compra.getStatus() == StatusCompra.AGUARDANDO_PAG || compra.getStatus() == StatusCompra.PARCIALMENTE_PAGO) {
                 atualizarStatus(compra, StatusCompra.PAGO);
             }
-        } else if (valorPago < 0) {
+        } else if (valorPago.compareTo(BigDecimal.ZERO) < 0) {
             atualizarStatus(compra, StatusCompra.PARCIALMENTE_PAGO);
         }
         return compraRepository.save(compra);
@@ -261,9 +273,9 @@ public class CompraService {
                     return CompraProduto.builder()
                             .compra(compra)
                             .produto(produto)
-                            .valorUnitario(produto.getValorVenda().doubleValue())
+                            .valorUnitario(produto.getValorVenda())
                             .quantidade(produtoDTO.getQuantidade())
-                            .valorTotal(valorFinalProduto.doubleValue())
+                            .valorTotal(valorFinalProduto)
                             .build();
                 })
                 .collect(Collectors.toList());
@@ -273,7 +285,8 @@ public class CompraService {
         return servicosDTO.stream()
                 .map(servicoDTO -> {
                     Servico servico = servicoService.buscarServicoAtivo(compra.getOwnerUser(), servicoDTO.getServicoId());
-                    double valorFinalServico = servico.getValorVenda() * servicoDTO.getQuantidade();
+                    BigDecimal valorFinalServico = servico.getValorVenda()
+                            .multiply(BigDecimal.valueOf(servicoDTO.getQuantidade()));
 
                     return CompraServico.builder()
                             .compra(compra)
@@ -346,7 +359,7 @@ public class CompraService {
                 if (statusAtual != StatusCompra.PAGO && statusAtual != StatusCompra.AGUARDANDO_EXECUCAO) {
                     throw new IllegalStateException("A compra só pode ser finalizada se estiver paga ou aguardando execução.");
                 }
-                if (compra.getValorPendente() > 0) {
+                if (compra.getValorPendente().compareTo(BigDecimal.ZERO) > 0) {
                     throw new IllegalStateException("A compra não pode ser finalizada enquanto houver saldo pendente.");
                 }
                 break;
@@ -369,7 +382,7 @@ public class CompraService {
             throw new IllegalArgumentException("Não é possível lançar um pagamento para uma compra já concretizada");
         } else if (compra.getStatus() == StatusCompra.CANCELADO) {
             throw new IllegalArgumentException("Não é possível lançar um pagamento para uma compra cancelada");
-        } else if (compra.getStatus() == StatusCompra.PAGO || compra.getValorPendente() <= 0) {
+        } else if (compra.getStatus() == StatusCompra.PAGO || compra.getValorPendente().compareTo(BigDecimal.ZERO) <= 0) {
             throw new IllegalArgumentException("Não é possível lançar um pagamento para uma compra já paga");
         } else if (compra.getStatus() == StatusCompra.ORCAMENTO) {
             throw new IllegalArgumentException("Não é possível lançar um pagamento para um orçamento");
@@ -379,10 +392,10 @@ public class CompraService {
     public void atualizarCompraPosPagamento(Compra compra) {
         List<CompraPagamento> pagamentos = pagamentoCompraService.listarPagamentosRealizadosCompra(compra.getOwnerUser(), compra.getId());
 
-        double valorPago = pagamentos.stream().mapToDouble(CompraPagamento::getValorPago).sum();
-        compra.setValorPendente(compra.getValorFinal() - valorPago);
+        BigDecimal valorPago = pagamentos.stream().map(CompraPagamento::getValorPago).reduce(BigDecimal.ZERO, BigDecimal::add);
+        compra.setValorPendente(compra.getValorFinal().subtract(valorPago));
 
-        if (compra.getValorPendente() == 0) {
+        if (compra.getValorPendente().compareTo(BigDecimal.ZERO) == 0) {
             if (compra.getStatus() == StatusCompra.AGUARDANDO_PAG || compra.getStatus() == StatusCompra.PARCIALMENTE_PAGO) {
                 atualizarStatus(compra, StatusCompra.PAGO);
             }


### PR DESCRIPTION
## Summary
- Use BigDecimal instead of Double for monetary values across Compra, Venda, and Servico flows
- Add @DecimalMin validation and BigDecimal comparisons (e.g. isPago)
- Update services, DTOs, and analytics to perform BigDecimal arithmetic
- Fix BigDecimal comparisons and forecast return

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af4445e9248324aacb427aad4db933