### PR TITLE
refactor: standardize controller responses

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
@@ -5,6 +5,7 @@ import com.AIT.Optimanage.Analytics.DTOs.ResumoDTO;
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
 import com.AIT.Optimanage.Models.User.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,13 +19,13 @@ public class AnalyticsController extends V1BaseController {
     private final AnalyticsService analyticsService;
 
     @GetMapping("/resumo")
-    public ResumoDTO resumo(@AuthenticationPrincipal User user) {
-        return analyticsService.obterResumo(user);
+    public ResponseEntity<ResumoDTO> resumo(@AuthenticationPrincipal User user) {
+        return ok(analyticsService.obterResumo(user));
     }
 
     @GetMapping("/previsao")
-    public PrevisaoDTO previsao(@AuthenticationPrincipal User user) {
-        return analyticsService.preverDemanda(user);
+    public ResponseEntity<PrevisaoDTO> previsao(@AuthenticationPrincipal User user) {
+        return ok(analyticsService.preverDemanda(user));
     }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Auth/AuthenticationController.java
+++ b/src/main/java/com/AIT/Optimanage/Auth/AuthenticationController.java
@@ -13,19 +13,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/auth")
 @RequiredArgsConstructor
 @Tag(name = "Autenticação", description = "Endpoints de autenticação")
-public class AuthenticationController {
+public class AuthenticationController extends com.AIT.Optimanage.Controllers.BaseController.V1BaseController {
 
     private final AuthenticationService authenticationService;
 
     @PostMapping("/register")
     @Operation(summary = "Registrar", description = "Registra um novo usuário")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
+    @ApiResponse(responseCode = "201", description = "Criado")
     public ResponseEntity<AuthenticationResponse> register(
             @Valid @RequestBody RegisterRequest request) {
-        return ResponseEntity.ok(authenticationService.register(request));
+        return created(authenticationService.register(request));
     }
 
     @PostMapping("/authenticate")
@@ -33,7 +33,7 @@ public class AuthenticationController {
     @ApiResponse(responseCode = "200", description = "Sucesso")
     public ResponseEntity<AuthenticationResponse> authenticate(
             @Valid @RequestBody AuthenticationRequest request) {
-        return ResponseEntity.ok(authenticationService.authenticate(request));
+        return ok(authenticationService.authenticate(request));
     }
 
     @PostMapping("/refresh")
@@ -41,6 +41,6 @@ public class AuthenticationController {
     @ApiResponse(responseCode = "200", description = "Sucesso")
     public ResponseEntity<AuthenticationResponse> refresh(
             @Valid @RequestBody RefreshTokenRequest request) {
-        return ResponseEntity.ok(authenticationService.refreshToken(request.getRefreshToken()));
+        return ok(authenticationService.refreshToken(request.getRefreshToken()));
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/AgendaController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/AgendaController.java
@@ -7,6 +7,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.AgendaService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,13 +31,13 @@ public class AgendaController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar eventos", description = "Retorna uma página de eventos da agenda")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Page<EventoAgenda> listarEventos(@AuthenticationPrincipal User loggedUser,
-                                            @RequestParam(value = "data_inicial", required = false) LocalDate data_inicial,
-                                            @RequestParam(value = "data_final", required = false) LocalDate data_final,
-                                            @RequestParam(value = "sort", required = false) String sort,
-                                            @RequestParam(value = "order", required = false) Sort.Direction order,
-                                            @RequestParam(value = "page", required = true) Integer page,
-                                            @RequestParam(value = "pagesize", required = true) Integer pagesize) {
+    public ResponseEntity<Page<EventoAgenda>> listarEventos(@AuthenticationPrincipal User loggedUser,
+                                                            @RequestParam(value = "data_inicial", required = false) LocalDate data_inicial,
+                                                            @RequestParam(value = "data_final", required = false) LocalDate data_final,
+                                                            @RequestParam(value = "sort", required = false) String sort,
+                                                            @RequestParam(value = "order", required = false) Sort.Direction order,
+                                                            @RequestParam(value = "page", required = true) Integer page,
+                                                            @RequestParam(value = "pagesize", required = true) Integer pagesize) {
         AgendaSearch pesquisa = AgendaSearch.builder()
                 .dataInicial(data_inicial)
                 .dataFinal(data_final)
@@ -45,6 +46,6 @@ public class AgendaController extends V1BaseController {
                 .sort(sort)
                 .order(order)
                 .build();
-        return agendaService.listarEventos(loggedUser, pesquisa);
+        return ok(agendaService.listarEventos(loggedUser, pesquisa));
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/BaseController/V1BaseController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/BaseController/V1BaseController.java
@@ -1,7 +1,21 @@
 package com.AIT.Optimanage.Controllers.BaseController;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequestMapping("/api/v1")
 public abstract class V1BaseController {
+
+    protected <T> ResponseEntity<T> ok(T body) {
+        return ResponseEntity.ok(body);
+    }
+
+    protected <T> ResponseEntity<T> created(T body) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(body);
+    }
+
+    protected ResponseEntity<Void> noContent() {
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteContatoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteContatoController.java
@@ -5,6 +5,7 @@ import com.AIT.Optimanage.Models.Cliente.ClienteContato;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.Cliente.ClienteContatoService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
@@ -25,37 +26,38 @@ public class ClienteContatoController extends V1BaseController {
     @GetMapping("/{idCliente}/contatos")
     @Operation(summary = "Listar contatos", description = "Lista contatos de um cliente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public List<ClienteContato> listarContatos(@AuthenticationPrincipal User loggedUser,
-                                               @PathVariable("idCliente") Integer idCliente) {
-        return clienteContatoService.listarContatos(loggedUser, idCliente);
+    public ResponseEntity<List<ClienteContato>> listarContatos(@AuthenticationPrincipal User loggedUser,
+                                                               @PathVariable("idCliente") Integer idCliente) {
+        return ok(clienteContatoService.listarContatos(loggedUser, idCliente));
     }
 
     @PostMapping("/{idCliente}/contatos")
     @Operation(summary = "Cadastrar contato", description = "Adiciona contato a um cliente")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ClienteContato cadastrarContato(@AuthenticationPrincipal User loggedUser,
-                                          @PathVariable("idCliente") Integer idCliente,
-                                          @RequestBody @Valid ClienteContato contato) {
-        return clienteContatoService.cadastrarContato(loggedUser, idCliente, contato);
+    @ApiResponse(responseCode = "201", description = "Criado")
+    public ResponseEntity<ClienteContato> cadastrarContato(@AuthenticationPrincipal User loggedUser,
+                                                           @PathVariable("idCliente") Integer idCliente,
+                                                           @RequestBody @Valid ClienteContato contato) {
+        return created(clienteContatoService.cadastrarContato(loggedUser, idCliente, contato));
     }
 
     @PutMapping("/{idCliente}/contatos/{idContato}")
     @Operation(summary = "Editar contato", description = "Atualiza contato de um cliente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ClienteContato editarContato(@AuthenticationPrincipal User loggedUser,
-                                        @PathVariable("idCliente") Integer idCliente,
-                                        @PathVariable("idContato") Integer idContato,
-                                        @RequestBody @Valid ClienteContato contato) {
-        return clienteContatoService.editarContato(loggedUser, idCliente, idContato, contato);
+    public ResponseEntity<ClienteContato> editarContato(@AuthenticationPrincipal User loggedUser,
+                                                        @PathVariable("idCliente") Integer idCliente,
+                                                        @PathVariable("idContato") Integer idContato,
+                                                        @RequestBody @Valid ClienteContato contato) {
+        return ok(clienteContatoService.editarContato(loggedUser, idCliente, idContato, contato));
     }
 
     @DeleteMapping("/{idCliente}/contatos/{idContato}")
     @Operation(summary = "Excluir contato", description = "Remove contato de um cliente")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public void excluirContato(@AuthenticationPrincipal User loggedUser,
-                               @PathVariable("idCliente") Integer idCliente,
-                               @PathVariable("idContato") Integer idContato) {
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+    public ResponseEntity<Void> excluirContato(@AuthenticationPrincipal User loggedUser,
+                                               @PathVariable("idCliente") Integer idCliente,
+                                               @PathVariable("idContato") Integer idContato) {
         clienteContatoService.excluirContato(loggedUser, idCliente, idContato);
+        return noContent();
     }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteController.java
@@ -10,6 +10,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.Cliente.ClienteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -37,7 +38,7 @@ public class ClienteController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar clientes", description = "Retorna uma página de clientes")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Page<Cliente> listarClientes(@AuthenticationPrincipal User loggedUser,
+    public ResponseEntity<Page<Cliente>> listarClientes(@AuthenticationPrincipal User loggedUser,
                                         @RequestParam(value = "id", required = false) Integer id,
                                         @RequestParam(value = "nome", required = false) String nome,
                                         @RequestParam(value = "estado", required = false) String estado,
@@ -62,58 +63,60 @@ public class ClienteController extends V1BaseController {
                 .sort(sort)
                 .order(order)
                 .build();
-        return clienteService.listarClientes(loggedUser, pesquisa);
+        return ok(clienteService.listarClientes(loggedUser, pesquisa));
     }
 
     @GetMapping("/{idCliente}")
     @Operation(summary = "Listar cliente", description = "Retorna um cliente pelo ID")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Cliente listarUmCliente(@AuthenticationPrincipal User loggedUser,
-                                   @PathVariable("idCliente") Integer idCliente) {
-        return clienteService.listarUmCliente(loggedUser, idCliente);
+    public ResponseEntity<Cliente> listarUmCliente(@AuthenticationPrincipal User loggedUser,
+                                                   @PathVariable("idCliente") Integer idCliente) {
+        return ok(clienteService.listarUmCliente(loggedUser, idCliente));
     }
 
     @PostMapping
     @Operation(summary = "Criar cliente", description = "Cria um novo cliente")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Cliente criarCliente(@AuthenticationPrincipal User loggedUser,
-                                @RequestBody @Valid ClienteRequest request) {
-        return clienteService.criarCliente(loggedUser, request);
+    @ApiResponse(responseCode = "201", description = "Criado")
+    public ResponseEntity<Cliente> criarCliente(@AuthenticationPrincipal User loggedUser,
+                                                @RequestBody @Valid ClienteRequest request) {
+        return created(clienteService.criarCliente(loggedUser, request));
     }
 
     @PutMapping("/{idCliente}")
     @Operation(summary = "Editar cliente", description = "Atualiza um cliente existente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Cliente editarCliente(@AuthenticationPrincipal User loggedUser,
-                                 @PathVariable("idCliente") Integer idCliente,
-                                 @RequestBody @Valid ClienteRequest request) {
-        return clienteService.editarCliente(loggedUser, idCliente, request);
+    public ResponseEntity<Cliente> editarCliente(@AuthenticationPrincipal User loggedUser,
+                                                 @PathVariable("idCliente") Integer idCliente,
+                                                 @RequestBody @Valid ClienteRequest request) {
+        return ok(clienteService.editarCliente(loggedUser, idCliente, request));
     }
 
     @DeleteMapping("/{idCliente}")
     @Operation(summary = "Inativar cliente", description = "Inativa um cliente pelo ID")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public void inativarCliente(@AuthenticationPrincipal User loggedUser,
-                                @PathVariable("idCliente") Integer idCliente) {
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+    public ResponseEntity<Void> inativarCliente(@AuthenticationPrincipal User loggedUser,
+                                                @PathVariable("idCliente") Integer idCliente) {
         clienteService.inativarCliente(loggedUser, idCliente);
+        return noContent();
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @PutMapping("/{idCliente}/restaurar")
     @Operation(summary = "Restaurar cliente", description = "Reativa um cliente inativo")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Cliente restaurarCliente(@AuthenticationPrincipal User loggedUser,
-                                    @PathVariable("idCliente") Integer idCliente) {
-        return clienteService.reativarCliente(loggedUser, idCliente);
+    public ResponseEntity<Cliente> restaurarCliente(@AuthenticationPrincipal User loggedUser,
+                                                    @PathVariable("idCliente") Integer idCliente) {
+        return ok(clienteService.reativarCliente(loggedUser, idCliente));
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping("/{idCliente}/permanente")
     @Operation(summary = "Remover cliente permanentemente", description = "Exclui definitivamente um cliente")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public void removerCliente(@AuthenticationPrincipal User loggedUser,
-                               @PathVariable("idCliente") Integer idCliente) {
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+    public ResponseEntity<Void> removerCliente(@AuthenticationPrincipal User loggedUser,
+                                               @PathVariable("idCliente") Integer idCliente) {
         clienteService.removerCliente(loggedUser, idCliente);
+        return noContent();
     }
 
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteEnderecoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteEnderecoController.java
@@ -5,6 +5,7 @@ import com.AIT.Optimanage.Models.Cliente.ClienteEndereco;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.Cliente.ClienteEnderecoService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
@@ -25,37 +26,38 @@ public class ClienteEnderecoController extends V1BaseController {
     @GetMapping("/{idCliente}/enderecos")
     @Operation(summary = "Listar endereços", description = "Lista endereços de um cliente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public List<ClienteEndereco> listarEnderecos(@AuthenticationPrincipal User loggedUser,
-                                                   @PathVariable("idCliente") Integer idCliente) {
-          return clienteEnderecoService.listarEnderecos(loggedUser, idCliente);
+      public ResponseEntity<List<ClienteEndereco>> listarEnderecos(@AuthenticationPrincipal User loggedUser,
+                                                                   @PathVariable("idCliente") Integer idCliente) {
+          return ok(clienteEnderecoService.listarEnderecos(loggedUser, idCliente));
       }
 
     @PostMapping("/{idCliente}/enderecos")
     @Operation(summary = "Cadastrar endereço", description = "Adiciona endereço a um cliente")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-      public ClienteEndereco cadastrarEndereco(@AuthenticationPrincipal User loggedUser,
+    @ApiResponse(responseCode = "201", description = "Criado")
+      public ResponseEntity<ClienteEndereco> cadastrarEndereco(@AuthenticationPrincipal User loggedUser,
                                               @PathVariable("idCliente") Integer idCliente,
                                               @RequestBody @Valid ClienteEndereco endereco) {
-          return clienteEnderecoService.cadastrarEndereco(loggedUser, idCliente, endereco);
+          return created(clienteEnderecoService.cadastrarEndereco(loggedUser, idCliente, endereco));
       }
 
     @PutMapping("/{idCliente}/enderecos/{idEndereco}")
     @Operation(summary = "Editar endereço", description = "Atualiza endereço de um cliente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public ClienteEndereco editarEndereco(@AuthenticationPrincipal User loggedUser,
-                                           @PathVariable("idCliente") Integer idCliente,
-                                           @PathVariable("idEndereco") Integer idEndereco,
-                                           @RequestBody @Valid ClienteEndereco endereco) {
-          return clienteEnderecoService.editarEndereco(loggedUser, idCliente, idEndereco, endereco);
+      public ResponseEntity<ClienteEndereco> editarEndereco(@AuthenticationPrincipal User loggedUser,
+                                                           @PathVariable("idCliente") Integer idCliente,
+                                                           @PathVariable("idEndereco") Integer idEndereco,
+                                                           @RequestBody @Valid ClienteEndereco endereco) {
+          return ok(clienteEnderecoService.editarEndereco(loggedUser, idCliente, idEndereco, endereco));
       }
 
     @DeleteMapping("/{idCliente}/enderecos/{idEndereco}")
     @Operation(summary = "Excluir endereço", description = "Remove endereço de um cliente")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-      public void excluirEndereco(@AuthenticationPrincipal User loggedUser,
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+      public ResponseEntity<Void> excluirEndereco(@AuthenticationPrincipal User loggedUser,
                                   @PathVariable("idCliente") Integer idCliente,
                                   @PathVariable("idEndereco") Integer idEndereco) {
           clienteEnderecoService.excluirEndereco(loggedUser, idCliente, idEndereco);
+          return noContent();
       }
 
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/Compra/CompraController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Compra/CompraController.java
@@ -11,6 +11,7 @@ import com.AIT.Optimanage.Models.Enums.FormaPagamento;
 import com.AIT.Optimanage.Services.Compra.CompraService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
@@ -31,7 +32,7 @@ public class CompraController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar compras", description = "Retorna uma página de compras")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Page<Compra> listarCompras(@AuthenticationPrincipal User loggedUser,
+    public ResponseEntity<Page<Compra>> listarCompras(@AuthenticationPrincipal User loggedUser,
                                       @RequestParam(value = "id", required = false) Integer id,
                                       @RequestParam(value = "fornecedor_id", required = false) Integer fornecedorId,
                                       @RequestParam(value = "data_inicial", required = false) String data_inicial,
@@ -56,90 +57,90 @@ public class CompraController extends V1BaseController {
                 .sort(sort)
                 .order(order)
                 .build();
-        return compraService.listarCompras(loggedUser, pesquisa);
+        return ok(compraService.listarCompras(loggedUser, pesquisa));
     }
 
     @GetMapping("/{idCompra}")
     @Operation(summary = "Listar compra", description = "Retorna uma compra pelo ID")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public Compra listarUmaCompra(@AuthenticationPrincipal User loggedUser,
-                                    @PathVariable("idCompra") Integer idCompra) {
-          return compraService.listarUmaCompra(loggedUser, idCompra);
+      public ResponseEntity<Compra> listarUmaCompra(@AuthenticationPrincipal User loggedUser,
+                                                    @PathVariable("idCompra") Integer idCompra) {
+          return ok(compraService.listarUmaCompra(loggedUser, idCompra));
       }
 
     @PostMapping
     @Operation(summary = "Criar compra", description = "Cria uma nova compra")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-      public Compra criarCompra(@AuthenticationPrincipal User loggedUser,
+    @ApiResponse(responseCode = "201", description = "Criado")
+      public ResponseEntity<Compra> criarCompra(@AuthenticationPrincipal User loggedUser,
                                @RequestBody @Valid CompraDTO compra) {
-          return compraService.criarCompra(loggedUser, compra);
+          return created(compraService.criarCompra(loggedUser, compra));
       }
 
     @PutMapping("/{idCompra}")
     @Operation(summary = "Editar compra", description = "Atualiza uma compra existente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public Compra editarCompra(@AuthenticationPrincipal User loggedUser,
-                                 @PathVariable("idCompra") Integer idCompra,
-                                 @RequestBody @Valid CompraDTO compra) {
-          return compraService.editarCompra(loggedUser, idCompra, compra);
+      public ResponseEntity<Compra> editarCompra(@AuthenticationPrincipal User loggedUser,
+                                                 @PathVariable("idCompra") Integer idCompra,
+                                                 @RequestBody @Valid CompraDTO compra) {
+          return ok(compraService.editarCompra(loggedUser, idCompra, compra));
       }
 
     @PutMapping("/{idCompra}/confirmar")
     @Operation(summary = "Confirmar compra", description = "Confirma uma compra")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public Compra confirmarCompra(@AuthenticationPrincipal User loggedUser,
-                                   @PathVariable("idCompra") Integer idCompra) {
-          return compraService.confirmarCompra(loggedUser, idCompra);
+      public ResponseEntity<Compra> confirmarCompra(@AuthenticationPrincipal User loggedUser,
+                                                   @PathVariable("idCompra") Integer idCompra) {
+          return ok(compraService.confirmarCompra(loggedUser, idCompra));
       }
 
     @PutMapping("/{idCompra}/pagar/{idPagamento}")
     @Operation(summary = "Pagar compra", description = "Realiza pagamento de uma compra")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public Compra pagarCompra(@AuthenticationPrincipal User loggedUser,
-                                @PathVariable("idCompra") Integer idCompra,
-                                @PathVariable("idPagamento") Integer idPagamento) {
-          return compraService.pagarCompra(loggedUser, idCompra, idPagamento);
+      public ResponseEntity<Compra> pagarCompra(@AuthenticationPrincipal User loggedUser,
+                                                @PathVariable("idCompra") Integer idCompra,
+                                                @PathVariable("idPagamento") Integer idPagamento) {
+          return ok(compraService.pagarCompra(loggedUser, idCompra, idPagamento));
       }
 
     @PutMapping("/{idCompra}/lancar-pagamento")
     @Operation(summary = "Lançar pagamento", description = "Registra pagamento de uma compra")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public Compra lancarPagamentoCompra(@AuthenticationPrincipal User loggedUser,
-                                          @PathVariable("idCompra") Integer idCompra,
-                                          @RequestBody List<@Valid PagamentoDTO> pagamentoDTO) {
-          return compraService.lancarPagamentoCompra(loggedUser, idCompra, pagamentoDTO);
+      public ResponseEntity<Compra> lancarPagamentoCompra(@AuthenticationPrincipal User loggedUser,
+                                                          @PathVariable("idCompra") Integer idCompra,
+                                                          @RequestBody List<@Valid PagamentoDTO> pagamentoDTO) {
+          return ok(compraService.lancarPagamentoCompra(loggedUser, idCompra, pagamentoDTO));
       }
 
     @PutMapping("/{idCompra}/estornar")
     @Operation(summary = "Estornar compra", description = "Estorna uma compra integralmente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public Compra estornarCompraIntegral(@AuthenticationPrincipal User loggedUser,
-                                           @PathVariable("idCompra") Integer idCompra) {
-          return compraService.estornarCompraIntegral(loggedUser, idCompra);
+      public ResponseEntity<Compra> estornarCompraIntegral(@AuthenticationPrincipal User loggedUser,
+                                                           @PathVariable("idCompra") Integer idCompra) {
+          return ok(compraService.estornarCompraIntegral(loggedUser, idCompra));
       }
 
     @PutMapping("/{idCompra}/estornar/{idPagamento}")
     @Operation(summary = "Estornar pagamento", description = "Estorna pagamento de uma compra")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public Compra estornarPagamentoCompra(@AuthenticationPrincipal User loggedUser,
-                                            @PathVariable("idCompra") Integer idCompra,
-                                            @PathVariable("idPagamento") Integer idPagamento) {
-          return compraService.estornarPagamentoCompra(loggedUser, idCompra, idPagamento);
+      public ResponseEntity<Compra> estornarPagamentoCompra(@AuthenticationPrincipal User loggedUser,
+                                                            @PathVariable("idCompra") Integer idCompra,
+                                                            @PathVariable("idPagamento") Integer idPagamento) {
+          return ok(compraService.estornarPagamentoCompra(loggedUser, idCompra, idPagamento));
       }
 
     @PutMapping("/{idCompra}/finalizar")
     @Operation(summary = "Finalizar compra", description = "Finaliza uma compra")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public Compra finalizarCompra(@AuthenticationPrincipal User loggedUser,
-                                   @PathVariable("idCompra") Integer idCompra) {
-          return compraService.finalizarCompra(loggedUser, idCompra);
+      public ResponseEntity<Compra> finalizarCompra(@AuthenticationPrincipal User loggedUser,
+                                                   @PathVariable("idCompra") Integer idCompra) {
+          return ok(compraService.finalizarCompra(loggedUser, idCompra));
       }
 
     @PutMapping("/{idCompra}/cancelar")
     @Operation(summary = "Cancelar compra", description = "Cancela uma compra")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public Compra cancelarCompra(@AuthenticationPrincipal User loggedUser,
-                                   @PathVariable("idCompra") Integer idCompra) {
-          return compraService.cancelarCompra(loggedUser, idCompra);
+      public ResponseEntity<Compra> cancelarCompra(@AuthenticationPrincipal User loggedUser,
+                                                   @PathVariable("idCompra") Integer idCompra) {
+          return ok(compraService.cancelarCompra(loggedUser, idCompra));
       }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorContatoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorContatoController.java
@@ -5,6 +5,7 @@ import com.AIT.Optimanage.Models.Fornecedor.FornecedorContato;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.Fornecedor.FornecedorContatoService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
@@ -25,36 +26,37 @@ public class FornecedorContatoController extends V1BaseController {
     @GetMapping("/{idFornecedor}/contatos")
     @Operation(summary = "Listar contatos", description = "Lista contatos de um fornecedor")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public List<FornecedorContato> listarContatos(@AuthenticationPrincipal User loggedUser,
+      public ResponseEntity<List<FornecedorContato>> listarContatos(@AuthenticationPrincipal User loggedUser,
                                                     @PathVariable("idFornecedor") Integer idFornecedor) {
-          return fornecedorContatoService.listarContatos(loggedUser, idFornecedor);
+          return ok(fornecedorContatoService.listarContatos(loggedUser, idFornecedor));
       }
 
     @PostMapping("/{idFornecedor}/contatos")
     @Operation(summary = "Cadastrar contato", description = "Adiciona contato a um fornecedor")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-      public FornecedorContato cadastrarContato(@AuthenticationPrincipal User loggedUser,
+    @ApiResponse(responseCode = "201", description = "Criado")
+      public ResponseEntity<FornecedorContato> cadastrarContato(@AuthenticationPrincipal User loggedUser,
                                                @PathVariable("idFornecedor") Integer idFornecedor,
                                                @RequestBody @Valid FornecedorContato contato) {
-          return fornecedorContatoService.cadastrarContato(loggedUser, idFornecedor, contato);
+          return created(fornecedorContatoService.cadastrarContato(loggedUser, idFornecedor, contato));
       }
 
     @PutMapping("/{idFornecedor}/contatos/{idContato}")
     @Operation(summary = "Editar contato", description = "Atualiza contato de um fornecedor")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public FornecedorContato editarContato(@AuthenticationPrincipal User loggedUser,
-                                             @PathVariable("idFornecedor") Integer idFornecedor,
-                                             @PathVariable("idContato") Integer idContato,
-                                             @RequestBody @Valid FornecedorContato contato) {
-          return fornecedorContatoService.editarContato(loggedUser, idFornecedor, idContato, contato);
+      public ResponseEntity<FornecedorContato> editarContato(@AuthenticationPrincipal User loggedUser,
+                                                             @PathVariable("idFornecedor") Integer idFornecedor,
+                                                             @PathVariable("idContato") Integer idContato,
+                                                             @RequestBody @Valid FornecedorContato contato) {
+          return ok(fornecedorContatoService.editarContato(loggedUser, idFornecedor, idContato, contato));
       }
 
     @DeleteMapping("/{idFornecedor}/contatos/{idContato}")
     @Operation(summary = "Excluir contato", description = "Remove contato de um fornecedor")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-      public void excluirContato(@AuthenticationPrincipal User loggedUser,
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+      public ResponseEntity<Void> excluirContato(@AuthenticationPrincipal User loggedUser,
                                  @PathVariable("idFornecedor") Integer idFornecedor,
                                  @PathVariable("idContato") Integer idContato) {
           fornecedorContatoService.excluirContato(loggedUser, idFornecedor, idContato);
+          return noContent();
       }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorController.java
@@ -9,6 +9,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.Fornecedor.FornecedorService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -30,7 +31,7 @@ public class FornecedorController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar fornecedores", description = "Retorna uma página de fornecedores")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Page<Fornecedor> listarFornecedores(@AuthenticationPrincipal User loggedUser,
+    public ResponseEntity<Page<Fornecedor>> listarFornecedores(@AuthenticationPrincipal User loggedUser,
                                               @RequestParam(value = "id", required = false) Integer id,
                                                @RequestParam(value = "nome", required = false) String nome,
                                                @RequestParam(value = "cpfOuCnpj", required = false) String cpfOuCnpj,
@@ -55,57 +56,59 @@ public class FornecedorController extends V1BaseController {
                 .sort(sort)
                 .order(order)
                 .build();
-        return fornecedorService.listarFornecedores(loggedUser, pesquisa);
+        return ok(fornecedorService.listarFornecedores(loggedUser, pesquisa));
     }
 
     @GetMapping("/{idFornecedor}")
     @Operation(summary = "Listar fornecedor", description = "Retorna um fornecedor pelo ID")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Fornecedor listarUmFornecedor(@AuthenticationPrincipal User loggedUser,
-                                         @PathVariable("idFornecedor") Integer idFornecedor) {
-        return fornecedorService.listarUmFornecedor(loggedUser, idFornecedor);
+    public ResponseEntity<Fornecedor> listarUmFornecedor(@AuthenticationPrincipal User loggedUser,
+                                                         @PathVariable("idFornecedor") Integer idFornecedor) {
+        return ok(fornecedorService.listarUmFornecedor(loggedUser, idFornecedor));
     }
 
     @PostMapping
     @Operation(summary = "Criar fornecedor", description = "Cria um novo fornecedor")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Fornecedor criarFornecedor(@AuthenticationPrincipal User loggedUser,
-                                     @RequestBody @Valid FornecedorRequest request) {
-        return fornecedorService.criarFornecedor(loggedUser, request);
+    @ApiResponse(responseCode = "201", description = "Criado")
+    public ResponseEntity<Fornecedor> criarFornecedor(@AuthenticationPrincipal User loggedUser,
+                                                     @RequestBody @Valid FornecedorRequest request) {
+        return created(fornecedorService.criarFornecedor(loggedUser, request));
     }
 
     @PutMapping("/{idFornecedor}")
     @Operation(summary = "Editar fornecedor", description = "Atualiza um fornecedor existente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Fornecedor editarFornecedor(@AuthenticationPrincipal User loggedUser,
-                                       @PathVariable("idFornecedor") Integer idFornecedor,
-                                       @RequestBody @Valid FornecedorRequest request) {
-        return fornecedorService.editarFornecedor(loggedUser, idFornecedor, request);
+    public ResponseEntity<Fornecedor> editarFornecedor(@AuthenticationPrincipal User loggedUser,
+                                                       @PathVariable("idFornecedor") Integer idFornecedor,
+                                                       @RequestBody @Valid FornecedorRequest request) {
+        return ok(fornecedorService.editarFornecedor(loggedUser, idFornecedor, request));
     }
 
     @DeleteMapping("/{idFornecedor}")
     @Operation(summary = "Inativar fornecedor", description = "Inativa um fornecedor pelo ID")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public void inativarFornecedor(@AuthenticationPrincipal User loggedUser,
-                                   @PathVariable("idFornecedor") Integer idFornecedor) {
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+    public ResponseEntity<Void> inativarFornecedor(@AuthenticationPrincipal User loggedUser,
+                                                   @PathVariable("idFornecedor") Integer idFornecedor) {
         fornecedorService.inativarFornecedor(loggedUser, idFornecedor);
+        return noContent();
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @PutMapping("/{idFornecedor}/restaurar")
     @Operation(summary = "Restaurar fornecedor", description = "Reativa um fornecedor inativo")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Fornecedor restaurarFornecedor(@AuthenticationPrincipal User loggedUser,
-                                          @PathVariable("idFornecedor") Integer idFornecedor) {
-        return fornecedorService.reativarFornecedor(loggedUser, idFornecedor);
+    public ResponseEntity<Fornecedor> restaurarFornecedor(@AuthenticationPrincipal User loggedUser,
+                                                          @PathVariable("idFornecedor") Integer idFornecedor) {
+        return ok(fornecedorService.reativarFornecedor(loggedUser, idFornecedor));
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping("/{idFornecedor}/permanente")
     @Operation(summary = "Remover fornecedor permanentemente", description = "Exclui definitivamente um fornecedor")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public void removerFornecedor(@AuthenticationPrincipal User loggedUser,
-                                  @PathVariable("idFornecedor") Integer idFornecedor) {
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+    public ResponseEntity<Void> removerFornecedor(@AuthenticationPrincipal User loggedUser,
+                                                  @PathVariable("idFornecedor") Integer idFornecedor) {
         fornecedorService.removerFornecedor(loggedUser, idFornecedor);
+        return noContent();
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorEnderecoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorEnderecoController.java
@@ -5,6 +5,7 @@ import com.AIT.Optimanage.Models.Fornecedor.FornecedorEndereco;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.Fornecedor.FornecedorEnderecoService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
@@ -25,37 +26,38 @@ public class FornecedorEnderecoController extends V1BaseController {
     @GetMapping("/{idFornecedor}/enderecos")
     @Operation(summary = "Listar endereços", description = "Lista endereços de um fornecedor")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public List<FornecedorEndereco> listarEnderecos(@AuthenticationPrincipal User loggedUser,
+      public ResponseEntity<List<FornecedorEndereco>> listarEnderecos(@AuthenticationPrincipal User loggedUser,
                                                       @PathVariable("idFornecedor") Integer idFornecedor) {
-          return fornecedorEnderecoService.listarEnderecos(loggedUser, idFornecedor);
+          return ok(fornecedorEnderecoService.listarEnderecos(loggedUser, idFornecedor));
       }
 
     @PostMapping("/{idFornecedor}/enderecos")
     @Operation(summary = "Cadastrar endereço", description = "Adiciona endereço a um fornecedor")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-      public FornecedorEndereco cadastrarEndereco(@AuthenticationPrincipal User loggedUser,
+    @ApiResponse(responseCode = "201", description = "Criado")
+      public ResponseEntity<FornecedorEndereco> cadastrarEndereco(@AuthenticationPrincipal User loggedUser,
                                                  @PathVariable("idFornecedor") Integer idFornecedor,
                                                  @RequestBody @Valid FornecedorEndereco endereco) {
-          return fornecedorEnderecoService.cadastrarEndereco(loggedUser, idFornecedor, endereco);
+          return created(fornecedorEnderecoService.cadastrarEndereco(loggedUser, idFornecedor, endereco));
       }
 
     @PutMapping("/{idFornecedor}/enderecos/{idEndereco}")
     @Operation(summary = "Editar endereço", description = "Atualiza endereço de um fornecedor")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public FornecedorEndereco editarEndereco(@AuthenticationPrincipal User loggedUser,
+      public ResponseEntity<FornecedorEndereco> editarEndereco(@AuthenticationPrincipal User loggedUser,
                                                @PathVariable("idFornecedor") Integer idFornecedor,
                                                @PathVariable("idEndereco") Integer idEndereco,
                                                @RequestBody @Valid FornecedorEndereco endereco) {
-          return fornecedorEnderecoService.editarEndereco(loggedUser, idFornecedor, idEndereco, endereco);
+          return ok(fornecedorEnderecoService.editarEndereco(loggedUser, idFornecedor, idEndereco, endereco));
       }
 
     @DeleteMapping("/{idFornecedor}/enderecos/{idEndereco}")
     @Operation(summary = "Excluir endereço", description = "Remove endereço de um fornecedor")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-      public void excluirEndereco(@AuthenticationPrincipal User loggedUser,
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+      public ResponseEntity<Void> excluirEndereco(@AuthenticationPrincipal User loggedUser,
                                   @PathVariable("idFornecedor") Integer idFornecedor,
                                   @PathVariable("idEndereco") Integer idEndereco) {
           fornecedorEnderecoService.excluirEndereco(loggedUser, idFornecedor, idEndereco);
+          return noContent();
       }
 
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/PlanoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/PlanoController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,33 +27,34 @@ public class PlanoController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar planos", description = "Retorna uma lista de planos")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public List<PlanoResponse> listarPlanos() {
-        return planoService.listarPlanos();
+    public ResponseEntity<List<PlanoResponse>> listarPlanos() {
+        return ok(planoService.listarPlanos());
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @PostMapping
     @Operation(summary = "Cadastrar plano", description = "Cria um novo plano")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public PlanoResponse criarPlano(@RequestBody @Valid PlanoRequest request) {
-        return planoService.criarPlano(request);
+    @ApiResponse(responseCode = "201", description = "Criado")
+    public ResponseEntity<PlanoResponse> criarPlano(@RequestBody @Valid PlanoRequest request) {
+        return created(planoService.criarPlano(request));
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @PutMapping("/{idPlano}")
     @Operation(summary = "Atualizar plano", description = "Atualiza um plano existente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public PlanoResponse atualizarPlano(@PathVariable Integer idPlano,
-                                        @RequestBody @Valid PlanoRequest request) {
-        return planoService.atualizarPlano(idPlano, request);
+    public ResponseEntity<PlanoResponse> atualizarPlano(@PathVariable Integer idPlano,
+                                                        @RequestBody @Valid PlanoRequest request) {
+        return ok(planoService.atualizarPlano(idPlano, request));
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping("/{idPlano}")
     @Operation(summary = "Remover plano", description = "Remove um plano")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public void removerPlano(@PathVariable Integer idPlano) {
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+    public ResponseEntity<Void> removerPlano(@PathVariable Integer idPlano) {
         planoService.removerPlano(idPlano);
+        return noContent();
     }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Controllers/ProdutoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/ProdutoController.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -28,64 +29,66 @@ public class ProdutoController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar produtos", description = "Retorna uma lista de produtos")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Page<ProdutoResponse> listarProdutos(@AuthenticationPrincipal User loggedUser,
-                                                @RequestParam(value = "page") Integer page,
-                                                @RequestParam(value = "pageSize") Integer pageSize,
-                                                @RequestParam(value = "sort", required = false) String sort,
-                                                @RequestParam(value = "order", required = false) Sort.Direction order) {
+    public ResponseEntity<Page<ProdutoResponse>> listarProdutos(@AuthenticationPrincipal User loggedUser,
+                                                                @RequestParam(value = "page") Integer page,
+                                                                @RequestParam(value = "pageSize") Integer pageSize,
+                                                                @RequestParam(value = "sort", required = false) String sort,
+                                                                @RequestParam(value = "order", required = false) Sort.Direction order) {
         var pesquisa = Search.builder()
                 .page(page)
                 .pageSize(pageSize)
                 .sort(sort)
                 .order(order)
                 .build();
-        return produtoService.listarProdutos(loggedUser, pesquisa);
+        return ok(produtoService.listarProdutos(loggedUser, pesquisa));
     }
 
     @GetMapping("/{idProduto}")
     @Operation(summary = "Listar produto", description = "Retorna um produto pelo ID")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ProdutoResponse listarUmProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
-        return produtoService.listarUmProduto(loggedUser, idProduto);
+    public ResponseEntity<ProdutoResponse> listarUmProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
+        return ok(produtoService.listarUmProduto(loggedUser, idProduto));
     }
 
     @PostMapping
     @Operation(summary = "Cadastrar produto", description = "Cria um novo produto")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ProdutoResponse cadastrarProduto(@AuthenticationPrincipal User loggedUser,
-                                            @RequestBody @Valid ProdutoRequest request) {
-        return produtoService.cadastrarProduto(loggedUser, request);
+    @ApiResponse(responseCode = "201", description = "Criado")
+    public ResponseEntity<ProdutoResponse> cadastrarProduto(@AuthenticationPrincipal User loggedUser,
+                                                            @RequestBody @Valid ProdutoRequest request) {
+        return created(produtoService.cadastrarProduto(loggedUser, request));
     }
 
     @PutMapping("/{idProduto}")
     @Operation(summary = "Editar produto", description = "Atualiza um produto existente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ProdutoResponse editarProduto(@AuthenticationPrincipal User loggedUser,
-                                         @PathVariable Integer idProduto,
-                                         @RequestBody @Valid ProdutoRequest request) {
-        return produtoService.editarProduto(loggedUser, idProduto, request);
+    public ResponseEntity<ProdutoResponse> editarProduto(@AuthenticationPrincipal User loggedUser,
+                                                         @PathVariable Integer idProduto,
+                                                         @RequestBody @Valid ProdutoRequest request) {
+        return ok(produtoService.editarProduto(loggedUser, idProduto, request));
     }
 
     @DeleteMapping("/{idProduto}")
     @Operation(summary = "Excluir produto", description = "Remove um produto")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public void excluirProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+    public ResponseEntity<Void> excluirProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
         produtoService.excluirProduto(loggedUser, idProduto);
+        return noContent();
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @PutMapping("/{idProduto}/restaurar")
     @Operation(summary = "Restaurar produto", description = "Restaura um produto inativo")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ProdutoResponse restaurarProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
-        return produtoService.restaurarProduto(loggedUser, idProduto);
+    public ResponseEntity<ProdutoResponse> restaurarProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
+        return ok(produtoService.restaurarProduto(loggedUser, idProduto));
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping("/{idProduto}/permanente")
     @Operation(summary = "Remover produto permanentemente", description = "Exclui definitivamente um produto")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public void removerProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+    public ResponseEntity<Void> removerProduto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idProduto) {
         produtoService.removerProduto(loggedUser, idProduto);
+        return noContent();
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/ServicoController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/ServicoController.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -28,65 +29,67 @@ public class ServicoController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar serviços", description = "Retorna uma lista de serviços")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Page<ServicoResponse> listarServicos(@AuthenticationPrincipal User loggedUser,
-                                                @RequestParam(value = "page") Integer page,
-                                                @RequestParam(value = "pageSize") Integer pageSize,
-                                                @RequestParam(value = "sort", required = false) String sort,
-                                                @RequestParam(value = "order", required = false) Sort.Direction order) {
+    public ResponseEntity<Page<ServicoResponse>> listarServicos(@AuthenticationPrincipal User loggedUser,
+                                                                @RequestParam(value = "page") Integer page,
+                                                                @RequestParam(value = "pageSize") Integer pageSize,
+                                                                @RequestParam(value = "sort", required = false) String sort,
+                                                                @RequestParam(value = "order", required = false) Sort.Direction order) {
         var pesquisa = Search.builder()
                 .page(page)
                 .pageSize(pageSize)
                 .sort(sort)
                 .order(order)
                 .build();
-        return servicoService.listarServicos(loggedUser, pesquisa);
+        return ok(servicoService.listarServicos(loggedUser, pesquisa));
     }
 
     @GetMapping("/{idServico}")
     @Operation(summary = "Listar serviço", description = "Retorna um serviço pelo ID")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ServicoResponse listarUmServico(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idServico) {
-        return servicoService.listarUmServico(loggedUser, idServico);
+    public ResponseEntity<ServicoResponse> listarUmServico(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idServico) {
+        return ok(servicoService.listarUmServico(loggedUser, idServico));
     }
 
     @PostMapping
     @Operation(summary = "Cadastrar serviço", description = "Cria um novo serviço")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ServicoResponse cadastrarServico(@AuthenticationPrincipal User loggedUser,
-                                    @RequestBody @Valid ServicoRequest request) {
-        return servicoService.cadastrarServico(loggedUser, request);
+    @ApiResponse(responseCode = "201", description = "Criado")
+    public ResponseEntity<ServicoResponse> cadastrarServico(@AuthenticationPrincipal User loggedUser,
+                                                            @RequestBody @Valid ServicoRequest request) {
+        return created(servicoService.cadastrarServico(loggedUser, request));
     }
 
     @PutMapping("/{idServico}")
     @Operation(summary = "Editar serviço", description = "Atualiza um serviço existente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ServicoResponse editarServico(@AuthenticationPrincipal User loggedUser,
-                                 @PathVariable Integer idServico,
-                                 @RequestBody @Valid ServicoRequest request) {
-        return servicoService.editarServico(loggedUser, idServico, request);
+    public ResponseEntity<ServicoResponse> editarServico(@AuthenticationPrincipal User loggedUser,
+                                                         @PathVariable Integer idServico,
+                                                         @RequestBody @Valid ServicoRequest request) {
+        return ok(servicoService.editarServico(loggedUser, idServico, request));
     }
 
     @DeleteMapping("/{idServico}")
     @Operation(summary = "Excluir serviço", description = "Remove um serviço")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public void excluirServico(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idServico) {
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+    public ResponseEntity<Void> excluirServico(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idServico) {
         servicoService.excluirServico(loggedUser, idServico);
+        return noContent();
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @PutMapping("/{idServico}/restaurar")
     @Operation(summary = "Restaurar serviço", description = "Restaura um serviço inativo")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ServicoResponse restaurarServico(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idServico) {
-        return servicoService.restaurarServico(loggedUser, idServico);
+    public ResponseEntity<ServicoResponse> restaurarServico(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idServico) {
+        return ok(servicoService.restaurarServico(loggedUser, idServico));
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping("/{idServico}/permanente")
     @Operation(summary = "Remover serviço permanentemente", description = "Exclui definitivamente um serviço")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public void removerServico(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idServico) {
+    @ApiResponse(responseCode = "204", description = "Sem conteúdo")
+    public ResponseEntity<Void> removerServico(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idServico) {
         servicoService.removerServico(loggedUser, idServico);
+        return noContent();
     }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Controllers/User/UsuarioController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/User/UsuarioController.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -28,7 +27,7 @@ public class UsuarioController extends V1BaseController {
     @PostMapping
     public ResponseEntity<UserResponse> criarUsuario(@RequestBody @Valid UserRequest request) {
         UserResponse novoUsuario = usuarioService.salvarUsuario(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(novoUsuario);
+        return created(novoUsuario);
     }
 
     @GetMapping
@@ -41,26 +40,26 @@ public class UsuarioController extends V1BaseController {
         String sortBy = sort != null ? sort : "id";
         Pageable pageable = PageRequest.of(page, pagesize, Sort.by(direction, sortBy));
         Page<UserResponse> usuarios = usuarioService.listarUsuarios(pageable);
-        return ResponseEntity.ok(usuarios);
+        return ok(usuarios);
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<UserResponse> buscarUsuario(@PathVariable Integer id) {
         UserResponse usuario = usuarioService.buscarUsuario(id);
-        return ResponseEntity.ok(usuario);
+        return ok(usuario);
     }
 
     @PutMapping("/{id}/plano")
     public ResponseEntity<UserResponse> atualizarPlanoAtivo(@PathVariable Integer id,
                                                             @RequestParam Integer novoPlanoId) {
         UserResponse usuarioAtualizado = usuarioService.atualizarPlanoAtivo(id, novoPlanoId);
-        return ResponseEntity.ok(usuarioAtualizado);
+        return ok(usuarioAtualizado);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> desativarUsuario(@PathVariable Integer id) {
         usuarioService.desativarUsuario(id);
-        return ResponseEntity.noContent().build();
+        return noContent();
     }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Controllers/Venda/CompatibilidadeController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Venda/CompatibilidadeController.java
@@ -6,7 +6,6 @@ import com.AIT.Optimanage.Models.Venda.Compatibilidade.CompatibilidadeDTO;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.Venda.CompatibilidadeService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -29,7 +28,7 @@ public class CompatibilidadeController extends V1BaseController {
     @ApiResponse(responseCode = "200", description = "Sucesso")
     public ResponseEntity<List<Compatibilidade>> getCompatibilidades(@AuthenticationPrincipal User loggedUser, @PathVariable String contexto) {
         List<Compatibilidade> compatibilidades = compatibilidadeService.buscarCompatibilidades(loggedUser, contexto);
-        return ResponseEntity.ok(compatibilidades);
+        return ok(compatibilidades);
     }
 
     @PostMapping
@@ -37,6 +36,6 @@ public class CompatibilidadeController extends V1BaseController {
     @ApiResponse(responseCode = "201", description = "Criado")
     public ResponseEntity<Compatibilidade> adicionarCompatibilidade(@AuthenticationPrincipal User loggedUser, @RequestBody CompatibilidadeDTO request) {
         Compatibilidade compatibilidade = compatibilidadeService.adicionarCompatibilidade(loggedUser, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(compatibilidade);
+        return created(compatibilidade);
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/Venda/ContextoCompatibilidadeController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Venda/ContextoCompatibilidadeController.java
@@ -6,7 +6,6 @@ import com.AIT.Optimanage.Models.Venda.Compatibilidade.ContextoCompatibilidadeDT
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Services.Venda.ContextoCompatibilidadeService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -27,14 +26,14 @@ public class ContextoCompatibilidadeController extends V1BaseController {
     @Operation(summary = "Listar contextos", description = "Retorna os contextos de compatibilidade")
     @ApiResponse(responseCode = "200", description = "Sucesso")
     public ResponseEntity<ContextoCompatibilidade> listarContextos(@AuthenticationPrincipal User loggedUser) {
-        return ResponseEntity.ok(contextoService.listarContextos(loggedUser));
+        return ok(contextoService.listarContextos(loggedUser));
     }
 
     @GetMapping("/{idContexto}")
     @Operation(summary = "Listar contexto", description = "Retorna um contexto pelo ID")
     @ApiResponse(responseCode = "200", description = "Sucesso")
     public ResponseEntity<ContextoCompatibilidade> listarUmContexto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idContexto) {
-        return ResponseEntity.ok(contextoService.listarUmContexto(loggedUser, idContexto));
+        return ok(contextoService.listarUmContexto(loggedUser, idContexto));
     }
 
     @PostMapping
@@ -42,7 +41,7 @@ public class ContextoCompatibilidadeController extends V1BaseController {
     @ApiResponse(responseCode = "201", description = "Criado")
     public ResponseEntity<ContextoCompatibilidade> criarContexto(@AuthenticationPrincipal User loggedUser, @RequestBody ContextoCompatibilidadeDTO request) {
         ContextoCompatibilidade contexto = contextoService.criarContexto(loggedUser, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(contexto);
+        return created(contexto);
     }
 
     @PutMapping("/{idContexto}")
@@ -50,7 +49,7 @@ public class ContextoCompatibilidadeController extends V1BaseController {
     @ApiResponse(responseCode = "200", description = "Sucesso")
     public ResponseEntity<ContextoCompatibilidade> editarContexto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idContexto, @RequestBody ContextoCompatibilidadeDTO request) {
         ContextoCompatibilidade contexto = contextoService.editarContexto(loggedUser, idContexto, request);
-        return ResponseEntity.ok(contexto);
+        return ok(contexto);
     }
 
     @DeleteMapping("/{idContexto}")
@@ -58,6 +57,6 @@ public class ContextoCompatibilidadeController extends V1BaseController {
     @ApiResponse(responseCode = "204", description = "Sem conteúdo")
     public ResponseEntity<Void> excluirContexto(@AuthenticationPrincipal User loggedUser, @PathVariable Integer idContexto) {
         contextoService.excluirContexto(loggedUser, idContexto);
-        return ResponseEntity.noContent().build();
+        return noContent();
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/Venda/VendaController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Venda/VendaController.java
@@ -11,6 +11,7 @@ import com.AIT.Optimanage.Models.Venda.Venda;
 import com.AIT.Optimanage.Services.Venda.VendaService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
@@ -31,18 +32,18 @@ public class VendaController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar vendas", description = "Retorna uma página de vendas")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Page<Venda> listarVendas(@AuthenticationPrincipal User loggedUser,
-                                    @RequestParam(value = "id", required = false) Integer id,
-                                    @RequestParam(value = "cliente_id", required = false) Integer clienteId,
-                                    @RequestParam(value = "data_inicial", required = false) String data_inicial,
-                                    @RequestParam(value = "data_final", required = false) String data_final,
-                                    @RequestParam(value = "pago", required = false) Boolean pago,
-                                    @RequestParam(value = "status", required = false) StatusVenda status,
-                                    @RequestParam(value = "forma_pagamento", required = false) FormaPagamento forma_pagamento,
-                                    @RequestParam(value = "sort", required = false) String sort,
-                                    @RequestParam(value = "order", required = false) Sort.Direction order,
-                                    @RequestParam(value = "page", required = true) Integer page,
-                                    @RequestParam(value = "pagesize", required = true) Integer pagesize) {
+    public ResponseEntity<Page<Venda>> listarVendas(@AuthenticationPrincipal User loggedUser,
+                                                    @RequestParam(value = "id", required = false) Integer id,
+                                                    @RequestParam(value = "cliente_id", required = false) Integer clienteId,
+                                                    @RequestParam(value = "data_inicial", required = false) String data_inicial,
+                                                    @RequestParam(value = "data_final", required = false) String data_final,
+                                                    @RequestParam(value = "pago", required = false) Boolean pago,
+                                                    @RequestParam(value = "status", required = false) StatusVenda status,
+                                                    @RequestParam(value = "forma_pagamento", required = false) FormaPagamento forma_pagamento,
+                                                    @RequestParam(value = "sort", required = false) String sort,
+                                                    @RequestParam(value = "order", required = false) Sort.Direction order,
+                                                    @RequestParam(value = "page", required = true) Integer page,
+                                                    @RequestParam(value = "pagesize", required = true) Integer pagesize) {
         var pesquisa = VendaSearch.builder()
                 .id(id)
                 .clienteId(clienteId)
@@ -56,110 +57,108 @@ public class VendaController extends V1BaseController {
                 .sort(sort)
                 .order(order)
                 .build();
-        return vendaService.listarVendas(loggedUser, pesquisa);
+        return ok(vendaService.listarVendas(loggedUser, pesquisa));
     }
-
-
 
     @GetMapping("/{idVenda}")
     @Operation(summary = "Listar venda", description = "Retorna uma venda pelo ID")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Venda listarUmaVenda(@AuthenticationPrincipal User loggedUser,
-                                @PathVariable("idVenda") Integer idVenda) {
-        return vendaService.listarUmaVenda(loggedUser, idVenda);
+    public ResponseEntity<Venda> listarUmaVenda(@AuthenticationPrincipal User loggedUser,
+                                                @PathVariable("idVenda") Integer idVenda) {
+        return ok(vendaService.listarUmaVenda(loggedUser, idVenda));
     }
 
     @PostMapping
     @Operation(summary = "Registrar venda", description = "Cria uma nova venda")
-    @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Venda registrarVenda(@AuthenticationPrincipal User loggedUser,
-                                @RequestBody @Valid VendaDTO venda) {
-        return vendaService.registrarVenda(loggedUser, venda);
+    @ApiResponse(responseCode = "201", description = "Criado")
+    public ResponseEntity<Venda> registrarVenda(@AuthenticationPrincipal User loggedUser,
+                                                @RequestBody @Valid VendaDTO venda) {
+        return created(vendaService.registrarVenda(loggedUser, venda));
     }
 
     @PutMapping("/{idVenda}")
     @Operation(summary = "Editar venda", description = "Atualiza uma venda existente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Venda editarVenda(@AuthenticationPrincipal User loggedUser,
-                             @PathVariable("idVenda") Integer idVenda,
-                             @RequestBody @Valid VendaDTO venda) {
-        return vendaService.atualizarVenda(loggedUser, idVenda, venda);
+    public ResponseEntity<Venda> editarVenda(@AuthenticationPrincipal User loggedUser,
+                                             @PathVariable("idVenda") Integer idVenda,
+                                             @RequestBody @Valid VendaDTO venda) {
+        return ok(vendaService.atualizarVenda(loggedUser, idVenda, venda));
     }
 
     @PutMapping("/{idVenda}/confirmar")
     @Operation(summary = "Confirmar venda", description = "Confirma uma venda")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Venda confirmarVenda(@AuthenticationPrincipal User loggedUser,
-                                @PathVariable("idVenda") Integer idVenda) {
-        return vendaService.confirmarVenda(loggedUser, idVenda);
+    public ResponseEntity<Venda> confirmarVenda(@AuthenticationPrincipal User loggedUser,
+                                                @PathVariable("idVenda") Integer idVenda) {
+        return ok(vendaService.confirmarVenda(loggedUser, idVenda));
     }
 
     @PutMapping("/{idVenda}/pagar/{idPagamento}")
     @Operation(summary = "Pagar venda", description = "Realiza pagamento de uma venda")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Venda pagarVenda(@AuthenticationPrincipal User loggedUser,
-                            @PathVariable("idVenda") Integer idVenda,
-                            @PathVariable("idPagamento") Integer idPagamento) {
-        return vendaService.pagarVenda(loggedUser, idVenda, idPagamento);
+    public ResponseEntity<Venda> pagarVenda(@AuthenticationPrincipal User loggedUser,
+                                            @PathVariable("idVenda") Integer idVenda,
+                                            @PathVariable("idPagamento") Integer idPagamento) {
+        return ok(vendaService.pagarVenda(loggedUser, idVenda, idPagamento));
     }
 
     @PutMapping("/{idVenda}/lancar-pagamento")
     @Operation(summary = "Lançar pagamento", description = "Registra pagamento de uma venda")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Venda lancarPagamentoVenda(@AuthenticationPrincipal User loggedUser,
-                                      @PathVariable("idVenda") Integer idVenda,
-                                      @RequestBody List<@Valid PagamentoDTO> pagamentoDTO) {
-        return vendaService.lancarPagamentoVenda(loggedUser, idVenda, pagamentoDTO);
+    public ResponseEntity<Venda> lancarPagamentoVenda(@AuthenticationPrincipal User loggedUser,
+                                                      @PathVariable("idVenda") Integer idVenda,
+                                                      @RequestBody List<@Valid PagamentoDTO> pagamentoDTO) {
+        return ok(vendaService.lancarPagamentoVenda(loggedUser, idVenda, pagamentoDTO));
     }
 
     @PutMapping("/{idVenda}/estornar")
     @Operation(summary = "Estornar venda", description = "Estorna venda integralmente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Venda estornarVendaIntegral(@AuthenticationPrincipal User loggedUser,
-                                       @PathVariable("idVenda") Integer idVenda) {
-        return vendaService.estornarVendaIntegral(loggedUser, idVenda);
+    public ResponseEntity<Venda> estornarVendaIntegral(@AuthenticationPrincipal User loggedUser,
+                                                       @PathVariable("idVenda") Integer idVenda) {
+        return ok(vendaService.estornarVendaIntegral(loggedUser, idVenda));
     }
 
     @PutMapping("/{idVenda}/estornar/{idPagamento}")
     @Operation(summary = "Estornar pagamento", description = "Estorna pagamento de uma venda")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Venda estornarPagamentoVenda(@AuthenticationPrincipal User loggedUser,
-                                        @PathVariable("idVenda") Integer idVenda,
-                                        @PathVariable("idPagamento") Integer idPagamento) {
-        return vendaService.estornarPagamentoVenda(loggedUser, idVenda, idPagamento);
+    public ResponseEntity<Venda> estornarPagamentoVenda(@AuthenticationPrincipal User loggedUser,
+                                                        @PathVariable("idVenda") Integer idVenda,
+                                                        @PathVariable("idPagamento") Integer idPagamento) {
+        return ok(vendaService.estornarPagamentoVenda(loggedUser, idVenda, idPagamento));
     }
 
     @PutMapping("/{idVenda}/agendar")
     @Operation(summary = "Agendar venda", description = "Agenda uma venda")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Venda agendarVenda(@AuthenticationPrincipal User loggedUser,
-                              @PathVariable("idVenda") Integer idVenda,
-                              @RequestParam String dataAgendada) {
-        return vendaService.agendarVenda(loggedUser, idVenda, dataAgendada);
+    public ResponseEntity<Venda> agendarVenda(@AuthenticationPrincipal User loggedUser,
+                                              @PathVariable("idVenda") Integer idVenda,
+                                              @RequestParam String dataAgendada) {
+        return ok(vendaService.agendarVenda(loggedUser, idVenda, dataAgendada));
     }
 
     @PutMapping("/{idVenda}/finalizar-agendamento")
     @Operation(summary = "Finalizar agendamento", description = "Finaliza o agendamento de uma venda")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Venda finalizarAgendamentoVenda(@AuthenticationPrincipal User loggedUser,
-                                           @PathVariable("idVenda") Integer idVenda) {
-        return vendaService.finalizarAgendamentoVenda(loggedUser, idVenda);
+    public ResponseEntity<Venda> finalizarAgendamentoVenda(@AuthenticationPrincipal User loggedUser,
+                                                           @PathVariable("idVenda") Integer idVenda) {
+        return ok(vendaService.finalizarAgendamentoVenda(loggedUser, idVenda));
     }
 
     @PutMapping("/{idVenda}/finalizar")
     @Operation(summary = "Finalizar venda", description = "Finaliza uma venda")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Venda finalizarVenda(@AuthenticationPrincipal User loggedUser,
-                                @PathVariable("idVenda") Integer idVenda) {
-        return vendaService.finalizarVenda(loggedUser, idVenda);
+    public ResponseEntity<Venda> finalizarVenda(@AuthenticationPrincipal User loggedUser,
+                                                @PathVariable("idVenda") Integer idVenda) {
+        return ok(vendaService.finalizarVenda(loggedUser, idVenda));
     }
 
     @PutMapping("/{idVenda}/cancelar")
     @Operation(summary = "Cancelar venda", description = "Cancela uma venda")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public Venda cancelarVenda(@AuthenticationPrincipal User loggedUser,
-                               @PathVariable("idVenda") Integer idVenda) {
-        return vendaService.cancelarVenda(loggedUser, idVenda);
+    public ResponseEntity<Venda> cancelarVenda(@AuthenticationPrincipal User loggedUser,
+                                               @PathVariable("idVenda") Integer idVenda) {
+        return ok(vendaService.cancelarVenda(loggedUser, idVenda));
     }
-
 }
+


### PR DESCRIPTION
## Summary
- standardize ResponseEntity usage across all controllers
- return 201 for resource creation and 204 for deletions
- centralize response handling via V1BaseController helpers

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.AIT:Optimanage:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68af45ac0720832483834ccec746e3c1