### PR TITLE
Validate Authorization header on logout

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Auth/AuthenticationController.java
+++ b/src/main/java/com/AIT/Optimanage/Auth/AuthenticationController.java
@@ -86,7 +86,7 @@ public class AuthenticationController extends com.AIT.Optimanage.Controllers.Bas
             return ResponseEntity.badRequest().build();
         }
         if (!authHeader.startsWith("Bearer ")) {
-            log.warn("Logout attempt with malformed Authorization header: {}", authHeader);
+            log.warn("Logout attempt with malformed Authorization header");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         String token = authHeader.substring(7);


### PR DESCRIPTION
## Summary
- validate Authorization header presence and format in logout endpoint
- log invalid logout attempts and return 400 or 401 accordingly
- add tests covering missing or malformed Authorization headers
- avoid logging raw Authorization header value on logout

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c302240f908324837e55c4d4a9ed1d