### PR TITLE
fix: return full plan for user

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/PlanoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/PlanoService.java
@@ -56,7 +56,8 @@ public class PlanoService {
 
     public Optional<Plano> obterPlanoUsuario(User user) {
         return userInfoRepository.findByOwnerUser(user)
-                .map(UserInfo::getPlanoAtivoId);
+                .map(UserInfo::getPlanoAtivoId)
+                .flatMap(planoRepository::findById);
     }
 
     private Plano fromRequest(PlanoRequest request) {


### PR DESCRIPTION
## Summary
- return full `Plano` entity in `obterPlanoUsuario`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c0c07b608324a14f2000928d8847