### PR TITLE
feat: implement logout endpoint with token revocation

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Auth/AuthenticationController.java
+++ b/src/main/java/com/AIT/Optimanage/Auth/AuthenticationController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.servlet.http.HttpServletRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -42,5 +43,17 @@ public class AuthenticationController {
     public ResponseEntity<AuthenticationResponse> refresh(
             @Valid @RequestBody RefreshTokenRequest request) {
         return ResponseEntity.ok(authenticationService.refreshToken(request.getRefreshToken()));
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "Logout", description = "Revoga tokens do usuário")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        final String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            authenticationService.logout(token);
+        }
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Auth/AuthenticationService.java
+++ b/src/main/java/com/AIT/Optimanage/Auth/AuthenticationService.java
@@ -6,6 +6,7 @@ import com.AIT.Optimanage.Config.JwtService;
 import com.AIT.Optimanage.Models.User.Role;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Repositories.UserRepository;
+import com.AIT.Optimanage.Auth.TokenBlacklistService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -24,6 +25,7 @@ public class AuthenticationService {
     private final JwtService jwtService;
     private final AuthenticationManager authenticationManager;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Transactional
     public AuthenticationResponse register(RegisterRequest request) {
@@ -88,5 +90,15 @@ public class AuthenticationService {
                 .build();
         refreshTokenRepository.save(token);
         return refreshToken;
+    }
+
+    @Transactional
+    public void logout(String token) {
+        var userEmail = jwtService.extractEmail(token);
+        if (userEmail != null) {
+            userRepository.findByEmail(userEmail)
+                    .ifPresent(refreshTokenRepository::deleteByUser);
+        }
+        tokenBlacklistService.blacklistToken(token);
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Auth/TokenBlacklistService.java
+++ b/src/main/java/com/AIT/Optimanage/Auth/TokenBlacklistService.java
@@ -1,0 +1,21 @@
+package com.AIT.Optimanage.Auth;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class TokenBlacklistService {
+
+    private final Set<String> blacklistedTokens = ConcurrentHashMap.newKeySet();
+
+    public void blacklistToken(String token) {
+        blacklistedTokens.add(token);
+    }
+
+    public boolean isTokenBlacklisted(String token) {
+        return blacklistedTokens.contains(token);
+    }
+}
+

--- a/src/main/java/com/AIT/Optimanage/Config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/AIT/Optimanage/Config/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import com.AIT.Optimanage.Auth.TokenBlacklistService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -22,6 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
     private final UserDetailsService userDetailService;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Override
     protected void doFilterInternal(
@@ -38,6 +40,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         jwt = authHeader.substring(7);
         userEmail = jwtService.extractEmail(jwt);
+        if (tokenBlacklistService.isTokenBlacklisted(jwt)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
         if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             UserDetails userDetails = this.userDetailService.loadUserByUsername(userEmail);
             if (jwtService.isTokenValid(jwt, userDetails)) {

--- a/src/test/java/com/AIT/Optimanage/Auth/AuthenticationControllerValidationTest.java
+++ b/src/test/java/com/AIT/Optimanage/Auth/AuthenticationControllerValidationTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Mockito.verify;
 
 @WebMvcTest(controllers = AuthenticationController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -41,5 +42,13 @@ class AuthenticationControllerValidationTest {
                 .content("{\"email\":\"invalid\",\"senha\":\"\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors[0]").exists());
+    }
+
+    @Test
+    void whenLogout_thenReturnsOk() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/logout")
+                .header("Authorization", "Bearer token"))
+                .andExpect(status().isOk());
+        verify(authenticationService).logout("token");
     }
 }

--- a/src/test/java/com/AIT/Optimanage/Auth/AuthenticationServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Auth/AuthenticationServiceTest.java
@@ -1,0 +1,61 @@
+package com.AIT.Optimanage.Auth;
+
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Repositories.UserRepository;
+import com.AIT.Optimanage.Config.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtService jwtService;
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private TokenBlacklistService tokenBlacklistService;
+
+    private AuthenticationService authenticationService;
+
+    @BeforeEach
+    void setUp() {
+        authenticationService = new AuthenticationService(
+                userRepository,
+                passwordEncoder,
+                jwtService,
+                authenticationManager,
+                refreshTokenRepository,
+                tokenBlacklistService);
+    }
+
+    @Test
+    void logoutShouldDeleteRefreshTokenAndBlacklistToken() {
+        String token = "jwt";
+        String email = "user@example.com";
+        User user = new User();
+
+        when(jwtService.extractEmail(token)).thenReturn(email);
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        authenticationService.logout(token);
+
+        verify(refreshTokenRepository).deleteByUser(user);
+        verify(tokenBlacklistService).blacklistToken(token);
+    }
+}


### PR DESCRIPTION
## Summary
- add logout endpoint that revokes refresh tokens and blacklists access tokens
- track revoked tokens via TokenBlacklistService and JwtAuthenticationFilter
- add unit and controller tests for logout behavior

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68af45dddbc083249b67d42f6dfdb8e9