### PR TITLE
Default ativo handling in mappers and test constructor fix

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Mappers/ClienteMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/ClienteMapper.java
@@ -13,6 +13,7 @@ public interface ClienteMapper {
 
     @Mapping(target = "atividade", source = "atividadeId", qualifiedByName = "idToAtividade")
     @Mapping(target = "ownerUser", ignore = true)
+    @Mapping(target = "ativo", source = "ativo", defaultValue = "true")
     Cliente toEntity(ClienteRequest request);
 
     @Mapping(target = "atividadeId", source = "atividade.id")

--- a/src/main/java/com/AIT/Optimanage/Mappers/FornecedorMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/FornecedorMapper.java
@@ -13,6 +13,7 @@ public interface FornecedorMapper {
 
     @Mapping(target = "atividade", source = "atividadeId", qualifiedByName = "idToAtividade")
     @Mapping(target = "ownerUser", ignore = true)
+    @Mapping(target = "ativo", source = "ativo", defaultValue = "true")
     Fornecedor toEntity(FornecedorRequest request);
 
     @Mapping(target = "atividadeId", source = "atividade.id")

--- a/src/test/java/com/AIT/Optimanage/Services/Cliente/ClienteServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/Cliente/ClienteServiceTest.java
@@ -14,7 +14,7 @@ class ClienteServiceTest {
         cliente.setTipoPessoa(TipoPessoa.PF);
         cliente.setInscricaoMunicipal("12345");
 
-        ClienteService service = new ClienteService(null);
+        ClienteService service = new ClienteService(null, null);
         service.validarCliente(cliente);
 
         assertNull(cliente.getInscricaoMunicipal());


### PR DESCRIPTION
## Summary
- default `ativo` to true in cliente and fornecedor mappers
- update ClienteService tests to pass new mapper dependency

## Testing
- `./mvnw -q -e test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f208fb2483249b220604dd02c741