### PR TITLE
feat: improve cache key generation

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
@@ -28,7 +28,7 @@ public class ClienteService {
 
     private final ClienteRepository clienteRepository;
 
-    @Cacheable(value = "clientes", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId() + '-' + #pesquisa.hashCode()")
+    @Cacheable(value = "clientes", key = "T(com.AIT.Optimanage.Support.CacheKeyUtils).generateKey(#pesquisa)")
     @Transactional(readOnly = true)
     public Page<Cliente> listarClientes(ClienteSearch pesquisa) {
         User loggedUser = CurrentUser.get();

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -58,7 +58,7 @@ public class CompraService {
     private final PagamentoCompraService pagamentoCompraService;
     private final ProdutoRepository produtoRepository;
 
-    @Cacheable(value = "compras", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId() + '-' + #pesquisa.hashCode()")
+    @Cacheable(value = "compras", key = "T(com.AIT.Optimanage.Support.CacheKeyUtils).generateKey(#pesquisa)")
     @Transactional(readOnly = true)
     public Page<Compra> listarCompras(CompraSearch pesquisa) {
         User loggedUser = CurrentUser.get();

--- a/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
@@ -29,7 +29,7 @@ public class FornecedorService {
 
     private final FornecedorRepository fornecedorRepository;
 
-    @Cacheable(value = "fornecedores", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId() + '-' + #pesquisa.hashCode()")
+    @Cacheable(value = "fornecedores", key = "T(com.AIT.Optimanage.Support.CacheKeyUtils).generateKey(#pesquisa)")
     @Transactional(readOnly = true)
     public Page<Fornecedor> listarFornecedores(FornecedorSearch pesquisa) {
         User loggedUser = CurrentUser.get();

--- a/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
@@ -27,7 +27,7 @@ public class ProdutoService {
     private final ProdutoRepository produtoRepository;
     private final ProdutoMapper produtoMapper;
 
-    @Cacheable(value = "produtos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId() + '-' + #pesquisa.hashCode()")
+    @Cacheable(value = "produtos", key = "T(com.AIT.Optimanage.Support.CacheKeyUtils).generateKey(#pesquisa)")
     public Page<ProdutoResponse> listarProdutos(Search pesquisa) {
         User loggedUser = CurrentUser.get();
         Sort.Direction direction = Optional.ofNullable(pesquisa.getOrder()).filter(Sort.Direction::isDescending)
@@ -47,7 +47,7 @@ public class ProdutoService {
     }
 
     @Transactional
-    @CacheEvict(value = "produtos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId()")
+    @CacheEvict(value = "produtos", key = "T(com.AIT.Optimanage.Support.CacheKeyUtils).generateKey()")
     public ProdutoResponse cadastrarProduto(ProdutoRequest request) {
         User loggedUser = CurrentUser.get();
         Produto produto = produtoMapper.toEntity(request);
@@ -57,7 +57,7 @@ public class ProdutoService {
     }
 
     @Transactional
-    @CacheEvict(value = "produtos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId()")
+    @CacheEvict(value = "produtos", key = "T(com.AIT.Optimanage.Support.CacheKeyUtils).generateKey()")
     public ProdutoResponse editarProduto(Integer idProduto, ProdutoRequest request) {
         Produto produtoSalvo = buscarProdutoAtivo(idProduto);
         Produto produto = produtoMapper.toEntity(request);
@@ -67,7 +67,7 @@ public class ProdutoService {
     }
 
     @Transactional
-    @CacheEvict(value = "produtos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId()")
+    @CacheEvict(value = "produtos", key = "T(com.AIT.Optimanage.Support.CacheKeyUtils).generateKey()")
     public void excluirProduto(Integer idProduto) {
         Produto produto = buscarProdutoAtivo(idProduto);
         produto.setAtivo(false);

--- a/src/main/java/com/AIT/Optimanage/Services/ServicoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ServicoService.java
@@ -27,7 +27,7 @@ public class ServicoService {
     private final ServicoRepository servicoRepository;
     private final ServicoMapper servicoMapper;
 
-    @Cacheable(value = "servicos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId() + '-' + #pesquisa.hashCode()")
+    @Cacheable(value = "servicos", key = "T(com.AIT.Optimanage.Support.CacheKeyUtils).generateKey(#pesquisa)")
     public Page<ServicoResponse> listarServicos(Search pesquisa) {
         User loggedUser = CurrentUser.get();
         Sort.Direction direction = Optional.ofNullable(pesquisa.getOrder()).filter(Sort.Direction::isDescending)
@@ -47,7 +47,7 @@ public class ServicoService {
     }
 
     @Transactional
-    @CacheEvict(value = "servicos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId()")
+    @CacheEvict(value = "servicos", key = "T(com.AIT.Optimanage.Support.CacheKeyUtils).generateKey()")
     public ServicoResponse cadastrarServico(ServicoRequest request) {
         User loggedUser = CurrentUser.get();
         Servico servico = servicoMapper.toEntity(request);
@@ -57,7 +57,7 @@ public class ServicoService {
     }
 
     @Transactional
-    @CacheEvict(value = "servicos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId()")
+    @CacheEvict(value = "servicos", key = "T(com.AIT.Optimanage.Support.CacheKeyUtils).generateKey()")
     public ServicoResponse editarServico(Integer idServico, ServicoRequest request) {
         User loggedUser = CurrentUser.get();
         Servico servicoSalvo = buscarServicoAtivo(idServico);
@@ -68,7 +68,7 @@ public class ServicoService {
     }
 
     @Transactional
-    @CacheEvict(value = "servicos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId()")
+    @CacheEvict(value = "servicos", key = "T(com.AIT.Optimanage.Support.CacheKeyUtils).generateKey()")
     public void excluirServico(Integer idServico) {
         User loggedUser = CurrentUser.get();
         Servico servico = buscarServicoAtivo(idServico);

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -67,7 +67,7 @@ public class VendaService {
     private final PaymentService paymentService;
     private final PaymentConfigService paymentConfigService;
 
-    @Cacheable(value = "vendas", key = "#loggedUser.id + '-' + #pesquisa.hashCode()")
+    @Cacheable(value = "vendas", key = "T(com.AIT.Optimanage.Support.CacheKeyUtils).generateKey(#pesquisa)")
     @Transactional(readOnly = true)
     public Page<Venda> listarVendas(User loggedUser, VendaSearch pesquisa) {
         // Configuração de paginação e ordenação

--- a/src/main/java/com/AIT/Optimanage/Support/CacheKeyUtils.java
+++ b/src/main/java/com/AIT/Optimanage/Support/CacheKeyUtils.java
@@ -1,0 +1,33 @@
+package com.AIT.Optimanage.Support;
+
+import com.AIT.Optimanage.Security.CurrentUser;
+
+/**
+ * Utility to generate cache keys that consider the current user or tenant.
+ */
+public final class CacheKeyUtils {
+
+    private CacheKeyUtils() {
+        // utility class
+    }
+
+    public static String generateKey(Object search) {
+        return getIdentifier() + "-" + (search != null ? search.hashCode() : 0);
+    }
+
+    public static String generateKey() {
+        return getIdentifier();
+    }
+
+    private static String getIdentifier() {
+        var user = CurrentUser.get();
+        if (user != null && user.getId() != null) {
+            return String.valueOf(user.getId());
+        }
+        Integer tenantId = TenantContext.getTenantId();
+        if (tenantId != null) {
+            return String.valueOf(tenantId);
+        }
+        return "default";
+    }
+}

--- a/src/test/java/com/AIT/Optimanage/Support/CacheKeyUtilsTest.java
+++ b/src/test/java/com/AIT/Optimanage/Support/CacheKeyUtilsTest.java
@@ -1,0 +1,29 @@
+package com.AIT.Optimanage.Support;
+
+import com.AIT.Optimanage.Security.CurrentUser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CacheKeyUtilsTest {
+
+    @AfterEach
+    void tearDown() {
+        CurrentUser.clear();
+        TenantContext.clear();
+    }
+
+    @Test
+    void shouldUseTenantWhenUserIsNull() {
+        TenantContext.setTenantId(42);
+        String key = CacheKeyUtils.generateKey("test");
+        assertTrue(key.startsWith("42-"));
+    }
+
+    @Test
+    void shouldFallbackToDefaultWhenNoUserOrTenant() {
+        String key = CacheKeyUtils.generateKey("test");
+        assertTrue(key.startsWith("default-"));
+    }
+}


### PR DESCRIPTION
## Summary
- centralize cache key building with new CacheKeyUtils using tenant/user fallback
- refactor services to reuse CacheKeyUtils for cache keys
- add unit tests ensuring cache key generation works without authenticated user

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2f6eab148324ae87ef819914223f