### PR TITLE
Add OwnableEntity interface and simplify owner listener

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Atividade.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Atividade.java
@@ -16,7 +16,7 @@ import com.AIT.Optimanage.Models.BaseEntity;
 @AllArgsConstructor
 @Entity
 @EntityListeners(OwnerEntityListener.class)
-public class Atividade extends BaseEntity {
+public class Atividade extends BaseEntity implements OwnableEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = true)

--- a/src/main/java/com/AIT/Optimanage/Models/Audit/OwnerEntityListener.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Audit/OwnerEntityListener.java
@@ -1,11 +1,10 @@
 package com.AIT.Optimanage.Models.Audit;
 
+import com.AIT.Optimanage.Models.OwnableEntity;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Support.CurrentUser;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
-
-import java.lang.reflect.Method;
 
 public class OwnerEntityListener {
 
@@ -20,18 +19,14 @@ public class OwnerEntityListener {
     }
 
     private void setOwnerUser(Object entity) {
-        try {
-            Method getOwner = entity.getClass().getMethod("getOwnerUser");
-            Object owner = getOwner.invoke(entity);
-            if (owner == null) {
-                Method setOwner = entity.getClass().getMethod("setOwnerUser", User.class);
+        if (entity instanceof OwnableEntity) {
+            OwnableEntity ownable = (OwnableEntity) entity;
+            if (ownable.getOwnerUser() == null) {
                 User current = CurrentUser.get();
                 if (current != null) {
-                    setOwner.invoke(entity, current);
+                    ownable.setOwnerUser(current);
                 }
             }
-        } catch (Exception e) {
-            // ignore entities without ownerUser or reflection issues
         }
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
+import com.AIT.Optimanage.Models.OwnableEntity;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -19,7 +20,7 @@ import java.util.List;
 @AllArgsConstructor
 @Entity
 @EntityListeners(OwnerEntityListener.class)
-public class Cliente extends BaseEntity {
+public class Cliente extends BaseEntity implements OwnableEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
+import com.AIT.Optimanage.Models.OwnableEntity;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
@@ -21,7 +22,7 @@ import java.util.List;
 @AllArgsConstructor
 @Entity
 @EntityListeners(OwnerEntityListener.class)
-public class Compra extends BaseEntity {
+public class Compra extends BaseEntity implements OwnableEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
+import com.AIT.Optimanage.Models.OwnableEntity;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -21,7 +22,7 @@ import java.util.List;
 @AllArgsConstructor
 @Entity
 @EntityListeners(OwnerEntityListener.class)
-public class Fornecedor extends BaseEntity {
+public class Fornecedor extends BaseEntity implements OwnableEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Funcionario.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Funcionario.java
@@ -14,7 +14,7 @@ import com.AIT.Optimanage.Models.BaseEntity;
 @AllArgsConstructor
 @Entity
 @EntityListeners(OwnerEntityListener.class)
-public class Funcionario extends BaseEntity {
+public class Funcionario extends BaseEntity implements OwnableEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/OwnableEntity.java
+++ b/src/main/java/com/AIT/Optimanage/Models/OwnableEntity.java
@@ -1,0 +1,11 @@
+package com.AIT.Optimanage.Models;
+
+import com.AIT.Optimanage.Models.User.User;
+
+/**
+ * Contract for entities that are owned by a {@link User}.
+ */
+public interface OwnableEntity {
+    User getOwnerUser();
+    void setOwnerUser(User ownerUser);
+}

--- a/src/main/java/com/AIT/Optimanage/Models/Produto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Produto.java
@@ -19,7 +19,7 @@ import java.util.List;
 @AllArgsConstructor
 @Entity
 @EntityListeners(OwnerEntityListener.class)
-public class Produto extends BaseEntity {
+public class Produto extends BaseEntity implements OwnableEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Servico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Servico.java
@@ -19,7 +19,7 @@ import java.util.List;
 @AllArgsConstructor
 @Entity
 @EntityListeners(OwnerEntityListener.class)
-public class Servico extends BaseEntity {
+public class Servico extends BaseEntity implements OwnableEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
+import com.AIT.Optimanage.Models.OwnableEntity;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
 
@@ -13,7 +14,7 @@ import com.AIT.Optimanage.Models.BaseEntity;
 @AllArgsConstructor
 @Entity
 @EntityListeners(OwnerEntityListener.class)
-public class Contador extends BaseEntity {
+public class Contador extends BaseEntity implements OwnableEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/User/UserInfo.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/UserInfo.java
@@ -2,6 +2,7 @@ package com.AIT.Optimanage.Models.User;
 
 import com.AIT.Optimanage.Models.Plano;
 import com.AIT.Optimanage.Models.BaseEntity;
+import com.AIT.Optimanage.Models.OwnableEntity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
@@ -19,7 +20,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Entity
 @EntityListeners(OwnerEntityListener.class)
-public class UserInfo extends BaseEntity {
+public class UserInfo extends BaseEntity implements OwnableEntity {
     @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Compatibilidade/ContextoCompatibilidade.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Compatibilidade/ContextoCompatibilidade.java
@@ -4,6 +4,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
+import com.AIT.Optimanage.Models.OwnableEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,7 +17,7 @@ import com.AIT.Optimanage.Models.BaseEntity;
 @AllArgsConstructor
 @Entity
 @EntityListeners(OwnerEntityListener.class)
-public class ContextoCompatibilidade extends BaseEntity {
+public class ContextoCompatibilidade extends BaseEntity implements OwnableEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
+import com.AIT.Optimanage.Models.OwnableEntity;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import com.AIT.Optimanage.Models.BaseEntity;
@@ -22,7 +23,7 @@ import java.util.List;
 @AllArgsConstructor
 @Entity
 @EntityListeners(OwnerEntityListener.class)
-public class Venda extends BaseEntity {
+public class Venda extends BaseEntity implements OwnableEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)

--- a/src/test/java/com/AIT/Optimanage/Models/Audit/OwnerEntityListenerTest.java
+++ b/src/test/java/com/AIT/Optimanage/Models/Audit/OwnerEntityListenerTest.java
@@ -1,0 +1,55 @@
+package com.AIT.Optimanage.Models.Audit;
+
+import com.AIT.Optimanage.Models.User.Role;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Models.Venda.Compatibilidade.ContextoCompatibilidade;
+import com.AIT.Optimanage.Support.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@EnableJpaAuditing
+class OwnerEntityListenerTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        TenantContext.clear();
+    }
+
+    @Test
+    void prePersistSetsOwnerUserWhenNull() {
+        TenantContext.setTenantId(1);
+        User user = User.builder()
+                .nome("John")
+                .sobrenome("Doe")
+                .email("john@example.com")
+                .senha("password")
+                .role(Role.USER)
+                .build();
+        entityManager.persistAndFlush(user);
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(user, null)
+        );
+
+        ContextoCompatibilidade ctx = new ContextoCompatibilidade();
+        ctx.setNome("Example");
+
+        ctx = entityManager.persistAndFlush(ctx);
+
+        assertNotNull(ctx.getOwnerUser());
+        assertEquals(user.getId(), ctx.getOwnerUser().getId());
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `OwnableEntity` interface defining `getOwnerUser`/`setOwnerUser`
- Update all owner-aware entities to implement `OwnableEntity`
- Refactor `OwnerEntityListener` to use the new interface instead of reflection
- Add JPA test verifying owner data population

## Testing
- `mvn -q -Dtest=OwnerEntityListenerTest test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f136171c832489829cfa16bf536e