### PR TITLE
feat: add authentication metrics

### DIFF
--- a/OBSERVABILITY_DASHBOARD.md
+++ b/OBSERVABILITY_DASHBOARD.md
@@ -1,0 +1,12 @@
+# Observability Dashboard
+
+## Authentication Metrics
+
+| Métrica | Descrição |
+| --- | --- |
+| `auth.register.success` | Quantidade de registros de usuários bem-sucedidos |
+| `auth.register.failure` | Registros de usuários que falharam |
+| `auth.authenticate.success` | Autenticações realizadas com sucesso |
+| `auth.authenticate.failure` | Tentativas de autenticação que falharam |
+
+Essas métricas podem ser consultadas via `/actuator/metrics`.

--- a/README.md
+++ b/README.md
@@ -151,4 +151,7 @@ Para executar as migrações manualmente, utilize o Maven especificando a conex�
 - `GET /actuator/metrics` – métricas do sistema e da JVM.
 - `GET /actuator/prometheus` – métricas no formato Prometheus.
 - Traces são exportados via OpenTelemetry OTLP para `http://localhost:4317` por padrão.
+- Métricas de autenticação:
+  - `auth.register.success` / `auth.register.failure` – registros bem-sucedidos ou falhos.
+  - `auth.authenticate.success` / `auth.authenticate.failure` – autenticações bem-sucedidas ou falhas.
 


### PR DESCRIPTION
## Summary
- inject MeterRegistry into AuthenticationService
- track success and failure counters for register and authenticate
- document authentication metrics in README and observability dashboard

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2faf4619c8324956abbc1bac42d4d