### PR TITLE
Add PIX payment provider

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Payment/PaymentProvider.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Payment/PaymentProvider.java
@@ -2,5 +2,6 @@ package com.AIT.Optimanage.Models.Payment;
 
 public enum PaymentProvider {
     STRIPE,
-    BOLETO
+    BOLETO,
+    PIX
 }

--- a/src/main/java/com/AIT/Optimanage/Payments/PaymentRequestDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Payments/PaymentRequestDTO.java
@@ -20,5 +20,6 @@ public class PaymentRequestDTO {
     private BigDecimal amount;
     private String currency;
     private String description;
+    @NotNull
     private PaymentProvider provider;
 }

--- a/src/main/java/com/AIT/Optimanage/Payments/PaymentService.java
+++ b/src/main/java/com/AIT/Optimanage/Payments/PaymentService.java
@@ -22,7 +22,7 @@ public class PaymentService {
     }
 
     public PaymentResponseDTO createPayment(PaymentRequestDTO request, PaymentConfig config) {
-        return getProvider(config.getProvider()).createPayment(request, config);
+        return getProvider(request.getProvider()).createPayment(request, config);
     }
 
     public PagamentoDTO confirmPayment(String paymentIntentId, PaymentConfig config) {

--- a/src/main/java/com/AIT/Optimanage/Payments/Providers/PixPaymentProvider.java
+++ b/src/main/java/com/AIT/Optimanage/Payments/Providers/PixPaymentProvider.java
@@ -1,0 +1,26 @@
+package com.AIT.Optimanage.Payments.Providers;
+
+import com.AIT.Optimanage.Models.PagamentoDTO;
+import com.AIT.Optimanage.Models.Payment.PaymentConfig;
+import com.AIT.Optimanage.Models.Payment.PaymentProvider;
+import com.AIT.Optimanage.Payments.PaymentRequestDTO;
+import com.AIT.Optimanage.Payments.PaymentResponseDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PixPaymentProvider implements PaymentProviderStrategy {
+    @Override
+    public PaymentProvider getProvider() {
+        return PaymentProvider.PIX;
+    }
+
+    @Override
+    public PaymentResponseDTO createPayment(PaymentRequestDTO request, PaymentConfig config) {
+        throw new UnsupportedOperationException("PIX não implementado");
+    }
+
+    @Override
+    public PagamentoDTO confirmPayment(String paymentIntentId, PaymentConfig config) {
+        throw new UnsupportedOperationException("PIX não implementado");
+    }
+}


### PR DESCRIPTION
## Summary
- add PIX option to PaymentProvider enum and validate provider in requests
- support selecting provider from request in PaymentService
- stub PixPaymentProvider strategy implementation

## Testing
- ⚠️ `./mvnw -q test` *(failed: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baf0ab8d788324bcf13ced6aff6802