### PR TITLE
Use ProblemDetail for error responses and document schema

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Config/SwaggerConfig.java
+++ b/src/main/java/com/AIT/Optimanage/Config/SwaggerConfig.java
@@ -2,15 +2,31 @@ package com.AIT.Optimanage.Config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI customOpenAPI() {
+        Schema<?> problemDetailSchema = new Schema<>()
+                .addProperty("type", new StringSchema().example("https://api.optimanage.com/problems/example"))
+                .addProperty("title", new StringSchema().example("Human readable title"))
+                .addProperty("status", new IntegerSchema().example(400))
+                .addProperty("detail", new StringSchema().example("More information about the error"))
+                .addProperty("correlationId", new StringSchema().example("123e4567-e89b-12d3-a456-426614174000"))
+                .addProperty("errors", new ArraySchema().items(new StringSchema()).example(List.of("field: must not be null")));
+
         return new OpenAPI()
+                .components(new Components().addSchemas("ProblemDetail", problemDetailSchema))
                 .info(new Info()
                         .title("API Optimanage")
                         .version("1.0")

--- a/src/main/java/com/AIT/Optimanage/Controllers/ExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/ExceptionHandler/GlobalExceptionHandler.java
@@ -4,8 +4,8 @@ import jakarta.persistence.EntityNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
-import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.LockedException;
@@ -21,6 +21,7 @@ import com.AIT.Optimanage.Exceptions.InvalidResetCodeException;
 import com.AIT.Optimanage.Exceptions.RefreshTokenNotFoundException;
 import com.AIT.Optimanage.Exceptions.RefreshTokenInvalidException;
 
+import java.net.URI;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -30,120 +31,133 @@ public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    public record ErrorResponse(LocalDateTime timestamp, int code, String message,
-                                String correlationId, List<String> errors) {}
+    private static final String PROBLEM_BASE_URI = "https://api.optimanage.com/problems/";
+
+    private ProblemDetail buildProblemDetail(HttpStatus status, String title, String detail,
+                                            String type, String correlationId, List<String> errors) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(status, detail);
+        problem.setTitle(title);
+        problem.setType(URI.create(PROBLEM_BASE_URI + type));
+        problem.setProperty("timestamp", LocalDateTime.now());
+        problem.setProperty("correlationId", correlationId);
+        if (errors != null && !errors.isEmpty()) {
+            problem.setProperty("errors", errors);
+        }
+        return problem;
+    }
 
     @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex) {
+    public ResponseEntity<ProblemDetail> handleEntityNotFound(EntityNotFoundException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Entity not found: {} - correlationId: {}", ex.getMessage(), correlationId);
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.NOT_FOUND.value(),
-                        ex.getMessage(), correlationId, Collections.emptyList()));
+        ProblemDetail problem = buildProblemDetail(HttpStatus.NOT_FOUND, "Entity not found",
+                ex.getMessage(), "entity-not-found", correlationId, Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problem);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
+    public ResponseEntity<ProblemDetail> handleIllegalArgument(IllegalArgumentException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Illegal argument: {} - correlationId: {}", ex.getMessage(), correlationId);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.BAD_REQUEST.value(),
-                        ex.getMessage(), correlationId, Collections.emptyList()));
+        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, "Bad request",
+                ex.getMessage(), "illegal-argument", correlationId, Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ProblemDetail> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
         String correlationId = MDC.get("correlationId");
         List<String> errors = ex.getBindingResult().getFieldErrors().stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .toList();
         log.warn("Validation failed: {} - correlationId: {}", errors, correlationId);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.BAD_REQUEST.value(),
-                        "Validation failed", correlationId, errors));
+        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, "Validation failed",
+                "Validation failed", "validation-error", correlationId, errors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex) {
+    public ResponseEntity<ProblemDetail> handleConstraintViolation(ConstraintViolationException ex) {
         String correlationId = MDC.get("correlationId");
         List<String> errors = ex.getConstraintViolations().stream()
                 .map(cv -> cv.getPropertyPath() + ": " + cv.getMessage())
                 .toList();
         log.warn("Validation failed: {} - correlationId: {}", errors, correlationId);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.BAD_REQUEST.value(),
-                        "Validation failed", correlationId, errors));
+        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, "Validation failed",
+                "Validation failed", "validation-error", correlationId, errors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex) {
+    public ResponseEntity<ProblemDetail> handleAccessDenied(AccessDeniedException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Access denied: {} - correlationId: {}", ex.getMessage(), correlationId);
-        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.FORBIDDEN.value(),
-                        ex.getMessage(), correlationId, Collections.emptyList()));
+        ProblemDetail problem = buildProblemDetail(HttpStatus.FORBIDDEN, "Access denied",
+                ex.getMessage(), "access-denied", correlationId, Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(problem);
     }
 
     @ExceptionHandler(LockedException.class)
-    public ResponseEntity<ErrorResponse> handleLocked(LockedException ex) {
+    public ResponseEntity<ProblemDetail> handleLocked(LockedException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Account locked: {} - correlationId: {}", ex.getMessage(), correlationId);
-        return ResponseEntity.status(HttpStatus.LOCKED)
-                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.LOCKED.value(),
-                        ex.getMessage(), correlationId, Collections.emptyList()));
+        ProblemDetail problem = buildProblemDetail(HttpStatus.LOCKED, "Account locked",
+                ex.getMessage(), "account-locked", correlationId, Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.LOCKED).body(problem);
     }
 
     @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex) {
+    public ResponseEntity<ProblemDetail> handleUserNotFound(UserNotFoundException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("User not found: {} - correlationId: {}", ex.getMessage(), correlationId);
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.NOT_FOUND.value(),
-                        ex.getMessage(), correlationId, Collections.emptyList()));
+        ProblemDetail problem = buildProblemDetail(HttpStatus.NOT_FOUND, "User not found",
+                ex.getMessage(), "user-not-found", correlationId, Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problem);
     }
 
     @ExceptionHandler({InvalidTwoFactorCodeException.class, InvalidResetCodeException.class})
-    public ResponseEntity<ErrorResponse> handleInvalidCode(CustomRuntimeException ex) {
+    public ResponseEntity<ProblemDetail> handleInvalidCode(CustomRuntimeException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Invalid code: {} - correlationId: {}", ex.getMessage(), correlationId);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.BAD_REQUEST.value(),
-                        ex.getMessage(), correlationId, Collections.emptyList()));
+        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, "Invalid code",
+                ex.getMessage(), "invalid-code", correlationId, Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
     }
 
     @ExceptionHandler(RefreshTokenNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleRefreshTokenNotFound(RefreshTokenNotFoundException ex) {
+    public ResponseEntity<ProblemDetail> handleRefreshTokenNotFound(RefreshTokenNotFoundException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Refresh token not found: {} - correlationId: {}", ex.getMessage(), correlationId);
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.NOT_FOUND.value(),
-                        ex.getMessage(), correlationId, Collections.emptyList()));
+        ProblemDetail problem = buildProblemDetail(HttpStatus.NOT_FOUND, "Refresh token not found",
+                ex.getMessage(), "refresh-token-not-found", correlationId, Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problem);
     }
 
     @ExceptionHandler(RefreshTokenInvalidException.class)
-    public ResponseEntity<ErrorResponse> handleRefreshTokenInvalid(RefreshTokenInvalidException ex) {
+    public ResponseEntity<ProblemDetail> handleRefreshTokenInvalid(RefreshTokenInvalidException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Refresh token invalid: {} - correlationId: {}", ex.getMessage(), correlationId);
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.UNAUTHORIZED.value(),
-                        ex.getMessage(), correlationId, Collections.emptyList()));
+        ProblemDetail problem = buildProblemDetail(HttpStatus.UNAUTHORIZED, "Refresh token invalid",
+                ex.getMessage(), "refresh-token-invalid", correlationId, Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(problem);
     }
 
     @ExceptionHandler(CustomRuntimeException.class)
-    public ResponseEntity<ErrorResponse> handleCustomRuntime(CustomRuntimeException ex) {
+    public ResponseEntity<ProblemDetail> handleCustomRuntime(CustomRuntimeException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Runtime exception: {} - correlationId: {}", ex.getMessage(), correlationId);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.BAD_REQUEST.value(),
-                        ex.getMessage(), correlationId, Collections.emptyList()));
+        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, "Bad request",
+                ex.getMessage(), "runtime-exception", correlationId, Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleGeneral(Exception ex) {
+    public ResponseEntity<ProblemDetail> handleGeneral(Exception ex) {
         String correlationId = MDC.get("correlationId");
         log.error("Internal server error - correlationId: {}", correlationId, ex);
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponse(LocalDateTime.now(), HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                        "Internal server error", correlationId, Collections.emptyList()));
+        ProblemDetail problem = buildProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR,
+                "Internal server error", "Internal server error", "internal-server-error",
+                correlationId, Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(problem);
     }
 }


### PR DESCRIPTION
## Summary
- refactor global exception handling to build and return `ProblemDetail` instances with RFC7807 fields
- expose `ProblemDetail` schema via OpenAPI components for consistent error docs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b19816888324856fdc96e47f7036