### PR TITLE
Register rate limiting filter using Bucket4j

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Config/ApplicationConfig.java
+++ b/src/main/java/com/AIT/Optimanage/Config/ApplicationConfig.java
@@ -2,6 +2,8 @@ package com.AIT.Optimanage.Config;
 
 import com.AIT.Optimanage.Repositories.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.core.Ordered;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -10,6 +12,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Collections;
 
 @Configuration
 @RequiredArgsConstructor
@@ -31,5 +35,14 @@ public class ApplicationConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public FilterRegistrationBean<RateLimitingFilter> rateLimitingFilterRegistration(RateLimitingFilter rateLimitingFilter) {
+        FilterRegistrationBean<RateLimitingFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(rateLimitingFilter);
+        registrationBean.setUrlPatterns(Collections.singletonList("/*"));
+        registrationBean.setOrder(Ordered.LOWEST_PRECEDENCE);
+        return registrationBean;
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Config/SecurityConfig.java
+++ b/src/main/java/com/AIT/Optimanage/Config/SecurityConfig.java
@@ -24,7 +24,6 @@ import org.springframework.security.web.context.SecurityContextHolderFilter;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthFilter;
-    private final RateLimitingFilter rateLimitingFilter;
     private final TenantFilter tenantFilter;
 
     @Bean
@@ -57,7 +56,6 @@ public class SecurityConfig {
                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .addFilterBefore(tenantFilter, SecurityContextHolderFilter.class)
-                .addFilterAfter(rateLimitingFilter, SecurityContextHolderFilter.class)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();


### PR DESCRIPTION
## Summary
- register RateLimitingFilter via FilterRegistrationBean for request throttling
- simplify SecurityConfig now that filter is registered globally

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dd946f108324a849ea93f9955dc9