### PR TITLE
Add product recommendation endpoint

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/RecommendationController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/RecommendationController.java
@@ -1,0 +1,35 @@
+package com.AIT.Optimanage.Controllers;
+
+import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
+import com.AIT.Optimanage.Controllers.dto.ProdutoResponse;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Services.RecommendationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/recommendations")
+@RequiredArgsConstructor
+@Tag(name = "Recomendações", description = "Sugestões de produtos baseadas em vendas")
+public class RecommendationController extends V1BaseController {
+
+    private final RecommendationService recommendationService;
+
+    @GetMapping("/{clienteId}")
+    @Operation(summary = "Recomendar produtos", description = "Sugere produtos com base no histórico de vendas")
+    @ApiResponse(responseCode = "200", description = "Sucesso")
+    public ResponseEntity<List<ProdutoResponse>> recomendar(@AuthenticationPrincipal User loggedUser,
+                                                            @PathVariable Integer clienteId) {
+        return ok(recommendationService.recomendarProdutos(loggedUser, clienteId));
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -44,4 +45,17 @@ public interface VendaRepository extends JpaRepository<Venda, Integer> {
     );
 
     Optional<Venda> findByIdAndOwnerUser(Integer idVenda, User loggedUser);
+
+    @Query("SELECT vp.produto.id AS produtoId, SUM(vp.quantidade) AS totalQuantidade " +
+            "FROM Venda v JOIN v.vendaProdutos vp " +
+            "WHERE v.cliente.id = :clienteId AND v.ownerUser.id = :userId " +
+            "GROUP BY vp.produto.id ORDER BY totalQuantidade DESC")
+    List<Object[]> findTopProdutosByCliente(@Param("clienteId") Integer clienteId,
+                                            @Param("userId") Integer userId);
+
+    @Query("SELECT DISTINCT v FROM Venda v " +
+            "JOIN FETCH v.vendaProdutos vp " +
+            "JOIN FETCH vp.produto p " +
+            "WHERE v.ownerUser.id = :userId")
+    List<Venda> findAllWithProdutosByOwnerUser(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/AIT/Optimanage/Services/RecommendationService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/RecommendationService.java
@@ -1,0 +1,79 @@
+package com.AIT.Optimanage.Services;
+
+import com.AIT.Optimanage.Controllers.dto.ProdutoResponse;
+import com.AIT.Optimanage.Models.Produto;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Models.Venda.Venda;
+import com.AIT.Optimanage.Repositories.ProdutoRepository;
+import com.AIT.Optimanage.Repositories.Venda.VendaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationService {
+
+    private final VendaRepository vendaRepository;
+    private final ProdutoRepository produtoRepository;
+
+    @Transactional(readOnly = true)
+    public List<ProdutoResponse> recomendarProdutos(User loggedUser, Integer clienteId) {
+        List<Object[]> historicoCliente = vendaRepository.findTopProdutosByCliente(clienteId, loggedUser.getId());
+
+        Set<Integer> produtosCliente = historicoCliente.stream()
+                .map(r -> (Integer) r[0])
+                .collect(Collectors.toSet());
+
+        if (produtosCliente.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Venda> vendas = vendaRepository.findAllWithProdutosByOwnerUser(loggedUser.getId());
+
+        Map<Integer, Integer> contagemRecomendacoes = new HashMap<>();
+        for (Venda venda : vendas) {
+            Set<Integer> produtosVenda = venda.getVendaProdutos().stream()
+                    .map(vp -> vp.getProduto().getId())
+                    .collect(Collectors.toSet());
+            if (Collections.disjoint(produtosVenda, produtosCliente)) {
+                continue;
+            }
+            for (Integer produto : produtosVenda) {
+                if (!produtosCliente.contains(produto)) {
+                    contagemRecomendacoes.merge(produto, 1, Integer::sum);
+                }
+            }
+        }
+
+        List<Integer> recomendadosIds = contagemRecomendacoes.entrySet().stream()
+                .sorted(Map.Entry.<Integer, Integer>comparingByValue().reversed())
+                .map(Map.Entry::getKey)
+                .toList();
+
+        List<Produto> produtos = produtoRepository.findAllById(recomendadosIds);
+
+        return produtos.stream().map(this::toResponse).toList();
+    }
+
+    private ProdutoResponse toResponse(Produto produto) {
+        return ProdutoResponse.builder()
+                .id(produto.getId())
+                .ownerUserId(produto.getOwnerUser() != null ? produto.getOwnerUser().getId() : null)
+                .fornecedorId(produto.getFornecedor() != null ? produto.getFornecedor().getId() : null)
+                .sequencialUsuario(produto.getSequencialUsuario())
+                .codigoReferencia(produto.getCodigoReferencia())
+                .nome(produto.getNome())
+                .descricao(produto.getDescricao())
+                .custo(produto.getCusto())
+                .disponivelVenda(produto.getDisponivelVenda())
+                .valorVenda(produto.getValorVenda())
+                .qtdEstoque(produto.getQtdEstoque())
+                .terceirizado(produto.getTerceirizado())
+                .ativo(produto.getAtivo())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- extend VendaRepository with methods to retrieve product history and fetch sales with products
- implement RecommendationService that suggests products using sales associations
- expose `/api/v1/recommendations/{clienteId}` endpoint

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68b5d5f926ac83248f2cc790f33657c6