### PR TITLE
Use MapStruct mappers for entity conversions

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Mappers/ClienteMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/ClienteMapper.java
@@ -13,6 +13,7 @@ public interface ClienteMapper {
 
     @Mapping(target = "atividade", source = "atividadeId", qualifiedByName = "idToAtividade")
     @Mapping(target = "ownerUser", ignore = true)
+    @Mapping(target = "ativo", source = "ativo", defaultValue = "true")
     Cliente toEntity(ClienteRequest request);
 
     @Mapping(target = "atividadeId", source = "atividade.id")


### PR DESCRIPTION
## Summary
- add MapStruct mappers for cliente, fornecedor and plano
- refactor services to leverage mapper conversions
- ensure cliente mapper preserves default `ativo` when request omits the flag

## Testing
- `sh ./mvnw -q -e test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f1fdfbb083249c4de4d97307fede