### PR TITLE
Restrict Postman runner to dev profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ Todos os recursos (exceto autenticação) usam o prefixo `/api/v1` e exigem um t
 2. Rodar testes: `./mvnw test`
 3. Executar aplicação: `./mvnw spring-boot:run`
 
+### Perfil de desenvolvimento
+Para habilitar o perfil `dev` e gerar a coleção Postman automaticamente na inicialização, execute a aplicação com o perfil de desenvolvimento:
+
+```
+./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
+```
+
+Ou defina a variável de ambiente `SPRING_PROFILES_ACTIVE=dev` ao executar o JAR.
+
+O arquivo `src/main/resources/application-dev.properties` ativa esse perfil.
+
 ## Migrações de Banco de Dados
 As migrações de esquema são gerenciadas pelo [Flyway](https://flywaydb.org/). Os scripts SQL ficam em `src/main/resources/db/migration` e são aplicados automaticamente na inicialização da aplicação.
 

--- a/src/main/java/com/AIT/Optimanage/Support/PostmanOnStartupRunner.java
+++ b/src/main/java/com/AIT/Optimanage/Support/PostmanOnStartupRunner.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -15,6 +16,7 @@ import java.nio.file.Path;
 import java.util.Map;
 
 @Component
+@Profile("dev")
 public class PostmanOnStartupRunner implements ApplicationRunner {
     private static final Logger log = LoggerFactory.getLogger(PostmanOnStartupRunner.class);
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+spring.profiles.active=dev


### PR DESCRIPTION
## Summary
- limit `PostmanOnStartupRunner` execution to dev profile
- add `application-dev.properties` enabling the profile
- document how to run with the dev profile in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d65a44b8832494ec59d1e5589ca5