### PR TITLE
feat: add owner entity listener

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Atividade.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Atividade.java
@@ -6,6 +6,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -14,6 +15,7 @@ import com.AIT.Optimanage.Models.BaseEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(OwnerEntityListener.class)
 public class Atividade extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Audit/OwnerEntityListener.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Audit/OwnerEntityListener.java
@@ -1,0 +1,37 @@
+package com.AIT.Optimanage.Models.Audit;
+
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Support.CurrentUser;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+
+import java.lang.reflect.Method;
+
+public class OwnerEntityListener {
+
+    @PrePersist
+    public void prePersist(Object entity) {
+        setOwnerUser(entity);
+    }
+
+    @PreUpdate
+    public void preUpdate(Object entity) {
+        setOwnerUser(entity);
+    }
+
+    private void setOwnerUser(Object entity) {
+        try {
+            Method getOwner = entity.getClass().getMethod("getOwnerUser");
+            Object owner = getOwner.invoke(entity);
+            if (owner == null) {
+                Method setOwner = entity.getClass().getMethod("setOwnerUser", User.class);
+                User current = CurrentUser.get();
+                if (current != null) {
+                    setOwner.invoke(entity, current);
+                }
+            }
+        } catch (Exception e) {
+            // ignore entities without ownerUser or reflection issues
+        }
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
@@ -6,6 +6,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -17,6 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(OwnerEntityListener.class)
 public class Cliente extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
@@ -6,6 +6,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
@@ -19,6 +20,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(OwnerEntityListener.class)
 public class Compra extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
@@ -6,6 +6,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -19,6 +20,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(OwnerEntityListener.class)
 public class Fornecedor extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Funcionario.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Funcionario.java
@@ -4,6 +4,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -12,6 +13,7 @@ import com.AIT.Optimanage.Models.BaseEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(OwnerEntityListener.class)
 public class Funcionario extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Produto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Produto.java
@@ -6,6 +6,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -17,6 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(OwnerEntityListener.class)
 public class Produto extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Servico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Servico.java
@@ -6,6 +6,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -17,6 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(OwnerEntityListener.class)
 public class Servico extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
@@ -3,6 +3,7 @@ package com.AIT.Optimanage.Models.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -11,6 +12,7 @@ import com.AIT.Optimanage.Models.BaseEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(OwnerEntityListener.class)
 public class Contador extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/User/UserInfo.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/UserInfo.java
@@ -5,6 +5,7 @@ import com.AIT.Optimanage.Models.BaseEntity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,6 +18,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(OwnerEntityListener.class)
 public class UserInfo extends BaseEntity {
     @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Compatibilidade/ContextoCompatibilidade.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Compatibilidade/ContextoCompatibilidade.java
@@ -3,6 +3,7 @@ package com.AIT.Optimanage.Models.Venda.Compatibilidade;
 import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
+import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,6 +15,7 @@ import com.AIT.Optimanage.Models.BaseEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(OwnerEntityListener.class)
 public class ContextoCompatibilidade extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
@@ -7,6 +7,7 @@ import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
@@ -20,6 +21,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(OwnerEntityListener.class)
 public class Venda extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
@@ -62,7 +62,6 @@ public class ClienteService {
     public Cliente criarCliente(User loggedUser, ClienteRequest request) {
         Cliente cliente = fromRequest(request);
         cliente.setId(null);
-        cliente.setOwnerUser(loggedUser);
         cliente.setDataCadastro(LocalDate.now());
         validarCliente(loggedUser, cliente);
         return clienteRepository.save(cliente);
@@ -74,7 +73,6 @@ public class ClienteService {
         Cliente clienteSalvo = listarUmCliente(loggedUser, idCliente);
         Cliente cliente = fromRequest(request);
         cliente.setId(clienteSalvo.getId());
-        cliente.setOwnerUser(clienteSalvo.getOwnerUser());
         cliente.setDataCadastro(clienteSalvo.getDataCadastro());
         validarCliente(loggedUser, cliente);
         return clienteRepository.save(cliente);

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -94,7 +94,6 @@ public class CompraService {
         Fornecedor fornecedor = fornecedorService.listarUmFornecedor(loggedUser, compraDTO.getFornecedorId());
         Contador contador = contadorService.BuscarContador(Tabela.COMPRA, loggedUser);
         Compra novaCompra = Compra.builder()
-                .ownerUser(loggedUser)
                 .fornecedor(fornecedor)
                 .sequencialUsuario(contador.getContagemAtual())
                 .dataEfetuacao(compraDTO.getDataEfetuacao())
@@ -144,7 +143,6 @@ public class CompraService {
 
         Compra compra = listarUmaCompra(loggedUser, idCompra);
         Compra compraAtualizada = Compra.builder()
-                .ownerUser(loggedUser)
                 .fornecedor(compra.getFornecedor())
                 .sequencialUsuario(compra.getSequencialUsuario())
                 .dataEfetuacao(compraDTO.getDataEfetuacao())

--- a/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
@@ -61,7 +61,6 @@ public class FornecedorService {
     @CacheEvict(value = "fornecedores", allEntries = true)
     public Fornecedor criarFornecedor(User loggedUser, FornecedorRequest request) {
         Fornecedor fornecedor = fromRequest(request);
-        fornecedor.setOwnerUser(loggedUser);
         fornecedor.setDataCadastro(LocalDate.now());
         validarFornecedor(loggedUser, fornecedor);
         return fornecedorRepository.save(fornecedor);
@@ -72,7 +71,6 @@ public class FornecedorService {
         Fornecedor fornecedorSalvo = listarUmFornecedor(loggedUser, idFornecedor);
         Fornecedor fornecedor = fromRequest(request);
         fornecedor.setId(fornecedorSalvo.getId());
-        fornecedor.setOwnerUser(fornecedorSalvo.getOwnerUser());
         fornecedor.setDataCadastro(fornecedorSalvo.getDataCadastro());
         validarFornecedor(loggedUser, fornecedor);
         return fornecedorRepository.save(fornecedor);

--- a/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
@@ -49,7 +49,6 @@ public class ProdutoService {
     public ProdutoResponse cadastrarProduto(User loggedUser, ProdutoRequest request) {
         Produto produto = produtoMapper.toEntity(request);
         produto.setId(null);
-        produto.setOwnerUser(loggedUser);
         Produto salvo = produtoRepository.save(produto);
         return toResponse(salvo);
     }
@@ -60,7 +59,6 @@ public class ProdutoService {
         Produto produtoSalvo = buscarProdutoAtivo(loggedUser, idProduto);
         Produto produto = produtoMapper.toEntity(request);
         produto.setId(produtoSalvo.getId());
-        produto.setOwnerUser(produtoSalvo.getOwnerUser());
         Produto atualizado = produtoRepository.save(produto);
         return toResponse(atualizado);
     }

--- a/src/main/java/com/AIT/Optimanage/Services/ServicoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ServicoService.java
@@ -49,7 +49,6 @@ public class ServicoService {
     public ServicoResponse cadastrarServico(User loggedUser, ServicoRequest request) {
         Servico servico = servicoMapper.toEntity(request);
         servico.setId(null);
-        servico.setOwnerUser(loggedUser);
         Servico salvo = servicoRepository.save(servico);
         return servicoMapper.toResponse(salvo);
     }
@@ -60,7 +59,6 @@ public class ServicoService {
         Servico servicoSalvo = buscarServicoAtivo(loggedUser, idServico);
         Servico servico = servicoMapper.toEntity(request);
         servico.setId(servicoSalvo.getId());
-        servico.setOwnerUser(servicoSalvo.getOwnerUser());
         Servico atualizado = servicoRepository.save(servico);
         return servicoMapper.toResponse(atualizado);
     }

--- a/src/main/java/com/AIT/Optimanage/Services/User/ContadorService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/User/ContadorService.java
@@ -17,7 +17,6 @@ public class ContadorService {
         Contador contador = contadorRepository.getByNomeTabelaAndOwnerUser(tabela, loggedUser);
         if (contador == null) {
             return contadorRepository.save(Contador.builder()
-                    .ownerUser(loggedUser)
                     .nomeTabela(tabela)
                     .contagemAtual(1)
                     .build()

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/ContextoCompatibilidadeService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/ContextoCompatibilidadeService.java
@@ -34,7 +34,6 @@ public class ContextoCompatibilidadeService {
             throw new RuntimeException("Contexto já existe!");
         } else {
             return contextoRepository.save(ContextoCompatibilidade.builder()
-                    .ownerUser(logedUser)
                     .nome(request.getNome())
                     .build());
             }

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -94,7 +94,6 @@ public class VendaService {
         Cliente cliente = clienteService.listarUmCliente(loggedUser, vendaDTO.getClienteId());
         Contador contador = contadorService.BuscarContador(Tabela.VENDA, loggedUser);
         Venda novaVenda = Venda.builder()
-                .ownerUser(loggedUser)
                 .cliente(cliente)
                 .sequencialUsuario(contador.getContagemAtual())
                 .dataEfetuacao(vendaDTO.getDataEfetuacao())
@@ -155,7 +154,6 @@ public class VendaService {
 
         Venda venda = listarUmaVenda(loggedUser, vendaId);
         Venda vendaAtualizada = Venda.builder()
-                .ownerUser(loggedUser)
                 .cliente(venda.getCliente())
                 .sequencialUsuario(venda.getSequencialUsuario())
                 .dataEfetuacao(vendaDTO.getDataEfetuacao())

--- a/src/main/java/com/AIT/Optimanage/Support/CurrentUser.java
+++ b/src/main/java/com/AIT/Optimanage/Support/CurrentUser.java
@@ -1,0 +1,19 @@
+package com.AIT.Optimanage.Support;
+
+import com.AIT.Optimanage.Models.User.User;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public final class CurrentUser {
+
+    private CurrentUser() {
+    }
+
+    public static User get() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof User user) {
+            return user;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add `OwnerEntityListener` to automatically set `ownerUser` using `CurrentUser`
- annotate entities with listener and drop manual owner assignment in services

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68b89db5b6ac832497cf63a5c9d54480