### PR TITLE
fix: preserve snake case ids in purchase DTOs

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraProdutoResponseDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraProdutoResponseDTO.java
@@ -1,5 +1,6 @@
 package com.AIT.Optimanage.Models.Compra.DTOs;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,6 +13,7 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 public class CompraProdutoResponseDTO {
     private Integer id;
+    @JsonProperty("produto_id")
     private Integer produtoId;
     private BigDecimal valorUnitario;
     private Integer quantidade;

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraResponseDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraResponseDTO.java
@@ -1,6 +1,7 @@
 package com.AIT.Optimanage.Models.Compra.DTOs;
 
 import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,6 +16,7 @@ import java.util.List;
 @AllArgsConstructor
 public class CompraResponseDTO {
     private Integer id;
+    @JsonProperty("fornecedor_id")
     private Integer fornecedorId;
     private Integer sequencialUsuario;
     private LocalDate dataEfetuacao;

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraServicoResponseDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraServicoResponseDTO.java
@@ -1,5 +1,6 @@
 package com.AIT.Optimanage.Models.Compra.DTOs;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,6 +13,7 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 public class CompraServicoResponseDTO {
     private Integer id;
+    @JsonProperty("servico_id")
     private Integer servicoId;
     private BigDecimal valorUnitario;
     private Integer quantidade;


### PR DESCRIPTION
## Summary
- add `@JsonProperty` for `fornecedor_id`, `produto_id` and `servico_id`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c0296564832488653e1ad58b2948