### PR TITLE
Propagate tenant context to async tasks

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Config/AsyncConfig.java
+++ b/src/main/java/com/AIT/Optimanage/Config/AsyncConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import com.AIT.Optimanage.Support.TenantTaskDecorator;
+
 import java.util.concurrent.Executor;
 
 @Configuration
@@ -18,6 +20,7 @@ public class AsyncConfig {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("Async-");
+        executor.setTaskDecorator(new TenantTaskDecorator());
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/AIT/Optimanage/Support/TenantTaskDecorator.java
+++ b/src/main/java/com/AIT/Optimanage/Support/TenantTaskDecorator.java
@@ -1,0 +1,25 @@
+package com.AIT.Optimanage.Support;
+
+import org.springframework.core.task.TaskDecorator;
+
+/**
+ * Propagates the current {@link TenantContext} to async threads.
+ */
+public class TenantTaskDecorator implements TaskDecorator {
+
+    @Override
+    public Runnable decorate(Runnable runnable) {
+        Integer tenantId = TenantContext.getTenantId();
+        return () -> {
+            try {
+                if (tenantId != null) {
+                    TenantContext.setTenantId(tenantId);
+                }
+                runnable.run();
+            } finally {
+                TenantContext.clear();
+            }
+        };
+    }
+}
+


### PR DESCRIPTION
## Summary
- add TenantTaskDecorator to propagate TenantContext to async threads
- register decorator with task executor to copy and clear tenant id

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2ddb49148324859bfc1f7f15648e