### PR TITLE
test: seed correlation id in MVC tests

### DIFF
--- a/src/test/java/com/AIT/Optimanage/Auth/AuthenticationControllerValidationTest.java
+++ b/src/test/java/com/AIT/Optimanage/Auth/AuthenticationControllerValidationTest.java
@@ -1,6 +1,8 @@
 package com.AIT.Optimanage.Auth;
 
 import com.AIT.Optimanage.Exceptions.GlobalExceptionHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -9,6 +11,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.slf4j.MDC;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -25,6 +28,16 @@ class AuthenticationControllerValidationTest {
 
     @MockBean
     private AuthenticationService authenticationService;
+
+    @BeforeEach
+    void setup() {
+        MDC.put("correlationId", "test-correlation-id");
+    }
+
+    @AfterEach
+    void cleanup() {
+        MDC.remove("correlationId");
+    }
 
     @Test
     void whenRegisterRequestInvalid_thenReturnsBadRequest() throws Exception {

--- a/src/test/java/com/AIT/Optimanage/Controllers/Cliente/ClienteControllerValidationTest.java
+++ b/src/test/java/com/AIT/Optimanage/Controllers/Cliente/ClienteControllerValidationTest.java
@@ -1,6 +1,8 @@
 package com.AIT.Optimanage.Controllers.Cliente;
 
 import com.AIT.Optimanage.Exceptions.GlobalExceptionHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -9,6 +11,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.slf4j.MDC;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -24,6 +27,16 @@ class ClienteControllerValidationTest {
 
     @MockBean
     private com.AIT.Optimanage.Services.Cliente.ClienteService clienteService;
+
+    @BeforeEach
+    void setup() {
+        MDC.put("correlationId", "test-correlation-id");
+    }
+
+    @AfterEach
+    void cleanup() {
+        MDC.remove("correlationId");
+    }
 
     @Test
     void whenCpfInvalid_thenReturnsBadRequest() throws Exception {

--- a/src/test/java/com/AIT/Optimanage/Exceptions/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/AIT/Optimanage/Exceptions/GlobalExceptionHandlerTest.java
@@ -2,6 +2,8 @@ package com.AIT.Optimanage.Exceptions;
 
 import com.AIT.Optimanage.Exceptions.CustomRuntimeException;
 import com.AIT.Optimanage.Exceptions.GlobalExceptionHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.slf4j.MDC;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -50,6 +53,16 @@ class GlobalExceptionHandlerTest {
     static class DummyRequest {
         @NotBlank
         public String name;
+    }
+
+    @BeforeEach
+    void setup() {
+        MDC.put("correlationId", "test-correlation-id");
+    }
+
+    @AfterEach
+    void cleanup() {
+        MDC.remove("correlationId");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- seed `correlationId` in `MDC` for WebMvc tests
- clear `MDC` after each test

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2db83477883249749b84fb68e7c92