### PR TITLE
feat: cache DTOs for purchase listings

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/Compra/CompraController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Compra/CompraController.java
@@ -3,6 +3,7 @@ package com.AIT.Optimanage.Controllers.Compra;
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
 import com.AIT.Optimanage.Models.Compra.Compra;
 import com.AIT.Optimanage.Models.Compra.DTOs.CompraDTO;
+import com.AIT.Optimanage.Models.Compra.DTOs.CompraResponseDTO;
 import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
 import com.AIT.Optimanage.Models.Compra.Search.CompraSearch;
 import com.AIT.Optimanage.Models.PagamentoDTO;
@@ -31,7 +32,7 @@ public class CompraController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar compras", description = "Retorna uma página de compras")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ResponseEntity<Page<Compra>> listarCompras(@RequestParam(value = "id", required = false) Integer id,
+    public ResponseEntity<Page<CompraResponseDTO>> listarCompras(@RequestParam(value = "id", required = false) Integer id,
                                       @RequestParam(value = "fornecedor_id", required = false) Integer fornecedorId,
                                       @RequestParam(value = "data_inicial", required = false) String data_inicial,
                                       @RequestParam(value = "data_final", required = false) String data_final,

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraPagamentoResponseDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraPagamentoResponseDTO.java
@@ -1,0 +1,23 @@
+package com.AIT.Optimanage.Models.Compra.DTOs;
+
+import com.AIT.Optimanage.Models.Enums.FormaPagamento;
+import com.AIT.Optimanage.Models.Enums.StatusPagamento;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompraPagamentoResponseDTO {
+    private Integer id;
+    private BigDecimal valorPago;
+    private LocalDate dataPagamento;
+    private FormaPagamento formaPagamento;
+    private StatusPagamento statusPagamento;
+    private String observacoes;
+}

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraProdutoResponseDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraProdutoResponseDTO.java
@@ -1,0 +1,19 @@
+package com.AIT.Optimanage.Models.Compra.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompraProdutoResponseDTO {
+    private Integer id;
+    private Integer produtoId;
+    private BigDecimal valorUnitario;
+    private Integer quantidade;
+    private BigDecimal valorTotal;
+}

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraResponseDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraResponseDTO.java
@@ -1,0 +1,30 @@
+package com.AIT.Optimanage.Models.Compra.DTOs;
+
+import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompraResponseDTO {
+    private Integer id;
+    private Integer fornecedorId;
+    private Integer sequencialUsuario;
+    private LocalDate dataEfetuacao;
+    private LocalDate dataAgendada;
+    private BigDecimal valorFinal;
+    private String condicaoPagamento;
+    private BigDecimal valorPendente;
+    private StatusCompra status;
+    private String observacoes;
+    private List<CompraProdutoResponseDTO> produtos;
+    private List<CompraServicoResponseDTO> servicos;
+    private List<CompraPagamentoResponseDTO> pagamentos;
+}

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraServicoResponseDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraServicoResponseDTO.java
@@ -1,0 +1,19 @@
+package com.AIT.Optimanage.Models.Compra.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompraServicoResponseDTO {
+    private Integer id;
+    private Integer servicoId;
+    private BigDecimal valorUnitario;
+    private Integer quantidade;
+    private BigDecimal valorTotal;
+}

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -7,6 +7,10 @@ import com.AIT.Optimanage.Models.Compra.CompraServico;
 import com.AIT.Optimanage.Models.Compra.DTOs.CompraDTO;
 import com.AIT.Optimanage.Models.Compra.DTOs.CompraProdutoDTO;
 import com.AIT.Optimanage.Models.Compra.DTOs.CompraServicoDTO;
+import com.AIT.Optimanage.Models.Compra.DTOs.CompraResponseDTO;
+import com.AIT.Optimanage.Models.Compra.DTOs.CompraProdutoResponseDTO;
+import com.AIT.Optimanage.Models.Compra.DTOs.CompraServicoResponseDTO;
+import com.AIT.Optimanage.Models.Compra.DTOs.CompraPagamentoResponseDTO;
 import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
 import com.AIT.Optimanage.Models.Compra.Search.CompraSearch;
 import com.AIT.Optimanage.Models.Enums.StatusPagamento;
@@ -63,7 +67,7 @@ public class CompraService {
 
     @Cacheable(value = "compras", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId() + '-' + #pesquisa.hashCode()")
     @Transactional(readOnly = true)
-    public Page<Compra> listarCompras(CompraSearch pesquisa) {
+    public Page<CompraResponseDTO> listarCompras(CompraSearch pesquisa) {
         User loggedUser = CurrentUser.get();
         // Configuração de paginação e ordenação
         Sort.Direction direction = Optional.ofNullable(pesquisa.getOrder()).filter(Sort.Direction::isDescending)
@@ -83,7 +87,54 @@ public class CompraService {
                 .and(pesquisa.getFormaPagamento(), CompraFilters::hasFormaPagamento)
                 .build();
 
-        return compraRepository.findAll(spec, pageable);
+        Page<Compra> compras = compraRepository.findAll(spec, pageable);
+        return compras.map(this::toResponse);
+    }
+
+    private CompraResponseDTO toResponse(Compra compra) {
+        return CompraResponseDTO.builder()
+                .id(compra.getId())
+                .fornecedorId(compra.getFornecedorId())
+                .sequencialUsuario(compra.getSequencialUsuario())
+                .dataEfetuacao(compra.getDataEfetuacao())
+                .dataAgendada(compra.getDataAgendada())
+                .valorFinal(compra.getValorFinal())
+                .condicaoPagamento(compra.getCondicaoPagamento())
+                .valorPendente(compra.getValorPendente())
+                .status(compra.getStatus())
+                .observacoes(compra.getObservacoes())
+                .produtos(Optional.ofNullable(compra.getCompraProdutos()).orElse(List.of())
+                        .stream()
+                        .map(cp -> CompraProdutoResponseDTO.builder()
+                                .id(cp.getId())
+                                .produtoId(cp.getProdutoId())
+                                .valorUnitario(cp.getValorUnitario())
+                                .quantidade(cp.getQuantidade())
+                                .valorTotal(cp.getValorTotal())
+                                .build())
+                        .collect(Collectors.toList()))
+                .servicos(Optional.ofNullable(compra.getCompraServicos()).orElse(List.of())
+                        .stream()
+                        .map(cs -> CompraServicoResponseDTO.builder()
+                                .id(cs.getId())
+                                .servicoId(cs.getServicoId())
+                                .valorUnitario(cs.getValorUnitario())
+                                .quantidade(cs.getQuantidade())
+                                .valorTotal(cs.getValorTotal())
+                                .build())
+                        .collect(Collectors.toList()))
+                .pagamentos(Optional.ofNullable(compra.getPagamentos()).orElse(List.of())
+                        .stream()
+                        .map(pg -> CompraPagamentoResponseDTO.builder()
+                                .id(pg.getId())
+                                .valorPago(pg.getValorPago())
+                                .dataPagamento(pg.getDataPagamento())
+                                .formaPagamento(pg.getFormaPagamento())
+                                .statusPagamento(pg.getStatusPagamento())
+                                .observacoes(pg.getObservacoes())
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
     }
 
     public Compra listarUmaCompra(Integer idCompra) {


### PR DESCRIPTION
## Summary
- return purchase pages as DTOs to avoid caching lazy entities
- add purchase, product, service and payment response DTOs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb430e5a588324b56f797fa57dd600