### PR TITLE
Enable JPA auditing for entities

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Atividade.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Atividade.java
@@ -7,13 +7,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Atividade {
+public class Atividade extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/BaseEntity.java
+++ b/src/main/java/com/AIT/Optimanage/Models/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.AIT.Optimanage.Models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -16,7 +17,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Cliente {
+public class Cliente extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/ClienteContato.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/ClienteContato.java
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class ClienteContato {
+public class ClienteContato extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/ClienteEndereco.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/ClienteEndereco.java
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class ClienteEndereco {
+public class ClienteEndereco extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Compra {
+public class Compra extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/CompraPagamento.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/CompraPagamento.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 import java.time.LocalDate;
 
@@ -15,7 +16,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class CompraPagamento {
+public class CompraPagamento extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/CompraProduto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/CompraProduto.java
@@ -5,13 +5,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class CompraProduto {
+public class CompraProduto extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/CompraServico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/CompraServico.java
@@ -5,13 +5,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class CompraServico {
+public class CompraServico extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 import java.time.LocalDate;
 import java.util.Date;
@@ -18,7 +19,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Fornecedor {
+public class Fornecedor extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Fornecedor/FornecedorContato.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Fornecedor/FornecedorContato.java
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class FornecedorContato {
+public class FornecedorContato extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Fornecedor/FornecedorEndereco.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Fornecedor/FornecedorEndereco.java
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class FornecedorEndereco {
+public class FornecedorEndereco extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Funcionario.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Funcionario.java
@@ -5,13 +5,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Funcionario {
+public class Funcionario extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Plano.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Plano.java
@@ -2,13 +2,14 @@ package com.AIT.Optimanage.Models;
 
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Plano {
+public class Plano extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Produto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Produto.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -16,7 +17,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Produto {
+public class Produto extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Servico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Servico.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 import java.util.List;
 
@@ -15,7 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Servico {
+public class Servico extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Contador {
+public class Contador extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/User/User.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/User.java
@@ -1,6 +1,7 @@
 package com.AIT.Optimanage.Models.User;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.AIT.Optimanage.Models.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +19,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class User implements UserDetails {
+public class User extends BaseEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/AIT/Optimanage/Models/User/UserInfo.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/UserInfo.java
@@ -1,6 +1,7 @@
 package com.AIT.Optimanage.Models.User;
 
 import com.AIT.Optimanage.Models.Plano;
+import com.AIT.Optimanage.Models.BaseEntity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
@@ -16,7 +17,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class UserInfo {
+public class UserInfo extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Compatibilidade/Compatibilidade.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Compatibilidade/Compatibilidade.java
@@ -9,13 +9,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Compatibilidade {
+public class Compatibilidade extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Compatibilidade/ContextoCompatibilidade.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Compatibilidade/ContextoCompatibilidade.java
@@ -7,13 +7,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class ContextoCompatibilidade {
+public class ContextoCompatibilidade extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Related/Alteracao.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Related/Alteracao.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 import java.time.LocalDateTime;
 
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Alteracao {
+public class Alteracao extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -18,7 +19,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Venda {
+public class Venda extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/VendaPagamento.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/VendaPagamento.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 import java.time.LocalDate;
 
@@ -15,7 +16,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class VendaPagamento {
+public class VendaPagamento extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/VendaProduto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/VendaProduto.java
@@ -5,13 +5,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class VendaProduto {
+public class VendaProduto extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/VendaServico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/VendaServico.java
@@ -5,13 +5,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+import com.AIT.Optimanage.Models.BaseEntity;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class VendaServico {
+public class VendaServico extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/src/main/java/com/AIT/Optimanage/OptimanageApplication.java
+++ b/src/main/java/com/AIT/Optimanage/OptimanageApplication.java
@@ -3,9 +3,11 @@ package com.AIT.Optimanage;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableJpaAuditing
 public class OptimanageApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
## Summary
- enable JPA auditing on application
- add BaseEntity with createdAt and updatedAt fields
- make all entities extend BaseEntity

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af44c9b7fc8324bb2d15e69fb3f48f