### PR TITLE
Use MapStruct mappers for entity conversions

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Mappers/ClienteMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/ClienteMapper.java
@@ -13,6 +13,7 @@ public interface ClienteMapper {
 
     @Mapping(target = "atividade", source = "atividadeId", qualifiedByName = "idToAtividade")
     @Mapping(target = "ownerUser", ignore = true)
+    @Mapping(target = "ativo", source = "ativo", defaultValue = "true")
     Cliente toEntity(ClienteRequest request);
 
     @Mapping(target = "atividadeId", source = "atividade.id")

--- a/src/main/java/com/AIT/Optimanage/Mappers/FornecedorMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/FornecedorMapper.java
@@ -13,6 +13,7 @@ public interface FornecedorMapper {
 
     @Mapping(target = "atividade", source = "atividadeId", qualifiedByName = "idToAtividade")
     @Mapping(target = "ownerUser", ignore = true)
+    @Mapping(target = "ativo", source = "ativo", defaultValue = "true")
     Fornecedor toEntity(FornecedorRequest request);
 
     @Mapping(target = "atividadeId", source = "atividade.id")

--- a/src/test/java/com/AIT/Optimanage/Services/Cliente/ClienteServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/Cliente/ClienteServiceTest.java
@@ -14,7 +14,7 @@ class ClienteServiceTest {
         cliente.setTipoPessoa(TipoPessoa.PF);
         cliente.setInscricaoMunicipal("12345");
 
-        ClienteService service = new ClienteService(null);
+        ClienteService service = new ClienteService(null, null);
         service.validarCliente(cliente);
 
         assertNull(cliente.getInscricaoMunicipal());


### PR DESCRIPTION
## Summary
- default `ativo` to true in cliente and fornecedor mappers
- update `ClienteServiceTest` to pass mapper in constructor

## Testing
- `./mvnw -q -e test` *(fails: Non-resolvable parent POM: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.4.1 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f255685c8324aa3e7d113df7f5c7