### PR TITLE
Add i18n message bundles and locale configuration

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Config/LocaleConfig.java
+++ b/src/main/java/com/AIT/Optimanage/Config/LocaleConfig.java
@@ -1,0 +1,29 @@
+package com.AIT.Optimanage.Config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+
+import java.util.Locale;
+
+@Configuration
+public class LocaleConfig {
+
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        return messageSource;
+    }
+
+    @Bean
+    public LocaleResolver localeResolver() {
+        AcceptHeaderLocaleResolver resolver = new AcceptHeaderLocaleResolver();
+        resolver.setDefaultLocale(Locale.forLanguageTag("pt"));
+        return resolver;
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/AIT/Optimanage/Exceptions/GlobalExceptionHandler.java
@@ -2,9 +2,12 @@ package com.AIT.Optimanage.Exceptions;
 
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -20,10 +23,13 @@ import java.util.Collections;
 import java.util.List;
 
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
     private static final String PROBLEM_BASE_URI = "https://api.optimanage.com/problems/";
+
+    private final MessageSource messageSource;
 
     private ProblemDetail buildProblemDetail(HttpStatus status, String title, String detail,
                                             String type, String correlationId, List<String> errors) {
@@ -42,7 +48,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleEntityNotFound(EntityNotFoundException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Entity not found: {} - correlationId: {}", ex.getMessage(), correlationId);
-        ProblemDetail problem = buildProblemDetail(HttpStatus.NOT_FOUND, "Entity not found",
+        String title = getMessage("error.entity_not_found");
+        ProblemDetail problem = buildProblemDetail(HttpStatus.NOT_FOUND, title,
                 ex.getMessage(), "entity-not-found", correlationId, Collections.emptyList());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problem);
     }
@@ -51,7 +58,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleIllegalArgument(IllegalArgumentException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Illegal argument: {} - correlationId: {}", ex.getMessage(), correlationId);
-        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, "Bad request",
+        String title = getMessage("error.bad_request");
+        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, title,
                 ex.getMessage(), "illegal-argument", correlationId, Collections.emptyList());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
     }
@@ -63,8 +71,9 @@ public class GlobalExceptionHandler {
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .toList();
         log.warn("Validation failed: {} - correlationId: {}", errors, correlationId);
-        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, "Validation failed",
-                "Validation failed", "validation-error", correlationId, errors);
+        String title = getMessage("error.validation_failed");
+        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, title,
+                title, "validation-error", correlationId, errors);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
     }
 
@@ -75,8 +84,9 @@ public class GlobalExceptionHandler {
                 .map(cv -> cv.getPropertyPath() + ": " + cv.getMessage())
                 .toList();
         log.warn("Validation failed: {} - correlationId: {}", errors, correlationId);
-        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, "Validation failed",
-                "Validation failed", "validation-error", correlationId, errors);
+        String title = getMessage("error.validation_failed");
+        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, title,
+                title, "validation-error", correlationId, errors);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
     }
 
@@ -84,7 +94,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleAccessDenied(AccessDeniedException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Access denied: {} - correlationId: {}", ex.getMessage(), correlationId);
-        ProblemDetail problem = buildProblemDetail(HttpStatus.FORBIDDEN, "Access denied",
+        String title = getMessage("error.access_denied");
+        ProblemDetail problem = buildProblemDetail(HttpStatus.FORBIDDEN, title,
                 ex.getMessage(), "access-denied", correlationId, Collections.emptyList());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(problem);
     }
@@ -93,7 +104,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleLocked(LockedException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Account locked: {} - correlationId: {}", ex.getMessage(), correlationId);
-        ProblemDetail problem = buildProblemDetail(HttpStatus.LOCKED, "Account locked",
+        String title = getMessage("error.account_locked");
+        ProblemDetail problem = buildProblemDetail(HttpStatus.LOCKED, title,
                 ex.getMessage(), "account-locked", correlationId, Collections.emptyList());
         return ResponseEntity.status(HttpStatus.LOCKED).body(problem);
     }
@@ -102,7 +114,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleUserNotFound(UserNotFoundException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("User not found: {} - correlationId: {}", ex.getMessage(), correlationId);
-        ProblemDetail problem = buildProblemDetail(HttpStatus.NOT_FOUND, "User not found",
+        String title = getMessage("error.user_not_found");
+        ProblemDetail problem = buildProblemDetail(HttpStatus.NOT_FOUND, title,
                 ex.getMessage(), "user-not-found", correlationId, Collections.emptyList());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problem);
     }
@@ -111,7 +124,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleInvalidCode(CustomRuntimeException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Invalid code: {} - correlationId: {}", ex.getMessage(), correlationId);
-        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, "Invalid code",
+        String title = getMessage("error.invalid_code");
+        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, title,
                 ex.getMessage(), "invalid-code", correlationId, Collections.emptyList());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
     }
@@ -120,7 +134,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleRefreshTokenNotFound(RefreshTokenNotFoundException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Refresh token not found: {} - correlationId: {}", ex.getMessage(), correlationId);
-        ProblemDetail problem = buildProblemDetail(HttpStatus.NOT_FOUND, "Refresh token not found",
+        String title = getMessage("error.refresh_token_not_found");
+        ProblemDetail problem = buildProblemDetail(HttpStatus.NOT_FOUND, title,
                 ex.getMessage(), "refresh-token-not-found", correlationId, Collections.emptyList());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problem);
     }
@@ -129,7 +144,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleRefreshTokenInvalid(RefreshTokenInvalidException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Refresh token invalid: {} - correlationId: {}", ex.getMessage(), correlationId);
-        ProblemDetail problem = buildProblemDetail(HttpStatus.UNAUTHORIZED, "Refresh token invalid",
+        String title = getMessage("error.refresh_token_invalid");
+        ProblemDetail problem = buildProblemDetail(HttpStatus.UNAUTHORIZED, title,
                 ex.getMessage(), "refresh-token-invalid", correlationId, Collections.emptyList());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(problem);
     }
@@ -138,7 +154,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleCustomRuntime(CustomRuntimeException ex) {
         String correlationId = MDC.get("correlationId");
         log.warn("Runtime exception: {} - correlationId: {}", ex.getMessage(), correlationId);
-        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, "Bad request",
+        String title = getMessage("error.bad_request");
+        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, title,
                 ex.getMessage(), "runtime-exception", correlationId, Collections.emptyList());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
     }
@@ -147,9 +164,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleGeneral(Exception ex) {
         String correlationId = MDC.get("correlationId");
         log.error("Internal server error - correlationId: {}", correlationId, ex);
+        String title = getMessage("error.internal_server_error");
         ProblemDetail problem = buildProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR,
-                "Internal server error", "Internal server error", "internal-server-error",
+                title, title, "internal-server-error",
                 correlationId, Collections.emptyList());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(problem);
+    }
+
+    private String getMessage(String key) {
+        return messageSource.getMessage(key, null, LocaleContextHolder.getLocale());
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Support/EmailService.java
+++ b/src/main/java/com/AIT/Optimanage/Support/EmailService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Async;
@@ -16,6 +18,7 @@ public class EmailService {
 
     // Optional provider so the app can start without mail configuration
     private final ObjectProvider<JavaMailSender> mailSenderProvider;
+    private final MessageSource messageSource;
 
     @Value("${spring.mail.username:no-reply@optimanage.com}")
     private String from;
@@ -24,8 +27,10 @@ public class EmailService {
     public void enviarCodigo(String destino, String codigo) {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(destino);
-        message.setSubject("Código de verificação");
-        message.setText("Seu código é: " + codigo);
+        String subject = messageSource.getMessage("email.verification.subject", null, LocaleContextHolder.getLocale());
+        String text = messageSource.getMessage("email.verification.text", new Object[]{codigo}, LocaleContextHolder.getLocale());
+        message.setSubject(subject);
+        message.setText(text);
         message.setFrom(from);
 
         JavaMailSender sender = mailSenderProvider.getIfAvailable();

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,12 @@
+error.entity_not_found=Entidade não encontrada
+error.bad_request=Requisição inválida
+error.validation_failed=Falha na validação
+error.access_denied=Acesso negado
+error.account_locked=Conta bloqueada
+error.user_not_found=Usuário não encontrado
+error.invalid_code=Código inválido
+error.refresh_token_not_found=Token de atualização não encontrado
+error.refresh_token_invalid=Token de atualização inválido
+error.internal_server_error=Erro interno do servidor
+email.verification.subject=Código de verificação
+email.verification.text=Seu código é: {0}

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1,0 +1,12 @@
+error.entity_not_found=Entity not found
+error.bad_request=Bad request
+error.validation_failed=Validation failed
+error.access_denied=Access denied
+error.account_locked=Account locked
+error.user_not_found=User not found
+error.invalid_code=Invalid code
+error.refresh_token_not_found=Refresh token not found
+error.refresh_token_invalid=Refresh token invalid
+error.internal_server_error=Internal server error
+email.verification.subject=Verification code
+email.verification.text=Your code is: {0}

--- a/src/test/java/com/AIT/Optimanage/Auth/AuthenticationControllerValidationTest.java
+++ b/src/test/java/com/AIT/Optimanage/Auth/AuthenticationControllerValidationTest.java
@@ -1,5 +1,6 @@
 package com.AIT.Optimanage.Auth;
 
+import com.AIT.Optimanage.Config.LocaleConfig;
 import com.AIT.Optimanage.Exceptions.GlobalExceptionHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,7 +21,7 @@ import static org.mockito.Mockito.verify;
 
 @WebMvcTest(controllers = AuthenticationController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@Import(GlobalExceptionHandler.class)
+@Import({GlobalExceptionHandler.class, LocaleConfig.class})
 class AuthenticationControllerValidationTest {
 
     @Autowired
@@ -45,7 +46,7 @@ class AuthenticationControllerValidationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.detail").value("Validation failed"))
+                .andExpect(jsonPath("$.detail").value("Falha na validação"))
                 .andExpect(jsonPath("$.errors[0]").exists())
                 .andExpect(jsonPath("$.correlationId").exists());
     }
@@ -56,7 +57,7 @@ class AuthenticationControllerValidationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"email\":\"invalid\",\"senha\":\"\"}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.detail").value("Validation failed"))
+                .andExpect(jsonPath("$.detail").value("Falha na validação"))
                 .andExpect(jsonPath("$.errors[0]").exists())
                 .andExpect(jsonPath("$.correlationId").exists());
     }

--- a/src/test/java/com/AIT/Optimanage/Controllers/Cliente/ClienteControllerValidationTest.java
+++ b/src/test/java/com/AIT/Optimanage/Controllers/Cliente/ClienteControllerValidationTest.java
@@ -1,5 +1,6 @@
 package com.AIT.Optimanage.Controllers.Cliente;
 
+import com.AIT.Optimanage.Config.LocaleConfig;
 import com.AIT.Optimanage.Exceptions.GlobalExceptionHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = ClienteController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@Import(GlobalExceptionHandler.class)
+@Import({GlobalExceptionHandler.class, LocaleConfig.class})
 class ClienteControllerValidationTest {
 
     @Autowired
@@ -45,7 +46,7 @@ class ClienteControllerValidationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.detail").value("Validation failed"))
+                .andExpect(jsonPath("$.detail").value("Falha na validação"))
                 .andExpect(jsonPath("$.errors[0]").exists())
                 .andExpect(jsonPath("$.correlationId").exists());
     }
@@ -57,7 +58,7 @@ class ClienteControllerValidationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.detail").value("Validation failed"))
+                .andExpect(jsonPath("$.detail").value("Falha na validação"))
                 .andExpect(jsonPath("$.errors[0]").exists())
                 .andExpect(jsonPath("$.correlationId").exists());
     }

--- a/src/test/java/com/AIT/Optimanage/Exceptions/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/AIT/Optimanage/Exceptions/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package com.AIT.Optimanage.Exceptions;
 
+import com.AIT.Optimanage.Config.LocaleConfig;
 import com.AIT.Optimanage.Exceptions.CustomRuntimeException;
 import com.AIT.Optimanage.Exceptions.GlobalExceptionHandler;
 import org.junit.jupiter.api.AfterEach;
@@ -27,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = GlobalExceptionHandlerTest.TestController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@Import(GlobalExceptionHandler.class)
+@Import({GlobalExceptionHandler.class, LocaleConfig.class})
 class GlobalExceptionHandlerTest {
 
     @Autowired
@@ -72,7 +73,7 @@ class GlobalExceptionHandlerTest {
                 .content("{}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.detail").value("Validation failed"))
+                .andExpect(jsonPath("$.detail").value("Falha na validação"))
                 .andExpect(jsonPath("$.errors[0]").exists())
                 .andExpect(jsonPath("$.correlationId").exists());
     }


### PR DESCRIPTION
## Summary
- add Portuguese and English message bundles
- configure MessageSource and Accept-Language resolver
- use localized messages in exceptions and emails

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fa8ac3548324ba38629b5c88d4c6