### PR TITLE
fix: retain entity fetch methods for cliente and fornecedor services

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Cliente/ClienteController.java
@@ -67,7 +67,7 @@ public class ClienteController extends V1BaseController {
     @Operation(summary = "Listar cliente", description = "Retorna um cliente pelo ID")
     @ApiResponse(responseCode = "200", description = "Sucesso")
     public ResponseEntity<ClienteResponse> listarUmCliente(@PathVariable("idCliente") Integer idCliente) {
-        return ok(clienteService.listarUmCliente(idCliente));
+        return ok(clienteService.listarUmClienteResponse(idCliente));
     }
 
     @PostMapping

--- a/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Fornecedor/FornecedorController.java
@@ -60,7 +60,7 @@ public class FornecedorController extends V1BaseController {
     @Operation(summary = "Listar fornecedor", description = "Retorna um fornecedor pelo ID")
     @ApiResponse(responseCode = "200", description = "Sucesso")
     public ResponseEntity<FornecedorResponse> listarUmFornecedor(@PathVariable("idFornecedor") Integer idFornecedor) {
-        return ok(fornecedorService.listarUmFornecedor(idFornecedor));
+        return ok(fornecedorService.listarUmFornecedorResponse(idFornecedor));
     }
 
     @PostMapping

--- a/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
@@ -56,11 +56,14 @@ public class ClienteService {
         ).map(clienteMapper::toResponse);
     }
 
-    public ClienteResponse listarUmCliente(Integer idCliente) {
+    public Cliente listarUmCliente(Integer idCliente) {
         User loggedUser = CurrentUser.get();
-        Cliente cliente = clienteRepository.findByIdAndOwnerUserAndAtivoTrue(idCliente, loggedUser)
+        return clienteRepository.findByIdAndOwnerUserAndAtivoTrue(idCliente, loggedUser)
                 .orElseThrow(() -> new EntityNotFoundException("Cliente não encontrado"));
-        return clienteMapper.toResponse(cliente);
+    }
+
+    public ClienteResponse listarUmClienteResponse(Integer idCliente) {
+        return clienteMapper.toResponse(listarUmCliente(idCliente));
     }
 
     @CacheEvict(value = "clientes", allEntries = true)

--- a/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
@@ -56,11 +56,14 @@ public class FornecedorService {
         ).map(fornecedorMapper::toResponse);
     }
 
-    public FornecedorResponse listarUmFornecedor(Integer idFornecedor) {
+    public Fornecedor listarUmFornecedor(Integer idFornecedor) {
         User loggedUser = CurrentUser.get();
-        Fornecedor fornecedor = fornecedorRepository.findByIdAndOwnerUserAndAtivoTrue(idFornecedor, loggedUser)
+        return fornecedorRepository.findByIdAndOwnerUserAndAtivoTrue(idFornecedor, loggedUser)
                 .orElseThrow(() -> new EntityNotFoundException("Fornecedor não encontrado"));
-        return fornecedorMapper.toResponse(fornecedor);
+    }
+
+    public FornecedorResponse listarUmFornecedorResponse(Integer idFornecedor) {
+        return fornecedorMapper.toResponse(listarUmFornecedor(idFornecedor));
     }
 
     @CacheEvict(value = "fornecedores", allEntries = true)


### PR DESCRIPTION
## Summary
- restore entity-returning methods in ClienteService and FornecedorService
- add DTO-specific methods and update controllers to use them

## Testing
- ⚠️ `./mvnw -q test` (failed: Non-resolvable parent POM for com.AIT:Optimanage:0.0.1-SNAPSHOT)


------
https://chatgpt.com/codex/tasks/task_e_68c31d424bbc832498bc708fe111d887