### PR TITLE
Propagate MDC context to async tasks

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Config/AsyncConfig.java
+++ b/src/main/java/com/AIT/Optimanage/Config/AsyncConfig.java
@@ -4,7 +4,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.core.task.TaskDecorator;
 
+import com.AIT.Optimanage.Support.MdcTaskDecorator;
 import com.AIT.Optimanage.Support.TenantTaskDecorator;
 
 import java.util.concurrent.Executor;
@@ -20,7 +22,9 @@ public class AsyncConfig {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("Async-");
-        executor.setTaskDecorator(new TenantTaskDecorator());
+        TaskDecorator tenantDecorator = new TenantTaskDecorator();
+        TaskDecorator mdcDecorator = new MdcTaskDecorator();
+        executor.setTaskDecorator(task -> mdcDecorator.decorate(tenantDecorator.decorate(task)));
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/AIT/Optimanage/Support/MdcTaskDecorator.java
+++ b/src/main/java/com/AIT/Optimanage/Support/MdcTaskDecorator.java
@@ -1,0 +1,27 @@
+package com.AIT.Optimanage.Support;
+
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+
+import java.util.Map;
+
+/**
+ * Copies the current MDC context map to async threads.
+ */
+public class MdcTaskDecorator implements TaskDecorator {
+
+    @Override
+    public Runnable decorate(Runnable runnable) {
+        Map<String, String> contextMap = MDC.getCopyOfContextMap();
+        return () -> {
+            try {
+                if (contextMap != null) {
+                    MDC.setContextMap(contextMap);
+                }
+                runnable.run();
+            } finally {
+                MDC.clear();
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add MdcTaskDecorator to copy MDC data to async threads and clear after execution
- chain MDC and tenant decorators on the task executor

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b38f46288324acd17514abdbcc0c