### PR TITLE
Fix permission check for budget status to use organization settings

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Validation/CompraValidator.java
+++ b/src/main/java/com/AIT/Optimanage/Validation/CompraValidator.java
@@ -25,9 +25,12 @@ public class CompraValidator {
                 throw new IllegalArgumentException("Data de cobrança não informada para venda concretizada");
             }
         }
+        boolean permiteOrcamento = loggedUser != null
+                && loggedUser.getOrganization() != null
+                && Boolean.TRUE.equals(loggedUser.getOrganization().getPermiteOrcamento());
         if (compraDTO.getStatus() == null) {
             throw new IllegalArgumentException("Status não informado");
-        } else if (compraDTO.getStatus() == StatusCompra.ORCAMENTO && !loggedUser.getUserInfo().getPermiteOrcamento()) {
+        } else if (compraDTO.getStatus() == StatusCompra.ORCAMENTO && !permiteOrcamento) {
             throw new IllegalArgumentException("Usuário não tem permissão para criar orçamentos");
         }
         if (compraDTO.hasNoItems()) {

--- a/src/main/java/com/AIT/Optimanage/Validation/VendaValidator.java
+++ b/src/main/java/com/AIT/Optimanage/Validation/VendaValidator.java
@@ -23,9 +23,12 @@ public class VendaValidator {
                 throw new IllegalArgumentException("Data de cobrança não informada para venda concretizada");
             }
         }
+        boolean permiteOrcamento = loggedUser != null
+                && loggedUser.getOrganization() != null
+                && Boolean.TRUE.equals(loggedUser.getOrganization().getPermiteOrcamento());
         if (vendaDTO.getStatus() == null) {
             throw new IllegalArgumentException("Status não informado");
-        } else if (vendaDTO.getStatus() == StatusVenda.ORCAMENTO && !loggedUser.getUserInfo().getPermiteOrcamento()) {
+        } else if (vendaDTO.getStatus() == StatusVenda.ORCAMENTO && !permiteOrcamento) {
             throw new IllegalArgumentException("Usuário não tem permissão para criar orçamentos");
         }
         if (vendaDTO.hasNoItems()) {


### PR DESCRIPTION
## Summary
- check the logged user's organization flag before allowing orçamento purchases or sales
- guard the validation against missing user or organization data when evaluating permissions

## Testing
- ./mvnw -q -DskipTests package *(fails: network unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68c9734872148324803438a7254a2cc5