### PR TITLE
Add Bucket4j rate limiting filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
             <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
+            <groupId>com.github.vladimir-bukhtoyarov</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>8.0.1</version>
+    </dependency>
+    <dependency>
               <groupId>org.springdoc</groupId>
               <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
               <version>2.8.11</version>

--- a/src/main/java/com/AIT/Optimanage/Config/RateLimitingFilter.java
+++ b/src/main/java/com/AIT/Optimanage/Config/RateLimitingFilter.java
@@ -1,0 +1,71 @@
+package com.AIT.Optimanage.Config;
+
+import com.github.bucket4j.Bandwidth;
+import com.github.bucket4j.Bucket;
+import com.github.bucket4j.Bucket4j;
+import com.github.bucket4j.Refill;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Filter that limits the number of requests per user or IP using Bucket4j.
+ * Blocked requests are recorded using Micrometer metrics for monitoring.
+ */
+@Component
+public class RateLimitingFilter extends OncePerRequestFilter {
+
+    private static final long CAPACITY = 100;
+    private static final Duration DURATION = Duration.ofMinutes(1);
+    private final ConcurrentMap<String, Bucket> buckets = new ConcurrentHashMap<>();
+    private final Counter blockedRequests;
+
+    public RateLimitingFilter(MeterRegistry meterRegistry) {
+        this.blockedRequests = Counter.builder("rate_limit.blocked_requests")
+                .description("Number of requests blocked due to rate limiting")
+                .register(meterRegistry);
+    }
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        String key = resolveKey(request);
+        Bucket bucket = buckets.computeIfAbsent(key, k -> newBucket());
+        if (bucket.tryConsume(1)) {
+            filterChain.doFilter(request, response);
+        } else {
+            blockedRequests.increment();
+            response.setStatus(429);
+            response.getWriter().write("Too many requests");
+        }
+    }
+
+    private Bucket newBucket() {
+        Refill refill = Refill.greedy(CAPACITY, DURATION);
+        Bandwidth limit = Bandwidth.classic(CAPACITY, refill);
+        return Bucket4j.builder().addLimit(limit).build();
+    }
+
+    private String resolveKey(HttpServletRequest request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            return authentication.getName();
+        }
+        return request.getRemoteAddr();
+    }
+}
+

--- a/src/main/java/com/AIT/Optimanage/Config/SecurityConfig.java
+++ b/src/main/java/com/AIT/Optimanage/Config/SecurityConfig.java
@@ -2,27 +2,18 @@ package com.AIT.Optimanage.Config;
 
 
 
-import jakarta.servlet.Filter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
 
 @Configuration
 @EnableWebSecurity
@@ -32,6 +23,7 @@ public class SecurityConfig {
 
 
     private final JwtAuthenticationFilter jwtAuthFilter;
+    private final RateLimitingFilter rateLimitingFilter;
     private final AuthenticationProvider authenticationProvider;
 
 
@@ -50,6 +42,7 @@ public class SecurityConfig {
                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authenticationProvider(authenticationProvider)
+                .addFilterBefore(rateLimitingFilter, JwtAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         ;


### PR DESCRIPTION
## Summary
- integrate Bucket4j to limit requests per user or IP
- track blocked requests with Micrometer metrics
- register filter in security chain

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af455bcc98832492e69a1cd0e311c6