### PR TITLE
Implement refresh token revocation and reuse checks

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Auth/RefreshTokenRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Auth/RefreshTokenRepository.java
@@ -14,9 +14,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Inte
     void deleteByUser(User user);
     void deleteByExpiryDateBefore(Instant expiryDate);
 
-    @Modifying
-    @Query("update RefreshToken t set t.revoked = true where t.token = :token")
-    void markAsRevoked(@Param("token") String token);
-
-    boolean existsByTokenAndRevokedFalse(String token);
+    @Modifying(clearAutomatically = true)
+    @Query("update RefreshToken t set t.revoked = true where t.token = :token and t.revoked = false")
+    int revokeIfNotRevoked(@Param("token") String token);
 }

--- a/src/test/java/com/AIT/Optimanage/Auth/AuthenticationServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Auth/AuthenticationServiceTest.java
@@ -107,7 +107,7 @@ class AuthenticationServiceTest {
                 .revoked(false)
                 .build();
 
-        when(refreshTokenRepository.existsByTokenAndRevokedFalse(oldToken)).thenReturn(true);
+        when(refreshTokenRepository.revokeIfNotRevoked(oldToken)).thenReturn(1);
         when(refreshTokenRepository.findByToken(oldToken)).thenReturn(Optional.of(storedToken));
         when(jwtService.isTokenValid(oldToken, user)).thenReturn(true);
         when(jwtService.generateToken(anyMap(), eq(user))).thenReturn("newJwt");
@@ -119,6 +119,6 @@ class AuthenticationServiceTest {
 
         assertEquals("newJwt", response.getToken());
         assertEquals("newRefresh", response.getRefreshToken());
-        verify(refreshTokenRepository).markAsRevoked(oldToken);
+        verify(refreshTokenRepository).revokeIfNotRevoked(oldToken);
     }
 }


### PR DESCRIPTION
## Summary
- Atomically revoke refresh tokens before issuing a replacement to avoid race reuse
- Replace exists check + revoke with single conditional update
- Update unit test to verify conditional revocation

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for org.springframework.boot:spring-boot-starter-parent:3.4.1 due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d992b53083248ed1b001bf2f4054