### PR TITLE
feat: expand user roles

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Auth/AuthenticationService.java
+++ b/src/main/java/com/AIT/Optimanage/Auth/AuthenticationService.java
@@ -55,7 +55,7 @@ public class AuthenticationService {
                     .sobrenome(request.getSobrenome())
                     .email(request.getEmail())
                     .senha(passwordEncoder.encode(request.getSenha()))
-                    .role(Role.USER)
+                    .role(Role.OPERADOR)
                     .ativo(true)
                     .build();
             userRepository.save(user);

--- a/src/main/java/com/AIT/Optimanage/Models/User/Role.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/Role.java
@@ -1,6 +1,8 @@
 package com.AIT.Optimanage.Models.User;
 
 public enum Role {
-    USER,
-    ADMIN;
+    OWNER,
+    ADMIN,
+    OPERADOR,
+    VISUALIZADOR;
 }

--- a/src/test/java/com/AIT/Optimanage/Models/Audit/OwnerEntityListenerTest.java
+++ b/src/test/java/com/AIT/Optimanage/Models/Audit/OwnerEntityListenerTest.java
@@ -36,7 +36,7 @@ class OwnerEntityListenerTest {
                 .sobrenome("Doe")
                 .email("john@example.com")
                 .senha("password")
-                .role(Role.USER)
+                .role(Role.OPERADOR)
                 .build();
         entityManager.persistAndFlush(user);
 


### PR DESCRIPTION
## Summary
- support OWNER, ADMIN, OPERADOR and VISUALIZADOR roles
- default newly registered users to OPERADOR
- update audit test for new role

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4207e2b8483248e8a0f0a46f42522