### PR TITLE
Add Boleto and Pix payment provider integrations

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Config/RestTemplateConfig.java
+++ b/src/main/java/com/AIT/Optimanage/Config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.AIT.Optimanage.Config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Payments/Providers/BoletoPaymentProvider.java
+++ b/src/main/java/com/AIT/Optimanage/Payments/Providers/BoletoPaymentProvider.java
@@ -1,14 +1,34 @@
 package com.AIT.Optimanage.Payments.Providers;
 
+import com.AIT.Optimanage.Models.Enums.FormaPagamento;
+import com.AIT.Optimanage.Models.Enums.StatusPagamento;
 import com.AIT.Optimanage.Models.PagamentoDTO;
 import com.AIT.Optimanage.Models.Payment.PaymentConfig;
 import com.AIT.Optimanage.Models.Payment.PaymentProvider;
 import com.AIT.Optimanage.Payments.PaymentRequestDTO;
 import com.AIT.Optimanage.Payments.PaymentResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
 
 @Component
+@RequiredArgsConstructor
 public class BoletoPaymentProvider implements PaymentProviderStrategy {
+
+    @Value("${boleto.api.url}")
+    private String apiUrl;
+
+    @Value("${boleto.api.key:}")
+    private String apiKey;
+
+    private final RestTemplate restTemplate;
+
     @Override
     public PaymentProvider getProvider() {
         return PaymentProvider.BOLETO;
@@ -16,11 +36,51 @@ public class BoletoPaymentProvider implements PaymentProviderStrategy {
 
     @Override
     public PaymentResponseDTO createPayment(PaymentRequestDTO request, PaymentConfig config) {
-        throw new UnsupportedOperationException("Boleto não implementado");
+        HttpHeaders headers = createHeaders(config);
+        HttpEntity<PaymentRequestDTO> entity = new HttpEntity<>(request, headers);
+        ResponseEntity<PaymentResponseDTO> response = restTemplate.exchange(
+                apiUrl + "/payments",
+                HttpMethod.POST,
+                entity,
+                PaymentResponseDTO.class);
+        return response.getBody();
     }
 
     @Override
     public PagamentoDTO confirmPayment(String paymentIntentId, PaymentConfig config) {
-        throw new UnsupportedOperationException("Boleto não implementado");
+        HttpHeaders headers = createHeaders(config);
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+        ResponseEntity<Map> response = restTemplate.exchange(
+                apiUrl + "/payments/" + paymentIntentId,
+                HttpMethod.GET,
+                entity,
+                Map.class);
+        Map body = response.getBody();
+        String status = body != null ? (String) body.get("status") : "";
+        BigDecimal amount = body != null && body.get("amount") != null
+                ? new BigDecimal(body.get("amount").toString())
+                : BigDecimal.ZERO;
+        StatusPagamento statusPagamento = "PAID".equalsIgnoreCase(status)
+                ? StatusPagamento.PAGO
+                : StatusPagamento.PENDENTE;
+        return PagamentoDTO.builder()
+                .valorPago(amount)
+                .dataPagamento(LocalDate.now())
+                .formaPagamento(FormaPagamento.BOLETO)
+                .statusPagamento(statusPagamento)
+                .observacoes("Boleto payment " + paymentIntentId)
+                .build();
+    }
+
+    private HttpHeaders createHeaders(PaymentConfig config) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String key = config != null && config.getApiKey() != null && !config.getApiKey().isEmpty()
+                ? config.getApiKey()
+                : apiKey;
+        if (key != null && !key.isEmpty()) {
+            headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + key);
+        }
+        return headers;
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Payments/Providers/PixPaymentProvider.java
+++ b/src/main/java/com/AIT/Optimanage/Payments/Providers/PixPaymentProvider.java
@@ -1,14 +1,34 @@
 package com.AIT.Optimanage.Payments.Providers;
 
+import com.AIT.Optimanage.Models.Enums.FormaPagamento;
+import com.AIT.Optimanage.Models.Enums.StatusPagamento;
 import com.AIT.Optimanage.Models.PagamentoDTO;
 import com.AIT.Optimanage.Models.Payment.PaymentConfig;
 import com.AIT.Optimanage.Models.Payment.PaymentProvider;
 import com.AIT.Optimanage.Payments.PaymentRequestDTO;
 import com.AIT.Optimanage.Payments.PaymentResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
 
 @Component
+@RequiredArgsConstructor
 public class PixPaymentProvider implements PaymentProviderStrategy {
+
+    @Value("${pix.api.url}")
+    private String apiUrl;
+
+    @Value("${pix.api.key:}")
+    private String apiKey;
+
+    private final RestTemplate restTemplate;
+
     @Override
     public PaymentProvider getProvider() {
         return PaymentProvider.PIX;
@@ -16,11 +36,51 @@ public class PixPaymentProvider implements PaymentProviderStrategy {
 
     @Override
     public PaymentResponseDTO createPayment(PaymentRequestDTO request, PaymentConfig config) {
-        throw new UnsupportedOperationException("PIX não implementado");
+        HttpHeaders headers = createHeaders(config);
+        HttpEntity<PaymentRequestDTO> entity = new HttpEntity<>(request, headers);
+        ResponseEntity<PaymentResponseDTO> response = restTemplate.exchange(
+                apiUrl + "/payments",
+                HttpMethod.POST,
+                entity,
+                PaymentResponseDTO.class);
+        return response.getBody();
     }
 
     @Override
     public PagamentoDTO confirmPayment(String paymentIntentId, PaymentConfig config) {
-        throw new UnsupportedOperationException("PIX não implementado");
+        HttpHeaders headers = createHeaders(config);
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+        ResponseEntity<Map> response = restTemplate.exchange(
+                apiUrl + "/payments/" + paymentIntentId,
+                HttpMethod.GET,
+                entity,
+                Map.class);
+        Map body = response.getBody();
+        String status = body != null ? (String) body.get("status") : "";
+        BigDecimal amount = body != null && body.get("amount") != null
+                ? new BigDecimal(body.get("amount").toString())
+                : BigDecimal.ZERO;
+        StatusPagamento statusPagamento = "PAID".equalsIgnoreCase(status)
+                ? StatusPagamento.PAGO
+                : StatusPagamento.PENDENTE;
+        return PagamentoDTO.builder()
+                .valorPago(amount)
+                .dataPagamento(LocalDate.now())
+                .formaPagamento(FormaPagamento.PIX)
+                .statusPagamento(statusPagamento)
+                .observacoes("PIX payment " + paymentIntentId)
+                .build();
+    }
+
+    private HttpHeaders createHeaders(PaymentConfig config) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String key = config != null && config.getApiKey() != null && !config.getApiKey().isEmpty()
+                ? config.getApiKey()
+                : apiKey;
+        if (key != null && !key.isEmpty()) {
+            headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + key);
+        }
+        return headers;
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -250,13 +250,15 @@ public class VendaService {
     public PaymentResponseDTO iniciarPagamentoExterno(User loggedUser, Integer idVenda, PaymentRequestDTO request) {
         Venda venda = listarUmaVenda(loggedUser, idVenda);
         podePagarVenda(venda);
+        PaymentProvider provider = request != null && request.getProvider() != null
+                ? request.getProvider()
+                : PaymentProvider.STRIPE;
         PaymentRequestDTO req = request != null ? request : PaymentRequestDTO.builder()
                 .amount(venda.getValorPendente())
                 .currency("brl")
                 .description("Venda " + idVenda)
-                .provider(PaymentProvider.STRIPE)
+                .provider(provider)
                 .build();
-        PaymentProvider provider = req.getProvider() != null ? req.getProvider() : PaymentProvider.STRIPE;
         PaymentConfig config = paymentConfigService.getConfig(loggedUser, provider);
         req.setProvider(provider);
         return paymentService.createPayment(req, config);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,6 +36,14 @@ server.servlet.context-path=/api/v1
 # Stripe payment configuration
 stripe.api.key=${STRIPE_API_KEY:}
 
+# Boleto payment configuration
+boleto.api.url=${BOLETO_API_URL:https://boleto.example.com}
+boleto.api.key=${BOLETO_API_KEY:}
+
+# PIX payment configuration
+pix.api.url=${PIX_API_URL:https://pix.example.com}
+pix.api.key=${PIX_API_KEY:}
+
 # Tracing (Spring Boot + Micrometer + OTLP)
 management.tracing.enabled=true
 management.tracing.sampling.probability=1.0

--- a/src/test/java/com/AIT/Optimanage/Payments/Providers/BoletoPaymentProviderTest.java
+++ b/src/test/java/com/AIT/Optimanage/Payments/Providers/BoletoPaymentProviderTest.java
@@ -1,0 +1,65 @@
+package com.AIT.Optimanage.Payments.Providers;
+
+import com.AIT.Optimanage.Models.Enums.FormaPagamento;
+import com.AIT.Optimanage.Models.Enums.StatusPagamento;
+import com.AIT.Optimanage.Models.PagamentoDTO;
+import com.AIT.Optimanage.Models.Payment.PaymentConfig;
+import com.AIT.Optimanage.Models.Payment.PaymentProvider;
+import com.AIT.Optimanage.Payments.PaymentRequestDTO;
+import com.AIT.Optimanage.Payments.PaymentResponseDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.client.MockRestServiceServer;
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RestClientTest(BoletoPaymentProvider.class)
+@TestPropertySource(properties = {
+        "boleto.api.url=https://boleto.test",
+        "boleto.api.key=test"
+})
+class BoletoPaymentProviderTest {
+
+    @Autowired
+    private BoletoPaymentProvider provider;
+
+    @Autowired
+    private MockRestServiceServer server;
+
+    @Test
+    void createPaymentCallsApi() {
+        PaymentRequestDTO request = PaymentRequestDTO.builder()
+                .amount(BigDecimal.TEN)
+                .currency("brl")
+                .description("Venda 1")
+                .provider(PaymentProvider.BOLETO)
+                .build();
+
+        server.expect(requestTo("https://boleto.test/payments"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("{\"paymentIntentId\":\"1\",\"clientSecret\":\"sec\",\"provider\":\"BOLETO\"}", MediaType.APPLICATION_JSON));
+
+        PaymentResponseDTO response = provider.createPayment(request, PaymentConfig.builder().build());
+        assertThat(response.getPaymentIntentId()).isEqualTo("1");
+    }
+
+    @Test
+    void confirmPaymentParsesStatus() {
+        server.expect(requestTo("https://boleto.test/payments/1"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("{\"status\":\"PAID\",\"amount\":10}", MediaType.APPLICATION_JSON));
+
+        PagamentoDTO dto = provider.confirmPayment("1", PaymentConfig.builder().build());
+        assertThat(dto.getStatusPagamento()).isEqualTo(StatusPagamento.PAGO);
+        assertThat(dto.getFormaPagamento()).isEqualTo(FormaPagamento.BOLETO);
+        assertThat(dto.getValorPago()).isEqualTo(BigDecimal.TEN);
+    }
+}

--- a/src/test/java/com/AIT/Optimanage/Payments/Providers/PixPaymentProviderTest.java
+++ b/src/test/java/com/AIT/Optimanage/Payments/Providers/PixPaymentProviderTest.java
@@ -1,0 +1,65 @@
+package com.AIT.Optimanage.Payments.Providers;
+
+import com.AIT.Optimanage.Models.Enums.FormaPagamento;
+import com.AIT.Optimanage.Models.Enums.StatusPagamento;
+import com.AIT.Optimanage.Models.PagamentoDTO;
+import com.AIT.Optimanage.Models.Payment.PaymentConfig;
+import com.AIT.Optimanage.Models.Payment.PaymentProvider;
+import com.AIT.Optimanage.Payments.PaymentRequestDTO;
+import com.AIT.Optimanage.Payments.PaymentResponseDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.client.MockRestServiceServer;
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RestClientTest(PixPaymentProvider.class)
+@TestPropertySource(properties = {
+        "pix.api.url=https://pix.test",
+        "pix.api.key=test"
+})
+class PixPaymentProviderTest {
+
+    @Autowired
+    private PixPaymentProvider provider;
+
+    @Autowired
+    private MockRestServiceServer server;
+
+    @Test
+    void createPaymentCallsApi() {
+        PaymentRequestDTO request = PaymentRequestDTO.builder()
+                .amount(BigDecimal.ONE)
+                .currency("brl")
+                .description("Venda 1")
+                .provider(PaymentProvider.PIX)
+                .build();
+
+        server.expect(requestTo("https://pix.test/payments"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("{\"paymentIntentId\":\"1\",\"clientSecret\":\"sec\",\"provider\":\"PIX\"}", MediaType.APPLICATION_JSON));
+
+        PaymentResponseDTO response = provider.createPayment(request, PaymentConfig.builder().build());
+        assertThat(response.getPaymentIntentId()).isEqualTo("1");
+    }
+
+    @Test
+    void confirmPaymentParsesStatus() {
+        server.expect(requestTo("https://pix.test/payments/1"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("{\"status\":\"PAID\",\"amount\":1}", MediaType.APPLICATION_JSON));
+
+        PagamentoDTO dto = provider.confirmPayment("1", PaymentConfig.builder().build());
+        assertThat(dto.getStatusPagamento()).isEqualTo(StatusPagamento.PAGO);
+        assertThat(dto.getFormaPagamento()).isEqualTo(FormaPagamento.PIX);
+        assertThat(dto.getValorPago()).isEqualTo(BigDecimal.ONE);
+    }
+}


### PR DESCRIPTION
## Summary
- implement Boleto and Pix payment providers using external API endpoints
- expose provider endpoints and credentials in application properties
- update sale payment flow to select provider dynamically
- add integration tests mocking boleto and pix gateways

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.AIT:Optimanage:0.0.1-SNAPSHOT due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b01b666c8324a5ef2ba71c5fb302