### PR TITLE
Fix context creation flow and adjust payment status checks

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
@@ -86,7 +86,7 @@ public class Venda extends AuditableEntity implements OwnableEntity {
     private List<VendaPagamento> pagamentos;
 
     public boolean isOrcamento() {
-        return this.status.equals(StatusVenda.PENDENTE);
+        return this.status.equals(StatusVenda.ORCAMENTO);
     }
 
     public boolean isPago() {

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -303,6 +303,7 @@ public class CompraService {
             throw new IllegalArgumentException("O pagamento informado não pode ser estornado");
         }
         BigDecimal valorPago = compra.getPagamentos().stream()
+                .filter(pagamentoCompra -> pagamentoCompra.getStatusPagamento() == StatusPagamento.PAGO)
                 .map(CompraPagamento::getValorPago)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
         compra.setValorPendente(compra.getValorFinal().subtract(valorPago));
@@ -310,7 +311,7 @@ public class CompraService {
             if (compra.getStatus() == StatusCompra.AGUARDANDO_PAG || compra.getStatus() == StatusCompra.PARCIALMENTE_PAGO) {
                 atualizarStatus(compra, StatusCompra.PAGO);
             }
-        } else if (valorPago.compareTo(BigDecimal.ZERO) < 0) {
+        } else if (valorPago.compareTo(BigDecimal.ZERO) > 0) {
             atualizarStatus(compra, StatusCompra.PARCIALMENTE_PAGO);
         }
         Compra salvo = compraRepository.save(compra);

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/ContextoCompatibilidadeService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/ContextoCompatibilidadeService.java
@@ -29,14 +29,16 @@ public class ContextoCompatibilidadeService {
     }
 
     public ContextoCompatibilidade criarContexto(User logedUser, ContextoCompatibilidadeDTO request) {
-        ContextoCompatibilidade contexto = listarUmContextoPorNome(logedUser, request.getNome());
-        if (contexto != null) {
+        if (contextoRepository.findByOwnerUserAndNome(logedUser, request.getNome()).isPresent()) {
             throw new RuntimeException("Contexto já existe!");
-        } else {
-            return contextoRepository.save(ContextoCompatibilidade.builder()
-                    .nome(request.getNome())
-                    .build());
-            }
+        }
+
+        ContextoCompatibilidade novoContexto = ContextoCompatibilidade.builder()
+                .ownerUser(logedUser)
+                .nome(request.getNome())
+                .build();
+
+        return contextoRepository.save(novoContexto);
     }
 
     public ContextoCompatibilidade editarContexto(User loggedUser, Integer idContexto, ContextoCompatibilidadeDTO request) {


### PR DESCRIPTION
## Summary
- prevent context creation from reusing the lookup that throws when the context does not exist and persist the new context with its owner
- make `Venda.isOrcamento()` honor the `ORCAMENTO` status instead of `PENDENTE`
- ensure purchase payment estornos only consider paid installments and flag the purchase as partially paid when there is a remaining balance

## Testing
- ./mvnw test *(fails: unable to resolve Spring Boot parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a2090cf88324b5c1e554a6722e08