### PR TITLE
Cache tenant-aware plan lookups

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/PlanoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/PlanoService.java
@@ -9,6 +9,7 @@ import com.AIT.Optimanage.Repositories.PlanoRepository;
 import com.AIT.Optimanage.Repositories.User.UserInfoRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,6 +40,7 @@ public class PlanoService {
     }
 
     @Transactional
+    @CacheEvict(value = "planos", allEntries = true)
     public PlanoResponse atualizarPlano(Integer idPlano, PlanoRequest request) {
         Plano existente = planoRepository.findById(idPlano)
                 .orElseThrow(() -> new EntityNotFoundException("Plano não encontrado"));
@@ -49,13 +51,14 @@ public class PlanoService {
     }
 
     @Transactional
+    @CacheEvict(value = "planos", allEntries = true)
     public void removerPlano(Integer idPlano) {
         Plano plano = planoRepository.findById(idPlano)
                 .orElseThrow(() -> new EntityNotFoundException("Plano não encontrado"));
         planoRepository.delete(plano);
     }
 
-    @Cacheable("planos")
+    @Cacheable(value = "planos", key = "#user.id")
     public Optional<Plano> obterPlanoUsuario(User user) {
         return userInfoRepository.findByOwnerUser(user)
                 .map(UserInfo::getPlanoAtivoId)

--- a/src/main/java/com/AIT/Optimanage/Services/User/UsuarioService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/User/UsuarioService.java
@@ -10,6 +10,7 @@ import com.AIT.Optimanage.Repositories.User.UserInfoRepository;
 import com.AIT.Optimanage.Repositories.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -50,6 +51,7 @@ public class UsuarioService {
     }
 
     @Transactional
+    @CacheEvict(value = "planos", key = "#id")
     public UserResponse atualizarPlanoAtivo(Integer id, Integer novoPlanoId) {
         User usuario = getUsuario(id);
         UserInfo userInfo = userInfoRepository.findByOwnerUser(usuario)

--- a/src/test/java/com/AIT/Optimanage/Services/PlanoServiceCacheTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/PlanoServiceCacheTest.java
@@ -6,12 +6,15 @@ import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Models.User.UserInfo;
 import com.AIT.Optimanage.Repositories.PlanoRepository;
 import com.AIT.Optimanage.Repositories.User.UserInfoRepository;
+import com.AIT.Optimanage.Repositories.UserRepository;
+import com.AIT.Optimanage.Services.User.UsuarioService;
 import com.AIT.Optimanage.Support.TenantContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.util.Optional;
 
@@ -20,17 +23,26 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest(classes = {PlanoService.class, CacheConfig.class}, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(classes = {PlanoService.class, UsuarioService.class, CacheConfig.class}, webEnvironment = SpringBootTest.WebEnvironment.NONE)
 class PlanoServiceCacheTest {
 
     @Autowired
     private PlanoService planoService;
+
+    @Autowired
+    private UsuarioService usuarioService;
 
     @MockBean
     private PlanoRepository planoRepository;
 
     @MockBean
     private UserInfoRepository userInfoRepository;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private BCryptPasswordEncoder passwordEncoder;
 
     @AfterEach
     void tearDown() {
@@ -40,6 +52,7 @@ class PlanoServiceCacheTest {
     @Test
     void obterPlanoUsuarioIsCachedPerTenant() {
         User user = new User();
+        user.setId(1);
         Plano plano = new Plano();
         plano.setId(10);
         UserInfo userInfo = new UserInfo();
@@ -63,6 +76,36 @@ class PlanoServiceCacheTest {
         assertThat(third).contains(plano);
         verify(planoRepository, times(2)).findById(10);
         verify(userInfoRepository, times(2)).findByOwnerUser(user);
+    }
+
+    @Test
+    void cacheEvictedWhenUserPlanChanges() {
+        User user = new User();
+        user.setId(1);
+        Plano antigo = new Plano();
+        antigo.setId(10);
+        Plano novo = new Plano();
+        novo.setId(20);
+        UserInfo info = new UserInfo();
+        info.setPlanoAtivoId(antigo);
+
+        when(userRepository.findById(1)).thenReturn(Optional.of(user));
+        when(userInfoRepository.findByOwnerUser(user)).thenReturn(Optional.of(info));
+        when(planoRepository.findById(10)).thenReturn(Optional.of(antigo));
+        when(planoRepository.findById(20)).thenReturn(Optional.of(novo));
+
+        Optional<Plano> first = planoService.obterPlanoUsuario(user);
+        assertThat(first).contains(antigo);
+        verify(userInfoRepository, times(1)).findByOwnerUser(user);
+        verify(planoRepository, times(1)).findById(10);
+
+        usuarioService.atualizarPlanoAtivo(1, 20);
+
+        Optional<Plano> second = planoService.obterPlanoUsuario(user);
+        assertThat(second).contains(novo);
+        verify(userInfoRepository, times(2)).findByOwnerUser(user);
+        verify(planoRepository, times(1)).findById(10);
+        verify(planoRepository, times(2)).findById(20);
     }
 }
 


### PR DESCRIPTION
## Summary
- evict `planos` cache when plans are updated or removed and when users change plans
- key cached plan lookups by user id
- add test covering cache eviction on plan change

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2dd4aa5f88324aeebd2045704b28e