### PR TITLE
feat: add CPF and CNPJ custom validators

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteRequest.java
@@ -1,6 +1,8 @@
 package com.AIT.Optimanage.Controllers.dto;
 
 import com.AIT.Optimanage.Models.Enums.TipoPessoa;
+import com.AIT.Optimanage.Support.validation.CNPJValido;
+import com.AIT.Optimanage.Support.validation.CPFValido;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,11 +36,11 @@ public class ClienteRequest {
     private String razaoSocial;
 
     @Size(max = 14)
-    @Pattern(regexp = "^(\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}|\\d{11})$", message = "CPF inválido")
+    @CPFValido
     private String cpf;
 
     @Size(max = 18)
-    @Pattern(regexp = "^(\\d{2}\\.\\d{3}\\.\\d{3}/\\d{4}-\\d{2}|\\d{14})$", message = "CNPJ inválido")
+    @CNPJValido
     private String cnpj;
 
     @Size(max = 18)

--- a/src/main/java/com/AIT/Optimanage/Support/validation/CNPJValidator.java
+++ b/src/main/java/com/AIT/Optimanage/Support/validation/CNPJValidator.java
@@ -1,0 +1,45 @@
+package com.AIT.Optimanage.Support.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class CNPJValidator implements ConstraintValidator<CNPJValido, String> {
+
+    @Override
+    public void initialize(CNPJValido constraintAnnotation) {
+        // no initialization needed
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isBlank()) {
+            return true;
+        }
+        String cnpj = value.replaceAll("\\D", "");
+        if (cnpj.length() != 14) {
+            return false;
+        }
+        if (cnpj.chars().distinct().count() == 1) {
+            return false;
+        }
+        int[] weights1 = {5,4,3,2,9,8,7,6,5,4,3,2};
+        int[] weights2 = {6,5,4,3,2,9,8,7,6,5,4,3,2};
+
+        int sum = 0;
+        for (int i = 0; i < 12; i++) {
+            sum += (cnpj.charAt(i) - '0') * weights1[i];
+        }
+        int firstCheck = sum % 11;
+        firstCheck = firstCheck < 2 ? 0 : 11 - firstCheck;
+        if ((cnpj.charAt(12) - '0') != firstCheck) {
+            return false;
+        }
+        sum = 0;
+        for (int i = 0; i < 13; i++) {
+            sum += (cnpj.charAt(i) - '0') * weights2[i];
+        }
+        int secondCheck = sum % 11;
+        secondCheck = secondCheck < 2 ? 0 : 11 - secondCheck;
+        return (cnpj.charAt(13) - '0') == secondCheck;
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Support/validation/CNPJValido.java
+++ b/src/main/java/com/AIT/Optimanage/Support/validation/CNPJValido.java
@@ -1,0 +1,21 @@
+package com.AIT.Optimanage.Support.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Constraint(validatedBy = CNPJValidator.class)
+@Target({ FIELD, METHOD, PARAMETER })
+@Retention(RUNTIME)
+public @interface CNPJValido {
+    String message() default "CNPJ inválido";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/AIT/Optimanage/Support/validation/CPFValidator.java
+++ b/src/main/java/com/AIT/Optimanage/Support/validation/CPFValidator.java
@@ -1,0 +1,42 @@
+package com.AIT.Optimanage.Support.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class CPFValidator implements ConstraintValidator<CPFValido, String> {
+
+    @Override
+    public void initialize(CPFValido constraintAnnotation) {
+        // no initialization needed
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isBlank()) {
+            return true;
+        }
+        String cpf = value.replaceAll("\\D", "");
+        if (cpf.length() != 11) {
+            return false;
+        }
+        if (cpf.chars().distinct().count() == 1) {
+            return false;
+        }
+        int sum = 0;
+        for (int i = 0; i < 9; i++) {
+            sum += (cpf.charAt(i) - '0') * (10 - i);
+        }
+        int firstCheck = sum % 11;
+        firstCheck = firstCheck < 2 ? 0 : 11 - firstCheck;
+        if ((cpf.charAt(9) - '0') != firstCheck) {
+            return false;
+        }
+        sum = 0;
+        for (int i = 0; i < 10; i++) {
+            sum += (cpf.charAt(i) - '0') * (11 - i);
+        }
+        int secondCheck = sum % 11;
+        secondCheck = secondCheck < 2 ? 0 : 11 - secondCheck;
+        return (cpf.charAt(10) - '0') == secondCheck;
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Support/validation/CPFValido.java
+++ b/src/main/java/com/AIT/Optimanage/Support/validation/CPFValido.java
@@ -1,0 +1,21 @@
+package com.AIT.Optimanage.Support.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Constraint(validatedBy = CPFValidator.class)
+@Target({ FIELD, METHOD, PARAMETER })
+@Retention(RUNTIME)
+public @interface CPFValido {
+    String message() default "CPF inválido";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
## Summary
- add `@CPFValido` and `@CNPJValido` annotations with check digit logic
- replace regex validations in `ClienteRequest` with the new annotations

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM; Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ce55464883248e265e766484389c