### PR TITLE
feat: padronizar cliente com DTO response e mapper

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteController.java
@@ -2,7 +2,7 @@ package com.AIT.Optimanage.Controllers.Cliente;
 
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
 import com.AIT.Optimanage.Controllers.dto.ClienteRequest;
-import com.AIT.Optimanage.Models.Cliente.Cliente;
+import com.AIT.Optimanage.Controllers.dto.ClienteResponse;
 import com.AIT.Optimanage.Models.Cliente.Search.ClienteSearch;
 import com.AIT.Optimanage.Models.Enums.TipoPessoa;
 
@@ -36,7 +36,7 @@ public class ClienteController extends V1BaseController {
     @GetMapping
     @Operation(summary = "Listar clientes", description = "Retorna uma página de clientes")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ResponseEntity<Page<Cliente>> listarClientes(@RequestParam(value = "id", required = false) Integer id,
+    public ResponseEntity<Page<ClienteResponse>> listarClientes(@RequestParam(value = "id", required = false) Integer id,
                                         @RequestParam(value = "nome", required = false) String nome,
                                         @RequestParam(value = "estado", required = false) String estado,
                                         @RequestParam(value = "cpfOuCnpj", required = false) String cpfOuCnpj,
@@ -66,22 +66,22 @@ public class ClienteController extends V1BaseController {
     @GetMapping("/{idCliente}")
     @Operation(summary = "Listar cliente", description = "Retorna um cliente pelo ID")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ResponseEntity<Cliente> listarUmCliente(@PathVariable("idCliente") Integer idCliente) {
+    public ResponseEntity<ClienteResponse> listarUmCliente(@PathVariable("idCliente") Integer idCliente) {
         return ok(clienteService.listarUmCliente(idCliente));
     }
 
     @PostMapping
     @Operation(summary = "Criar cliente", description = "Cria um novo cliente")
     @ApiResponse(responseCode = "201", description = "Criado")
-    public ResponseEntity<Cliente> criarCliente(@RequestBody @Valid ClienteRequest request) {
+    public ResponseEntity<ClienteResponse> criarCliente(@RequestBody @Valid ClienteRequest request) {
         return created(clienteService.criarCliente(request));
     }
 
     @PutMapping("/{idCliente}")
     @Operation(summary = "Editar cliente", description = "Atualiza um cliente existente")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ResponseEntity<Cliente> editarCliente(@PathVariable("idCliente") Integer idCliente,
-                                                 @RequestBody @Valid ClienteRequest request) {
+    public ResponseEntity<ClienteResponse> editarCliente(@PathVariable("idCliente") Integer idCliente,
+                                                         @RequestBody @Valid ClienteRequest request) {
         return ok(clienteService.editarCliente(idCliente, request));
     }
 
@@ -97,7 +97,7 @@ public class ClienteController extends V1BaseController {
     @PutMapping("/{idCliente}/restaurar")
     @Operation(summary = "Restaurar cliente", description = "Reativa um cliente inativo")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ResponseEntity<Cliente> restaurarCliente(@PathVariable("idCliente") Integer idCliente) {
+    public ResponseEntity<ClienteResponse> restaurarCliente(@PathVariable("idCliente") Integer idCliente) {
         return ok(clienteService.reativarCliente(idCliente));
     }
 

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteResponse.java
@@ -1,0 +1,33 @@
+package com.AIT.Optimanage.Controllers.dto;
+
+import com.AIT.Optimanage.Models.Enums.TipoPessoa;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClienteResponse {
+
+    private Integer id;
+    private Integer ownerUserId;
+    private Integer atividadeId;
+    private LocalDate dataCadastro;
+    private TipoPessoa tipoPessoa;
+    private String origem;
+    private Boolean ativo;
+    private String nome;
+    private String nomeFantasia;
+    private String razaoSocial;
+    private String cpf;
+    private String cnpj;
+    private String inscricaoEstadual;
+    private String inscricaoMunicipal;
+    private String site;
+    private String informacoesAdicionais;
+}

--- a/src/main/java/com/AIT/Optimanage/Mappers/ClienteMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/ClienteMapper.java
@@ -1,6 +1,7 @@
 package com.AIT.Optimanage.Mappers;
 
 import com.AIT.Optimanage.Controllers.dto.ClienteRequest;
+import com.AIT.Optimanage.Controllers.dto.ClienteResponse;
 import com.AIT.Optimanage.Models.Atividade;
 import com.AIT.Optimanage.Models.Cliente.Cliente;
 import org.mapstruct.Mapper;
@@ -18,6 +19,10 @@ public interface ClienteMapper {
 
     @Mapping(target = "atividadeId", source = "atividade.id")
     ClienteRequest toRequest(Cliente cliente);
+
+    @Mapping(target = "ownerUserId", source = "ownerUser.id")
+    @Mapping(target = "atividadeId", source = "atividade.id")
+    ClienteResponse toResponse(Cliente cliente);
 
     @Named("idToAtividade")
     default Atividade mapAtividade(Integer atividadeId) {

--- a/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteContatoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteContatoService.java
@@ -25,14 +25,14 @@ public class ClienteContatoService {
 
     public ClienteContato listarUmContato(Integer idCliente, Integer idContato) {
         User loggedUser = CurrentUser.get();
-        Cliente cliente = clienteService.listarUmCliente(idCliente);
+        Cliente cliente = clienteService.buscarCliente(idCliente);
         return clienteContatoRepository.findByIdAndCliente_IdAndClienteOwnerUser(idContato, cliente.getId(), loggedUser)
                 .orElseThrow(() -> new EntityNotFoundException("Contato não encontrado"));
     }
 
     public ClienteContato cadastrarContato(Integer idCliente, ClienteContato contato) {
         User loggedUser = CurrentUser.get();
-        Cliente cliente = clienteService.listarUmCliente(idCliente);
+        Cliente cliente = clienteService.buscarCliente(idCliente);
 
         contato.setId(null);
         contato.setCliente(cliente);

--- a/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteEnderecoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteEnderecoService.java
@@ -25,14 +25,14 @@ public class ClienteEnderecoService {
 
     public ClienteEndereco listarUmEndereco(Integer idCliente, Integer idEndereco) {
         User loggedUser = CurrentUser.get();
-        Cliente cliente = clienteService.listarUmCliente(idCliente);
+        Cliente cliente = clienteService.buscarCliente(idCliente);
         return clienteEnderecoRepository.findByIdAndCliente_IdAndClienteOwnerUser(idEndereco, cliente.getId(), loggedUser)
                 .orElseThrow(() -> new EntityNotFoundException("Endereço não encontrado"));
     }
 
     public ClienteEndereco cadastrarEndereco(Integer idCliente, ClienteEndereco endereco) {
         User loggedUser = CurrentUser.get();
-        Cliente cliente = clienteService.listarUmCliente(idCliente);
+        Cliente cliente = clienteService.buscarCliente(idCliente);
 
         endereco.setId(null);
         endereco.setCliente(cliente);

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -100,7 +100,7 @@ public class VendaService {
     public Venda registrarVenda(User loggedUser, VendaDTO vendaDTO) {
         validarVenda(vendaDTO, loggedUser);
 
-        Cliente cliente = clienteService.listarUmCliente(vendaDTO.getClienteId());
+        Cliente cliente = clienteService.buscarCliente(vendaDTO.getClienteId());
         Contador contador = contadorService.BuscarContador(Tabela.VENDA);
         Venda novaVenda = Venda.builder()
                 .cliente(cliente)


### PR DESCRIPTION
## Summary
- adicionar DTO de resposta para cliente
- mapear cliente para resposta usando mapstruct
- ajustar serviços e controladores para usar `ClienteResponse`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c310ffbd408324b4af667ab27d2132