### PR TITLE
feat: add email-based code delivery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,10 +56,14 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-mail</artifactId>
+                </dependency>
                 <dependency>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-data-jdbc</artifactId>

--- a/src/main/java/com/AIT/Optimanage/Auth/AuthenticationService.java
+++ b/src/main/java/com/AIT/Optimanage/Auth/AuthenticationService.java
@@ -5,6 +5,7 @@ import com.AIT.Optimanage.Models.User.Role;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Repositories.UserRepository;
 import com.AIT.Optimanage.Auth.TokenBlacklistService;
+import com.AIT.Optimanage.Support.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -25,6 +26,7 @@ public class AuthenticationService {
     private final AuthenticationManager authenticationManager;
     private final RefreshTokenRepository refreshTokenRepository;
     private final TokenBlacklistService tokenBlacklistService;
+    private final EmailService emailService;
 
     @Transactional
     public AuthenticationResponse register(RegisterRequest request) {
@@ -176,6 +178,6 @@ public class AuthenticationService {
     }
 
     private void sendCode(String destination, String code) {
-        System.out.println("Sending code " + code + " to " + destination);
+        emailService.enviarCodigo(destination, code);
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Support/EmailService.java
+++ b/src/main/java/com/AIT/Optimanage/Support/EmailService.java
@@ -1,0 +1,26 @@
+package com.AIT.Optimanage.Support;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username:no-reply@optimanage.com}")
+    private String from;
+
+    public void enviarCodigo(String destino, String codigo) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(destino);
+        message.setSubject("Código de verificação");
+        message.setText("Seu código é: " + codigo);
+        message.setFrom(from);
+        mailSender.send(message);
+    }
+}


### PR DESCRIPTION
## Summary
- add `EmailService` to send verification codes via SMTP
- replace `System.out.println` code delivery with `EmailService.enviarCodigo`
- include Spring Mail starter dependency

## Testing
- `sh ./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d569ac1883248709cd30964b608d