### PR TITLE
feat: apply owner user filter across repositories

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Config/OwnerUserHibernateFilter.java
+++ b/src/main/java/com/AIT/Optimanage/Config/OwnerUserHibernateFilter.java
@@ -1,0 +1,48 @@
+package com.AIT.Optimanage.Config;
+
+import com.AIT.Optimanage.Models.User.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.hibernate.Filter;
+import org.hibernate.Session;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Habilita o filtro de proprietário (ownerUser) do Hibernate em cada requisição,
+ * garantindo que apenas registros pertencentes ao usuário autenticado sejam retornados.
+ */
+@Component
+public class OwnerUserHibernateFilter extends OncePerRequestFilter {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        Session session = entityManager.unwrap(Session.class);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Filter filter = null;
+        if (authentication != null && authentication.getPrincipal() instanceof User user) {
+            filter = session.enableFilter("ownerUserFilter");
+            filter.setParameter("ownerUserId", user.getId());
+        }
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            if (filter != null) {
+                session.disableFilter("ownerUserFilter");
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/AIT/Optimanage/Config/SecurityConfig.java
+++ b/src/main/java/com/AIT/Optimanage/Config/SecurityConfig.java
@@ -14,6 +14,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.AIT.Optimanage.Config.OwnerUserHibernateFilter;
+
 
 @Configuration
 @EnableWebSecurity
@@ -24,6 +26,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthFilter;
     private final RateLimitingFilter rateLimitingFilter;
     private final AuthenticationProvider authenticationProvider;
+    private final OwnerUserHibernateFilter ownerUserHibernateFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -51,7 +54,8 @@ public class SecurityConfig {
                 // Place rate limiting early, before authentication processing
                 .addFilterBefore(rateLimitingFilter, UsernamePasswordAuthenticationFilter.class)
                 // JWT authentication runs before username/password auth
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(ownerUserHibernateFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/AIT/Optimanage/Models/Atividade.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Atividade.java
@@ -6,6 +6,9 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -14,6 +17,8 @@ import com.AIT.Optimanage.Models.BaseEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@FilterDef(name = "ownerUserFilter", parameters = @ParamDef(name = "ownerUserId", type = Integer.class))
+@Filter(name = "ownerUserFilter", condition = "owner_user_id = :ownerUserId")
 public class Atividade extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
@@ -6,6 +6,9 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -17,6 +20,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@FilterDef(name = "ownerUserFilter", parameters = @ParamDef(name = "ownerUserId", type = Integer.class))
+@Filter(name = "ownerUserFilter", condition = "owner_user_id = :ownerUserId")
 public class Cliente extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
@@ -6,6 +6,9 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
@@ -19,6 +22,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@FilterDef(name = "ownerUserFilter", parameters = @ParamDef(name = "ownerUserId", type = Integer.class))
+@Filter(name = "ownerUserFilter", condition = "owner_user_id = :ownerUserId")
 public class Compra extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
@@ -6,6 +6,9 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -19,6 +22,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@FilterDef(name = "ownerUserFilter", parameters = @ParamDef(name = "ownerUserId", type = Integer.class))
+@Filter(name = "ownerUserFilter", condition = "owner_user_id = :ownerUserId")
 public class Fornecedor extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Funcionario.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Funcionario.java
@@ -4,6 +4,9 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -12,6 +15,8 @@ import com.AIT.Optimanage.Models.BaseEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@FilterDef(name = "ownerUserFilter", parameters = @ParamDef(name = "ownerUserId", type = Integer.class))
+@Filter(name = "ownerUserFilter", condition = "owner_user_id = :ownerUserId")
 public class Funcionario extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Produto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Produto.java
@@ -6,6 +6,9 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -17,6 +20,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@FilterDef(name = "ownerUserFilter", parameters = @ParamDef(name = "ownerUserId", type = Integer.class))
+@Filter(name = "ownerUserFilter", condition = "owner_user_id = :ownerUserId")
 public class Produto extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Servico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Servico.java
@@ -6,6 +6,9 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -17,6 +20,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@FilterDef(name = "ownerUserFilter", parameters = @ParamDef(name = "ownerUserId", type = Integer.class))
+@Filter(name = "ownerUserFilter", condition = "owner_user_id = :ownerUserId")
 public class Servico extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
@@ -3,6 +3,9 @@ package com.AIT.Optimanage.Models.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -11,6 +14,8 @@ import com.AIT.Optimanage.Models.BaseEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@FilterDef(name = "ownerUserFilter", parameters = @ParamDef(name = "ownerUserId", type = Integer.class))
+@Filter(name = "ownerUserFilter", condition = "owner_user_id = :ownerUserId")
 public class Contador extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/User/UserInfo.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/UserInfo.java
@@ -5,6 +5,9 @@ import com.AIT.Optimanage.Models.BaseEntity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,6 +20,8 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@FilterDef(name = "ownerUserFilter", parameters = @ParamDef(name = "ownerUserId", type = Integer.class))
+@Filter(name = "ownerUserFilter", condition = "owner_user_id = :ownerUserId")
 public class UserInfo extends BaseEntity {
     @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Compatibilidade/ContextoCompatibilidade.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Compatibilidade/ContextoCompatibilidade.java
@@ -3,6 +3,9 @@ package com.AIT.Optimanage.Models.Venda.Compatibilidade;
 import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,6 +17,8 @@ import com.AIT.Optimanage.Models.BaseEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@FilterDef(name = "ownerUserFilter", parameters = @ParamDef(name = "ownerUserId", type = Integer.class))
+@Filter(name = "ownerUserFilter", condition = "owner_user_id = :ownerUserId")
 public class ContextoCompatibilidade extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
@@ -7,6 +7,9 @@ import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
@@ -20,6 +23,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@FilterDef(name = "ownerUserFilter", parameters = @ParamDef(name = "ownerUserId", type = Integer.class))
+@Filter(name = "ownerUserFilter", condition = "owner_user_id = :ownerUserId")
 public class Venda extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Repositories/Cliente/ClienteRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Cliente/ClienteRepository.java
@@ -2,7 +2,6 @@ package com.AIT.Optimanage.Repositories.Cliente;
 
 import com.AIT.Optimanage.Models.Cliente.Cliente;
 import com.AIT.Optimanage.Models.Enums.TipoPessoa;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,24 +15,21 @@ import java.util.Optional;
 @Repository
 public interface ClienteRepository extends JpaRepository<Cliente, Integer> {
 
-    List<Cliente> findByOwnerUserAndAtivoTrue(User ownerUser);
+    List<Cliente> findByAtivoTrue();
 
     @Query("SELECT DISTINCT c FROM Cliente c " +
             "LEFT JOIN c.enderecos e " +
-            "WHERE " +
-            "(:userId IS NULL OR c.ownerUser.id = :userId) AND " +
-            "(:id IS NULL OR c.id = :id) AND " +
+            "WHERE (:id IS NULL OR c.id = :id) AND " +
             "(:nome IS NULL OR LOWER(c.nome) LIKE LOWER(CONCAT('%', :nome, '%')) " +
             "OR LOWER(c.nomeFantasia) LIKE LOWER(CONCAT('%', :nome, '%'))) AND " +
             "(:cpfOuCnpj IS NULL OR " +
             " REPLACE(REPLACE(REPLACE(c.cpf, '.', ''), '-', ''), '/', '') = REPLACE(REPLACE(REPLACE(:cpfOuCnpj, '.', ''), '-', ''), '/', '') " +
             " OR REPLACE(REPLACE(REPLACE(c.cnpj, '.', ''), '-', ''), '/', '') = REPLACE(REPLACE(REPLACE(:cpfOuCnpj, '.', ''), '-', ''), '/', '')) AND " +
             "(:atividade IS NULL OR c.atividade.id = :atividade) AND " +
-            "(:estado IS NULL OR EXISTS (SELECT 1 FROM ClienteEndereco e WHERE e.cliente.id = c.id AND e.estado = :estado)) AND " +
+            "(:estado IS NULL OR EXISTS (SELECT 1 FROM ClienteEndereco e WHERE e.cliente.id = c.id AND e.estado = :estado)) AND" +
             "(:tipoPessoa IS NULL OR c.tipoPessoa = :tipoPessoa) AND " +
             "(:ativo IS NULL OR c.ativo = :ativo)")
     Page<Cliente> buscarClientes(
-            @Param("userId") Integer userId,
             @Param("id") Integer id,
             @Param("nome") String nome,
             @Param("cpfOuCnpj") String cpfOuCnpj,
@@ -44,7 +40,6 @@ public interface ClienteRepository extends JpaRepository<Cliente, Integer> {
             Pageable pageable
     );
 
-    Optional<Cliente> findByIdAndOwnerUserAndAtivoTrue(Integer idCliente, User loggedUser);
-
-    Optional<Cliente> findByIdAndOwnerUser(Integer idCliente, User loggedUser);
+    Optional<Cliente> findByIdAndAtivoTrue(Integer idCliente);
 }
+

--- a/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
@@ -3,14 +3,11 @@ package com.AIT.Optimanage.Repositories.Compra;
 import com.AIT.Optimanage.Models.Compra.Compra;
 import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
 import com.AIT.Optimanage.Models.Enums.FormaPagamento;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
 
 public interface CompraRepository extends JpaRepository<Compra, Integer> {
 
@@ -20,9 +17,7 @@ public interface CompraRepository extends JpaRepository<Compra, Integer> {
             "LEFT JOIN FETCH c.compraServicos vs " +
             "LEFT JOIN FETCH vs.servico s " +
             "LEFT JOIN c.pagamentos pag " +
-            "WHERE " +
-            "((:id IS NOT NULL AND c.ownerUser.id = :userId AND c.sequencialUsuario = :id) " +
-            "OR (:userId IS NULL OR c.ownerUser.id = :userId)) " +
+            "WHERE (:id IS NULL OR c.sequencialUsuario = :id) " +
             "AND (:fornecedorId IS NULL OR c.fornecedor.id = :fornecedorId) " +
             "AND (:dataInicial IS NULL OR c.dataEfetuacao >= :dataInicial) " +
             "AND (:dataFinal IS NULL OR c.dataEfetuacao <= :dataFinal) " +
@@ -30,7 +25,6 @@ public interface CompraRepository extends JpaRepository<Compra, Integer> {
             "AND (:pago IS NULL OR (CASE WHEN c.valorPendente <= 0 THEN TRUE ELSE FALSE END) = :pago) " +
             "AND (:formaPagamento IS NULL OR EXISTS (SELECT 1 FROM CompraPagamento pagSub WHERE pagSub.compra.id = c.id AND pagSub.formaPagamento = :formaPagamento))")
     Page<Compra> buscarCompras(
-            @Param("userId") Integer userId,
             @Param("id") Integer id,
             @Param("fornecedorId") Integer fornecedorId,
             @Param("dataInicial") String dataInicial,
@@ -40,6 +34,5 @@ public interface CompraRepository extends JpaRepository<Compra, Integer> {
             @Param("formaPagamento") FormaPagamento formaPagamento,
             Pageable pageable
     );
-
-    Optional<Compra> findByIdAndOwnerUser(Integer idCompra, User loggedUser);
 }
+

--- a/src/main/java/com/AIT/Optimanage/Repositories/Fornecedor/FornecedorRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Fornecedor/FornecedorRepository.java
@@ -2,7 +2,6 @@ package com.AIT.Optimanage.Repositories.Fornecedor;
 
 import com.AIT.Optimanage.Models.Enums.TipoPessoa;
 import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,24 +14,19 @@ import java.util.Optional;
 @Repository
 public interface FornecedorRepository extends JpaRepository<Fornecedor, Integer> {
 
-
     @Query("SELECT DISTINCT f FROM Fornecedor f " +
             "LEFT JOIN f.enderecos e " +
-            "WHERE " +
-            "(:userId IS NULL OR f.ownerUser.id = :userId) AND " +
-            "(:id IS NULL OR f.id = :id) OR " +
-            "(:userId IS NULL OR f.ownerUser.id = :userId) AND " +
+            "WHERE (:id IS NULL OR f.id = :id) AND " +
             "(:nome IS NULL OR LOWER(f.nome) LIKE LOWER(CONCAT('%', :nome, '%')) " +
             "OR LOWER(f.nomeFantasia) LIKE LOWER(CONCAT('%', :nome, '%'))) AND " +
             "(:cpfOuCnpj IS NULL OR " +
             " REPLACE(REPLACE(REPLACE(f.cpf, '.', ''), '-', ''), '/', '') = REPLACE(REPLACE(REPLACE(:cpfOuCnpj, '.', ''), '-', ''), '/', '') " +
             " OR REPLACE(REPLACE(REPLACE(f.cnpj, '.', ''), '-', ''), '/', '') = REPLACE(REPLACE(REPLACE(:cpfOuCnpj, '.', ''), '-', ''), '/', '')) AND " +
             "(:atividade IS NULL OR f.atividade.id = :atividade) AND " +
-            "(:estado IS NULL OR EXISTS (SELECT 1 FROM ClienteEndereco e WHERE e.cliente.id = f.id AND e.estado = :estado)) AND " +
+            "(:estado IS NULL OR EXISTS (SELECT 1 FROM ClienteEndereco e WHERE e.cliente.id = f.id AND e.estado = :estado)) AND" +
             "(:tipoPessoa IS NULL OR f.tipoPessoa = :tipoPessoa) AND " +
             "(:ativo IS NULL OR f.ativo = :ativo)")
     Page<Fornecedor> buscarFornecedores(
-            @Param("userId") Integer userId,
             @Param("id") Integer id,
             @Param("nome") String nome,
             @Param("cpfOuCnpj") String cpfOuCnpj,
@@ -43,7 +37,6 @@ public interface FornecedorRepository extends JpaRepository<Fornecedor, Integer>
             Pageable pageable
     );
 
-    Optional<Fornecedor> findByIdAndOwnerUserAndAtivoTrue(Integer idFornecedor, User loggedUser);
-
-    Optional<Fornecedor> findByIdAndOwnerUser(Integer idFornecedor, User loggedUser);
+    Optional<Fornecedor> findByIdAndAtivoTrue(Integer idFornecedor);
 }
+

--- a/src/main/java/com/AIT/Optimanage/Repositories/ProdutoRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/ProdutoRepository.java
@@ -1,7 +1,6 @@
 package com.AIT.Optimanage.Repositories;
 
 import com.AIT.Optimanage.Models.Produto;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,9 +11,7 @@ import java.util.Optional;
 @Repository
 public interface ProdutoRepository extends JpaRepository<Produto, Integer> {
 
-    Page<Produto> findAllByOwnerUserAndAtivoTrue(User loggedUser, Pageable pageable);
+    Page<Produto> findAllByAtivoTrue(Pageable pageable);
 
-    Optional<Produto> findByIdAndOwnerUserAndAtivoTrue(Integer idProduto, User loggedUser);
-
-    Optional<Produto> findByIdAndOwnerUser(Integer idProduto, User loggedUser);
+    Optional<Produto> findByIdAndAtivoTrue(Integer idProduto);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/ServicoRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/ServicoRepository.java
@@ -1,7 +1,6 @@
 package com.AIT.Optimanage.Repositories;
 
 import com.AIT.Optimanage.Models.Servico;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,9 +11,7 @@ import java.util.Optional;
 @Repository
 public interface ServicoRepository extends JpaRepository<Servico, Integer> {
 
-    Page<Servico> findAllByOwnerUserAndAtivoTrue(User ownerUser, Pageable pageable);
+    Page<Servico> findAllByAtivoTrue(Pageable pageable);
 
-    Optional<Servico> findByIdAndOwnerUserAndAtivoTrue(Integer idServico, User ownerUser);
-
-    Optional<Servico> findByIdAndOwnerUser(Integer idServico, User ownerUser);
+    Optional<Servico> findByIdAndAtivoTrue(Integer idServico);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/User/ContadorRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/User/ContadorRepository.java
@@ -2,12 +2,12 @@ package com.AIT.Optimanage.Repositories.User;
 
 import com.AIT.Optimanage.Models.User.Contador;
 import com.AIT.Optimanage.Models.User.Tabela;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ContadorRepository extends JpaRepository<Contador, Integer> {
 
-    Contador getByNomeTabelaAndOwnerUser(Tabela nomeTabela, User loggedUser);
+    Contador getByNomeTabela(Tabela nomeTabela);
 }
+

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/Compatibilidade/ContextoCompatibilidadeRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/Compatibilidade/ContextoCompatibilidadeRepository.java
@@ -1,16 +1,14 @@
 package com.AIT.Optimanage.Repositories.Venda.Compatibilidade;
 
 import com.AIT.Optimanage.Models.Venda.Compatibilidade.ContextoCompatibilidade;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
-
 @Repository
 public interface ContextoCompatibilidadeRepository extends JpaRepository<ContextoCompatibilidade, Integer> {
-    Optional<ContextoCompatibilidade> findByOwnerUserAndNome(User loggedUser, String nome);
-
-    Optional<ContextoCompatibilidade> findByOwnerUser(User loggedUser);
+    Optional<ContextoCompatibilidade> findByNome(String nome);
+    Optional<ContextoCompatibilidade> findFirstByOrderByIdAsc();
 }
+

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -1,6 +1,5 @@
 package com.AIT.Optimanage.Repositories.Venda;
 
-import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Models.Enums.FormaPagamento;
 import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
 import com.AIT.Optimanage.Models.Venda.Venda;
@@ -9,11 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
-@Repository
 public interface VendaRepository extends JpaRepository<Venda, Integer> {
 
     @Query("SELECT v FROM Venda v " +
@@ -22,9 +17,7 @@ public interface VendaRepository extends JpaRepository<Venda, Integer> {
             "LEFT JOIN FETCH v.vendaServicos vs " +
             "LEFT JOIN FETCH vs.servico s " +
             "LEFT JOIN v.pagamentos pag " +
-            "WHERE " +
-            "((:id IS NOT NULL AND v.ownerUser.id = :userId AND v.sequencialUsuario = :id) " +
-            "OR (:userId IS NULL OR v.ownerUser.id = :userId)) " +
+            "WHERE (:id IS NULL OR v.sequencialUsuario = :id) " +
             "AND (:clienteId IS NULL OR v.cliente.id = :clienteId) " +
             "AND (:dataInicial IS NULL OR v.dataEfetuacao >= :dataInicial) " +
             "AND (:dataFinal IS NULL OR v.dataEfetuacao <= :dataFinal) " +
@@ -32,7 +25,6 @@ public interface VendaRepository extends JpaRepository<Venda, Integer> {
             "AND (:pago IS NULL OR (CASE WHEN v.valorPendente <= 0 THEN TRUE ELSE FALSE END) = :pago) " +
             "AND (:formaPagamento IS NULL OR EXISTS (SELECT 1 FROM VendaPagamento pagSub WHERE pagSub.venda.id = v.id AND pagSub.formaPagamento = :formaPagamento))")
     Page<Venda> buscarVendas(
-            @Param("userId") Integer userId,
             @Param("id") Integer id,
             @Param("clienteId") Integer clienteId,
             @Param("dataInicial") String dataInicial,
@@ -42,6 +34,5 @@ public interface VendaRepository extends JpaRepository<Venda, Integer> {
             @Param("formaPagamento") FormaPagamento formaPagamento,
             Pageable pageable
     );
-
-    Optional<Venda> findByIdAndOwnerUser(Integer idVenda, User loggedUser);
 }
+

--- a/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
@@ -38,9 +38,8 @@ public class ClienteService {
 
         Pageable pageable = PageRequest.of(pesquisa.getPage(), pesquisa.getPageSize(), Sort.by(direction, sortBy));
 
-        // Realiza a busca no repositório com os filtros definidos e associando o usuário logado
+        // Realiza a busca no repositório com os filtros definidos
         return clienteRepository.buscarClientes(
-                loggedUser.getId(),
                 pesquisa.getId(),
                 pesquisa.getNome(),
                 pesquisa.getCpfOuCnpj(),
@@ -53,7 +52,7 @@ public class ClienteService {
     }
 
     public Cliente listarUmCliente(User loggedUser, Integer idCliente) {
-        return clienteRepository.findByIdAndOwnerUserAndAtivoTrue(idCliente, loggedUser)
+        return clienteRepository.findByIdAndAtivoTrue(idCliente)
                 .orElseThrow(() -> new EntityNotFoundException("Cliente não encontrado"));
     }
 
@@ -91,7 +90,7 @@ public class ClienteService {
     @CacheEvict(value = "clientes", allEntries = true)
     @Transactional(rollbackFor = Exception.class)
     public Cliente reativarCliente(User loggedUser, Integer idCliente) {
-        Cliente cliente = clienteRepository.findByIdAndOwnerUser(idCliente, loggedUser)
+        Cliente cliente = clienteRepository.findById(idCliente)
                 .orElseThrow(() -> new EntityNotFoundException("Cliente não encontrado"));
         cliente.setAtivo(true);
         return clienteRepository.save(cliente);
@@ -100,7 +99,7 @@ public class ClienteService {
     @CacheEvict(value = "clientes", allEntries = true)
     @Transactional(rollbackFor = Exception.class)
     public void removerCliente(User loggedUser, Integer idCliente) {
-        Cliente cliente = clienteRepository.findByIdAndOwnerUser(idCliente, loggedUser)
+        Cliente cliente = clienteRepository.findById(idCliente)
                 .orElseThrow(() -> new EntityNotFoundException("Cliente não encontrado"));
         clienteRepository.delete(cliente);
     }

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -63,9 +63,8 @@ public class CompraService {
         String sortBy = Optional.ofNullable(pesquisa.getSort()).orElse("id");
         Pageable pageable = PageRequest.of(pesquisa.getPage(), pesquisa.getPageSize(), Sort.by(direction, sortBy));
 
-        // Realiza a busca no repositório com os filtros definidos e associando o usuário logado
+        // Realiza a busca no repositório com os filtros definidos
         return compraRepository.buscarCompras(
-                loggedUser.getId(),
                 pesquisa.getId(),
                 pesquisa.getFornecedorId(),
                 pesquisa.getDataInicial(),
@@ -78,7 +77,7 @@ public class CompraService {
     }
 
     public Compra listarUmaCompra(User loggedUser, Integer idCompra) {
-        return compraRepository.findByIdAndOwnerUser(idCompra, loggedUser)
+        return compraRepository.findById(idCompra)
                 .orElseThrow(() -> new RuntimeException("Compra não encontrada"));
     }
 
@@ -266,7 +265,7 @@ public class CompraService {
     private List<CompraProduto> criarListaProdutos(List<CompraProdutoDTO> produtosDTO, Compra compra) {
         return produtosDTO.stream()
                 .map(produtoDTO -> {
-                    Produto produto = produtoService.buscarProdutoAtivo(compra.getOwnerUser(), produtoDTO.getProdutoId());
+                    Produto produto = produtoService.buscarProdutoAtivo(produtoDTO.getProdutoId());
                     BigDecimal valorFinalProduto = produto.getValorVenda()
                             .multiply(BigDecimal.valueOf(produtoDTO.getQuantidade()));
 
@@ -284,7 +283,7 @@ public class CompraService {
     private List<CompraServico> criarListaServicos(List<CompraServicoDTO> servicosDTO, Compra compra) {
         return servicosDTO.stream()
                 .map(servicoDTO -> {
-                    Servico servico = servicoService.buscarServicoAtivo(compra.getOwnerUser(), servicoDTO.getServicoId());
+                    Servico servico = servicoService.buscarServicoAtivo(servicoDTO.getServicoId());
                     BigDecimal valorFinalServico = servico.getValorVenda()
                             .multiply(BigDecimal.valueOf(servicoDTO.getQuantidade()));
 

--- a/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
@@ -39,9 +39,8 @@ public class FornecedorService {
 
         Pageable pageable = PageRequest.of(pesquisa.getPage(), pesquisa.getPageSize(), Sort.by(direction, sortBy));
 
-        // Realiza a busca no repositório com os filtros definidos e associando o usuário logado
+        // Realiza a busca no repositório com os filtros definidos
         return fornecedorRepository.buscarFornecedores(
-                loggedUser.getId(),
                 pesquisa.getId(),
                 pesquisa.getNome(),
                 pesquisa.getCpfOuCnpj(),
@@ -54,7 +53,7 @@ public class FornecedorService {
     }
 
     public Fornecedor listarUmFornecedor(User loggedUser, Integer idFornecedor) {
-        return fornecedorRepository.findByIdAndOwnerUserAndAtivoTrue(idFornecedor, loggedUser)
+        return fornecedorRepository.findByIdAndAtivoTrue(idFornecedor)
                 .orElseThrow(() -> new EntityNotFoundException("Fornecedor não encontrado"));
     }
 
@@ -87,7 +86,7 @@ public class FornecedorService {
 
     @CacheEvict(value = "fornecedores", allEntries = true)
     public Fornecedor reativarFornecedor(User loggedUser, Integer idFornecedor) {
-        Fornecedor fornecedor = fornecedorRepository.findByIdAndOwnerUser(idFornecedor, loggedUser)
+        Fornecedor fornecedor = fornecedorRepository.findById(idFornecedor)
                 .orElseThrow(() -> new EntityNotFoundException("Fornecedor não encontrado"));
         fornecedor.setAtivo(true);
         return fornecedorRepository.save(fornecedor);
@@ -95,7 +94,7 @@ public class FornecedorService {
 
     @CacheEvict(value = "fornecedores", allEntries = true)
     public void removerFornecedor(User loggedUser, Integer idFornecedor) {
-        Fornecedor fornecedor = fornecedorRepository.findByIdAndOwnerUser(idFornecedor, loggedUser)
+        Fornecedor fornecedor = fornecedorRepository.findById(idFornecedor)
                 .orElseThrow(() -> new EntityNotFoundException("Fornecedor não encontrado"));
         fornecedorRepository.delete(fornecedor);
     }

--- a/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
@@ -35,12 +35,12 @@ public class ProdutoService {
 
         Pageable pageable = PageRequest.of(pesquisa.getPage(), pesquisa.getPageSize(), Sort.by(direction, sortBy));
 
-        return produtoRepository.findAllByOwnerUserAndAtivoTrue(loggedUser, pageable)
+        return produtoRepository.findAllByAtivoTrue(pageable)
                 .map(this::toResponse);
     }
 
     public ProdutoResponse listarUmProduto(User loggedUser, Integer idProduto) {
-        Produto produto = buscarProdutoAtivo(loggedUser, idProduto);
+        Produto produto = buscarProdutoAtivo(idProduto);
         return toResponse(produto);
     }
 
@@ -57,7 +57,7 @@ public class ProdutoService {
     @Transactional
     @CacheEvict(value = "produtos", key = "#loggedUser.id")
     public ProdutoResponse editarProduto(User loggedUser, Integer idProduto, ProdutoRequest request) {
-        Produto produtoSalvo = buscarProdutoAtivo(loggedUser, idProduto);
+        Produto produtoSalvo = buscarProdutoAtivo(idProduto);
         Produto produto = produtoMapper.toEntity(request);
         produto.setId(produtoSalvo.getId());
         produto.setOwnerUser(produtoSalvo.getOwnerUser());
@@ -68,30 +68,30 @@ public class ProdutoService {
     @Transactional
     @CacheEvict(value = "produtos", key = "#loggedUser.id")
     public void excluirProduto(User loggedUser, Integer idProduto) {
-        Produto produto = buscarProdutoAtivo(loggedUser, idProduto);
+        Produto produto = buscarProdutoAtivo(idProduto);
         produto.setAtivo(false);
         produtoRepository.save(produto);
     }
 
     public ProdutoResponse restaurarProduto(User loggedUser, Integer idProduto) {
-        Produto produto = buscarProduto(loggedUser, idProduto);
+        Produto produto = buscarProduto(idProduto);
         produto.setAtivo(true);
         Produto atualizado = produtoRepository.save(produto);
         return toResponse(atualizado);
     }
 
     public void removerProduto(User loggedUser, Integer idProduto) {
-        Produto produto = buscarProduto(loggedUser, idProduto);
+        Produto produto = buscarProduto(idProduto);
         produtoRepository.delete(produto);
     }
 
-    private Produto buscarProduto(User loggedUser, Integer idProduto) {
-        return produtoRepository.findByIdAndOwnerUser(idProduto, loggedUser)
+    private Produto buscarProduto(Integer idProduto) {
+        return produtoRepository.findById(idProduto)
                 .orElseThrow(() -> new EntityNotFoundException("Produto não encontrado"));
     }
 
-    public Produto buscarProdutoAtivo(User loggedUser, Integer idProduto) {
-        return produtoRepository.findByIdAndOwnerUserAndAtivoTrue(idProduto, loggedUser)
+    public Produto buscarProdutoAtivo(Integer idProduto) {
+        return produtoRepository.findByIdAndAtivoTrue(idProduto)
                 .orElseThrow(() -> new EntityNotFoundException("Produto não encontrado"));
     }
 

--- a/src/main/java/com/AIT/Optimanage/Services/ServicoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ServicoService.java
@@ -35,12 +35,12 @@ public class ServicoService {
 
         Pageable pageable = PageRequest.of(pesquisa.getPage(), pesquisa.getPageSize(), Sort.by(direction, sortBy));
 
-        return servicoRepository.findAllByOwnerUserAndAtivoTrue(loggedUser, pageable)
+        return servicoRepository.findAllByAtivoTrue(pageable)
                 .map(servicoMapper::toResponse);
     }
 
     public ServicoResponse listarUmServico(User loggedUser, Integer idServico) {
-        Servico servico = buscarServicoAtivo(loggedUser, idServico);
+        Servico servico = buscarServicoAtivo(idServico);
         return servicoMapper.toResponse(servico);
     }
 
@@ -57,7 +57,7 @@ public class ServicoService {
     @Transactional
     @CacheEvict(value = "servicos", key = "#loggedUser.id")
     public ServicoResponse editarServico(User loggedUser, Integer idServico, ServicoRequest request) {
-        Servico servicoSalvo = buscarServicoAtivo(loggedUser, idServico);
+        Servico servicoSalvo = buscarServicoAtivo(idServico);
         Servico servico = servicoMapper.toEntity(request);
         servico.setId(servicoSalvo.getId());
         servico.setOwnerUser(servicoSalvo.getOwnerUser());
@@ -68,30 +68,30 @@ public class ServicoService {
     @Transactional
     @CacheEvict(value = "servicos", key = "#loggedUser.id")
     public void excluirServico(User loggedUser, Integer idServico) {
-        Servico servico = buscarServicoAtivo(loggedUser, idServico);
+        Servico servico = buscarServicoAtivo(idServico);
         servico.setAtivo(false);
         servicoRepository.save(servico);
     }
 
     public ServicoResponse restaurarServico(User loggedUser, Integer idServico) {
-        Servico servico = buscarServico(loggedUser, idServico);
+        Servico servico = buscarServico(idServico);
         servico.setAtivo(true);
         Servico atualizado = servicoRepository.save(servico);
         return servicoMapper.toResponse(atualizado);
     }
 
     public void removerServico(User loggedUser, Integer idServico) {
-        Servico servico = buscarServico(loggedUser, idServico);
+        Servico servico = buscarServico(idServico);
         servicoRepository.delete(servico);
     }
 
-    private Servico buscarServico(User loggedUser, Integer idServico) {
-        return servicoRepository.findByIdAndOwnerUser(idServico, loggedUser)
+    private Servico buscarServico(Integer idServico) {
+        return servicoRepository.findById(idServico)
                 .orElseThrow(() -> new EntityNotFoundException("Servico não encontrado"));
     }
 
-    public Servico buscarServicoAtivo(User loggedUser, Integer idServico) {
-        return servicoRepository.findByIdAndOwnerUserAndAtivoTrue(idServico, loggedUser)
+    public Servico buscarServicoAtivo(Integer idServico) {
+        return servicoRepository.findByIdAndAtivoTrue(idServico)
                 .orElseThrow(() -> new EntityNotFoundException("Servico não encontrado"));
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Services/User/ContadorService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/User/ContadorService.java
@@ -14,7 +14,7 @@ public class ContadorService {
     private final ContadorRepository contadorRepository;
 
     public Contador BuscarContador(Tabela tabela, User loggedUser) {
-        Contador contador = contadorRepository.getByNomeTabelaAndOwnerUser(tabela, loggedUser);
+        Contador contador = contadorRepository.getByNomeTabela(tabela);
         if (contador == null) {
             return contadorRepository.save(Contador.builder()
                     .ownerUser(loggedUser)
@@ -27,7 +27,7 @@ public class ContadorService {
     }
 
     public void IncrementarContador(Tabela tabela, User ownerUser) {
-        Contador contador = contadorRepository.getByNomeTabelaAndOwnerUser(tabela, ownerUser);
+        Contador contador = contadorRepository.getByNomeTabela(tabela);
         contador.setContagemAtual(contador.getContagemAtual() + 1);
         contadorRepository.save(contador);
     }

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/CompatibilidadeService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/CompatibilidadeService.java
@@ -30,8 +30,8 @@ public class CompatibilidadeService {
         ContextoCompatibilidade contexto = contextoCompatibilidadeService.listarUmContexto(logedUser, request.getContextoId());
 
         Compatibilidade compatibilidade = Compatibilidade.builder()
-                .produto(request.getProdutoId() != null ? produtoService.buscarProdutoAtivo(logedUser, request.getProdutoId()) : null)
-                .servico(request.getServicoId() != null ? servicoService.buscarServicoAtivo(logedUser, request.getServicoId()) : null)
+                .produto(request.getProdutoId() != null ? produtoService.buscarProdutoAtivo(request.getProdutoId()) : null)
+                .servico(request.getServicoId() != null ? servicoService.buscarServicoAtivo(request.getServicoId()) : null)
                 .contexto(contexto)
                 .compativel(request.getCompativel())
                 .build();

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/ContextoCompatibilidadeService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/ContextoCompatibilidadeService.java
@@ -14,7 +14,7 @@ public class ContextoCompatibilidadeService {
     private final ContextoCompatibilidadeRepository contextoRepository;
 
     public ContextoCompatibilidade listarContextos(User loggedUser) {
-        return contextoRepository.findByOwnerUser(loggedUser)
+        return contextoRepository.findFirstByOrderByIdAsc()
                 .orElseThrow(() -> new RuntimeException("Contexto não encontrado!"));
     }
 
@@ -24,12 +24,12 @@ public class ContextoCompatibilidadeService {
     }
 
     public ContextoCompatibilidade listarUmContextoPorNome(User loggedUser, String nomeContexto) {
-        return contextoRepository.findByOwnerUserAndNome(loggedUser, nomeContexto)
+        return contextoRepository.findByNome(nomeContexto)
                 .orElseThrow(() -> new RuntimeException("Contexto não encontrado!"));
     }
 
     public ContextoCompatibilidade criarContexto(User logedUser, ContextoCompatibilidadeDTO request) {
-        ContextoCompatibilidade contexto = listarUmContextoPorNome(logedUser, request.getNome());
+        ContextoCompatibilidade contexto = contextoRepository.findByNome(request.getNome()).orElse(null);
         if (contexto != null) {
             throw new RuntimeException("Contexto já existe!");
         } else {

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -64,9 +64,8 @@ public class VendaService {
         String sortBy = Optional.ofNullable(pesquisa.getSort()).orElse("id");
         Pageable pageable = PageRequest.of(pesquisa.getPage(), pesquisa.getPageSize(), Sort.by(direction, sortBy));
 
-        // Realiza a busca no repositório com os filtros definidos e associando o usuario logado
+        // Realiza a busca no repositório com os filtros definidos
         return vendaRepository.buscarVendas(
-                loggedUser.getId(),
                 pesquisa.getId(),
                 pesquisa.getClienteId(),
                 pesquisa.getDataInicial(),
@@ -78,7 +77,7 @@ public class VendaService {
     }
 
     public Venda listarUmaVenda(User loggedUser, Integer idVenda) {
-        return vendaRepository.findByIdAndOwnerUser(idVenda, loggedUser)
+        return vendaRepository.findById(idVenda)
                 .orElseThrow(() -> new EntityNotFoundException("Venda não encontrada"));
     }
 
@@ -319,7 +318,7 @@ public class VendaService {
     private List<VendaProduto> criarListaProdutos(List<VendaProdutoDTO> produtosDTO, Venda venda) {
         return produtosDTO.stream()
                 .map(produtoDTO -> {
-                    Produto produto = produtoService.buscarProdutoAtivo(venda.getOwnerUser(), produtoDTO.getProdutoId());
+                    Produto produto = produtoService.buscarProdutoAtivo(produtoDTO.getProdutoId());
                     BigDecimal valorProduto = produto.getValorVenda().multiply(BigDecimal.valueOf(produtoDTO.getQuantidade()));
                     BigDecimal descontoProduto = valorProduto
                             .multiply(produtoDTO.getDesconto().divide(BigDecimal.valueOf(100)));
@@ -340,7 +339,7 @@ public class VendaService {
     private List<VendaServico> criarListaServicos(List<VendaServicoDTO> servicosDTO, Venda venda) {
         return servicosDTO.stream()
             .map(servicoDTO -> {
-                Servico servico = servicoService.buscarServicoAtivo(venda.getOwnerUser(), servicoDTO.getServicoId());
+                Servico servico = servicoService.buscarServicoAtivo(servicoDTO.getServicoId());
                 BigDecimal valorServico = servico.getValorVenda().multiply(BigDecimal.valueOf(servicoDTO.getQuantidade()));
                 BigDecimal descontoServico = valorServico
                         .multiply(servicoDTO.getDesconto().divide(BigDecimal.valueOf(100)));


### PR DESCRIPTION
## Summary
- add servlet filter enabling Hibernate ownerUser filter
- annotate entities and repositories to automatically scope data by ownerUser
- drop manual ownerUser filtering in services and queries

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d5952c108324bf2baba2056be2e9