### PR TITLE
Link users to organizations

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/User/User.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/User.java
@@ -1,7 +1,9 @@
 package com.AIT.Optimanage.Models.User;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.AIT.Optimanage.Models.BaseEntity;
+import com.AIT.Optimanage.Models.Organization.Organization;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,6 +38,11 @@ public class User extends BaseEntity implements UserDetails {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id", insertable = false, updatable = false)
+    private Organization organization;
 
     @Builder.Default
     @Column(nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Services/Organization/OrganizationService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Organization/OrganizationService.java
@@ -67,6 +67,7 @@ public class OrganizationService {
         // Update tenant for owner and organization to the generated id
         Integer orgId = organization.getId();
         owner.setTenantId(orgId);
+        owner.setOrganization(organization);
         userRepository.save(owner);
         organization.setTenantId(orgId);
         organizationRepository.save(organization);
@@ -97,6 +98,7 @@ public class OrganizationService {
                 .senha(passwordEncoder.encode(request.getSenha()))
                 .role(request.getRole())
                 .ativo(true)
+                .organization(organization)
                 .build();
         user.setTenantId(organizationId);
         user = userRepository.save(user);

--- a/src/main/java/com/AIT/Optimanage/Support/PlatformDataInitializer.java
+++ b/src/main/java/com/AIT/Optimanage/Support/PlatformDataInitializer.java
@@ -70,6 +70,9 @@ public class PlatformDataInitializer implements ApplicationRunner {
         organization.setId(1);
         organizationRepository.save(organization);
 
+        owner.setOrganization(organization);
+        userRepository.save(owner);
+
         TenantContext.clear();
     }
 }

--- a/src/test/java/com/AIT/Optimanage/Repositories/ProdutoRepositoryConcurrencyTest.java
+++ b/src/test/java/com/AIT/Optimanage/Repositories/ProdutoRepositoryConcurrencyTest.java
@@ -48,7 +48,7 @@ class ProdutoRepositoryConcurrencyTest {
                 .sobrenome("Doe")
                 .email("john@doe.com")
                 .senha("pwd")
-                .role(Role.USER)
+                .role(Role.OPERADOR)
                 .build();
         userRepository.save(owner);
     }


### PR DESCRIPTION
## Summary
- connect User entity to Organization and expose relationship
- associate users with organizations when creating platform data and managing org members
- adjust concurrency test to reflect updated role enum

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c33249513483249b7cf9a96dfea281