### PR TITLE
fix: reject scheduling for incompatible purchase status

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -302,10 +302,14 @@ public class CompraService {
             throw new IllegalArgumentException("Não é possível agendar uma compra sem produtos ou serviços.");
         }
 
-        if (compra.getStatus() == StatusCompra.AGUARDANDO_EXECUCAO || compra.getStatus() == StatusCompra.PAGO) {
-            compra.setDataAgendada(LocalDate.parse(dataAgendada));
-            compra.setStatus(StatusCompra.AGENDADA);
+        if (compra.getStatus() != StatusCompra.AGUARDANDO_EXECUCAO && compra.getStatus() != StatusCompra.PAGO) {
+            throw new IllegalStateException(
+                    "Não é possível agendar uma compra com status " + compra.getStatus() + ".");
         }
+
+        compra.setDataAgendada(LocalDate.parse(dataAgendada));
+        atualizarStatus(compra, StatusCompra.AGENDADA);
+
         Compra salvo = compraRepository.save(compra);
         return compraMapper.toResponse(salvo);
     }


### PR DESCRIPTION
## Summary
- enforce allowed statuses before scheduling a purchase
- use existing status validation to ensure illegal transitions throw errors

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c3253392b88324b6925cc6bb887a6c