### PR TITLE
Fix Fornecedor ID mapping in Produto and Servico mappers

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Mappers/ProdutoMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/ProdutoMapper.java
@@ -1,19 +1,30 @@
 package com.AIT.Optimanage.Mappers;
 
 import com.AIT.Optimanage.Controllers.dto.ProdutoRequest;
+import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
 import com.AIT.Optimanage.Models.Produto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface ProdutoMapper {
 
-    @Mapping(target = "fornecedor.id", source = "fornecedorId")
-    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "fornecedor", source = "fornecedorId", qualifiedByName = "idToFornecedor")
     @Mapping(target = "ownerUser", ignore = true)
     Produto toEntity(ProdutoRequest request);
 
     @Mapping(target = "fornecedorId", source = "fornecedor.id")
     ProdutoRequest toRequest(Produto produto);
+
+    @Named("idToFornecedor")
+    default Fornecedor mapFornecedor(Integer fornecedorId) {
+        if (fornecedorId == null) {
+            return null;
+        }
+        Fornecedor fornecedor = new Fornecedor();
+        fornecedor.setId(fornecedorId);
+        return fornecedor;
+    }
 }

--- a/src/main/java/com/AIT/Optimanage/Mappers/ServicoMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/ServicoMapper.java
@@ -2,16 +2,17 @@ package com.AIT.Optimanage.Mappers;
 
 import com.AIT.Optimanage.Controllers.dto.ServicoRequest;
 import com.AIT.Optimanage.Controllers.dto.ServicoResponse;
+import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
 import com.AIT.Optimanage.Models.Servico;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface ServicoMapper {
 
-    @Mapping(target = "fornecedor.id", source = "fornecedorId")
-    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "fornecedor", source = "fornecedorId", qualifiedByName = "idToFornecedor")
     @Mapping(target = "ownerUser", ignore = true)
     Servico toEntity(ServicoRequest request);
 
@@ -21,5 +22,15 @@ public interface ServicoMapper {
 
     @Mapping(target = "fornecedorId", source = "fornecedor.id")
     ServicoRequest toRequest(Servico servico);
+
+    @Named("idToFornecedor")
+    default Fornecedor mapFornecedor(Integer fornecedorId) {
+        if (fornecedorId == null) {
+            return null;
+        }
+        Fornecedor fornecedor = new Fornecedor();
+        fornecedor.setId(fornecedorId);
+        return fornecedor;
+    }
 }
 


### PR DESCRIPTION
## Summary
- Convert fornecedorId into Fornecedor entities via helper methods
- Clean up MapStruct mappings in ProdutoMapper and ServicoMapper

## Testing
- `./mvnw test` *(fails: Network is unreachable when resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68af661d150c8324aba48e5dc7daa56c