### PR TITLE
fix: allow pending payments and keep due dates

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Compra/CompraPagamento.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/CompraPagamento.java
@@ -25,7 +25,7 @@ public class CompraPagamento extends BaseEntity {
     @Column(nullable = false, precision = 10, scale = 2)
     private BigDecimal valorPago;
 
-    @Column(nullable = false)
+    @Column
     private LocalDate dataPagamento;
 
     @Column(nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/VendaPagamento.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/VendaPagamento.java
@@ -25,7 +25,7 @@ public class VendaPagamento extends BaseEntity {
     @Column(nullable = false, precision = 10, scale = 2)
     private BigDecimal valorPago;
 
-    @Column(nullable = false)
+    @Column
     private LocalDate dataPagamento;
 
     @Column(nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/PagamentoCompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/PagamentoCompraService.java
@@ -46,7 +46,6 @@ public class PagamentoCompraService {
 
         pagamento.setDataPagamento(LocalDate.now());
         pagamento.setStatusPagamento(StatusPagamento.PAGO);
-        pagamento.setDataVencimento(null);
 
         pagamentoCompraRepository.save(pagamento);
     }
@@ -85,7 +84,6 @@ public class PagamentoCompraService {
             throw new RuntimeException("Pagamento não pode ser estornado");
         }
         compraPagamento.setStatusPagamento(StatusPagamento.ESTORNADO);
-        compraPagamento.setDataVencimento(null);
         pagamentoCompraRepository.save(compraPagamento);
     }
 
@@ -95,7 +93,6 @@ public class PagamentoCompraService {
             throw new RuntimeException("Pagamento não pode ser estornado");
         }
         compraPagamento.setStatusPagamento(StatusPagamento.ESTORNADO);
-        compraPagamento.setDataVencimento(null);
         pagamentoCompraRepository.save(compraPagamento);
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/PagamentoVendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/PagamentoVendaService.java
@@ -41,7 +41,6 @@ public class PagamentoVendaService {
 
         pagamento.setDataPagamento(LocalDate.now());
         pagamento.setStatusPagamento(StatusPagamento.PAGO);
-        pagamento.setDataVencimento(null);
 
         pagamentoVendaRepository.save(pagamento);
     }
@@ -67,7 +66,6 @@ public class PagamentoVendaService {
             throw new RuntimeException("O pagamento não pode ser estornado");
         }
         vendaPagamento.setStatusPagamento(StatusPagamento.ESTORNADO);
-        vendaPagamento.setDataVencimento(null);
         pagamentoVendaRepository.save(vendaPagamento);
     }
 
@@ -77,7 +75,6 @@ public class PagamentoVendaService {
             throw new RuntimeException("O pagamento não pode ser estornado");
         }
         vendaPagamento.setStatusPagamento(StatusPagamento.ESTORNADO);
-        vendaPagamento.setDataVencimento(null);
         pagamentoVendaRepository.save(vendaPagamento);
     }
 


### PR DESCRIPTION
## Summary
- allow pending payments by making `dataPagamento` nullable in purchase and sale entities
- keep `dataVencimento` after confirmation or estorno instead of clearing it

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c32730c5608324b99997829a018636