### PR TITLE
Add fallback defaults for payment configuration

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/AIT/Optimanage/Exceptions/GlobalExceptionHandler.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.AIT.Optimanage.Services.Payment.MissingPaymentConfigurationException;
+
 import java.net.URI;
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -61,6 +63,16 @@ public class GlobalExceptionHandler {
         String title = getMessage("error.bad_request");
         ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, title,
                 ex.getMessage(), "illegal-argument", correlationId, Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
+    }
+
+    @ExceptionHandler(MissingPaymentConfigurationException.class)
+    public ResponseEntity<ProblemDetail> handleMissingPaymentConfig(MissingPaymentConfigurationException ex) {
+        String correlationId = MDC.get("correlationId");
+        log.warn("Missing payment configuration: {} - correlationId: {}", ex.getMessage(), correlationId);
+        String title = getMessage("error.bad_request");
+        ProblemDetail problem = buildProblemDetail(HttpStatus.BAD_REQUEST, title,
+                ex.getMessage(), "missing-payment-config", correlationId, Collections.emptyList());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
     }
 

--- a/src/main/java/com/AIT/Optimanage/Services/Payment/MissingPaymentConfigurationException.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Payment/MissingPaymentConfigurationException.java
@@ -10,6 +10,6 @@ public class MissingPaymentConfigurationException extends RuntimeException {
 
     public MissingPaymentConfigurationException(PaymentProvider provider) {
         super("Nenhuma configuração de pagamento disponível para o provedor " + provider
-                + ". Cadastre as credenciais ou defina chaves padrão antes de iniciar cobranças.");
+                + ". Cadastre as credenciais antes de iniciar cobranças.");
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Services/Payment/MissingPaymentConfigurationException.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Payment/MissingPaymentConfigurationException.java
@@ -1,0 +1,15 @@
+package com.AIT.Optimanage.Services.Payment;
+
+import com.AIT.Optimanage.Models.Payment.PaymentProvider;
+
+/**
+ * Exceção lançada quando não existe configuração de pagamento cadastrada e
+ * nenhuma alternativa padrão pode ser utilizada para o provedor solicitado.
+ */
+public class MissingPaymentConfigurationException extends RuntimeException {
+
+    public MissingPaymentConfigurationException(PaymentProvider provider) {
+        super("Nenhuma configuração de pagamento disponível para o provedor " + provider
+                + ". Cadastre as credenciais ou defina chaves padrão antes de iniciar cobranças.");
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Services/Payment/PaymentConfigService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Payment/PaymentConfigService.java
@@ -5,11 +5,7 @@ import com.AIT.Optimanage.Models.Payment.PaymentProvider;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Repositories.Payment.PaymentConfigRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,80 +13,13 @@ public class PaymentConfigService {
 
     private final PaymentConfigRepository repository;
 
-    @Value("${stripe.api.key:}")
-    private String defaultStripeApiKey;
-
-    @Value("${boleto.api.key:}")
-    private String defaultBoletoApiKey;
-
-    @Value("${pix.api.key:}")
-    private String defaultPixApiKey;
-
-    @Value("${paypal.client.id:}")
-    private String defaultPaypalClientId;
-
-    @Value("${paypal.client.secret:}")
-    private String defaultPaypalClientSecret;
-
-    @Value("${paypal.environment:sandbox}")
-    private String defaultPaypalEnvironment;
-
     public PaymentConfig getConfig(User user, PaymentProvider provider) {
         return repository.findByUserAndProvider(user, provider)
-                .or(() -> fallbackConfig(user, provider))
                 .orElseThrow(() -> new MissingPaymentConfigurationException(provider));
     }
 
     public PaymentConfig getConfig(PaymentProvider provider) {
         return repository.findFirstByProvider(provider)
                 .orElseThrow(() -> new MissingPaymentConfigurationException(provider));
-    }
-
-    private Optional<PaymentConfig> fallbackConfig(User user, PaymentProvider provider) {
-        if (user == null) {
-            return Optional.empty();
-        }
-
-        PaymentConfig.PaymentConfigBuilder builder = PaymentConfig.builder()
-                .provider(provider)
-                .user(user);
-
-        switch (provider) {
-            case STRIPE -> {
-                if (!StringUtils.hasText(defaultStripeApiKey)) {
-                    return Optional.empty();
-                }
-                builder.apiKey(defaultStripeApiKey);
-            }
-            case BOLETO -> {
-                if (!StringUtils.hasText(defaultBoletoApiKey)) {
-                    return Optional.empty();
-                }
-                builder.apiKey(defaultBoletoApiKey);
-            }
-            case PIX -> {
-                if (!StringUtils.hasText(defaultPixApiKey)) {
-                    return Optional.empty();
-                }
-                builder.apiKey(defaultPixApiKey);
-            }
-            case PAYPAL -> {
-                if (!StringUtils.hasText(defaultPaypalClientId) || !StringUtils.hasText(defaultPaypalClientSecret)) {
-                    return Optional.empty();
-                }
-                builder.clientId(defaultPaypalClientId)
-                        .clientSecret(defaultPaypalClientSecret)
-                        .environment(StringUtils.hasText(defaultPaypalEnvironment) ? defaultPaypalEnvironment : null);
-            }
-            default -> {
-                return Optional.empty();
-            }
-        }
-
-        PaymentConfig fallback = builder.build();
-        if (user.getOrganizationId() != null) {
-            fallback.setOrganizationId(user.getOrganizationId());
-        }
-        return Optional.of(fallback);
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Services/Payment/PaymentConfigService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Payment/PaymentConfigService.java
@@ -5,7 +5,11 @@ import com.AIT.Optimanage.Models.Payment.PaymentProvider;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Repositories.Payment.PaymentConfigRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,13 +17,80 @@ public class PaymentConfigService {
 
     private final PaymentConfigRepository repository;
 
+    @Value("${stripe.api.key:}")
+    private String defaultStripeApiKey;
+
+    @Value("${boleto.api.key:}")
+    private String defaultBoletoApiKey;
+
+    @Value("${pix.api.key:}")
+    private String defaultPixApiKey;
+
+    @Value("${paypal.client.id:}")
+    private String defaultPaypalClientId;
+
+    @Value("${paypal.client.secret:}")
+    private String defaultPaypalClientSecret;
+
+    @Value("${paypal.environment:sandbox}")
+    private String defaultPaypalEnvironment;
+
     public PaymentConfig getConfig(User user, PaymentProvider provider) {
         return repository.findByUserAndProvider(user, provider)
-                .orElseThrow(() -> new IllegalArgumentException("Configuração de pagamento não encontrada"));
+                .or(() -> fallbackConfig(user, provider))
+                .orElseThrow(() -> new MissingPaymentConfigurationException(provider));
     }
 
     public PaymentConfig getConfig(PaymentProvider provider) {
         return repository.findFirstByProvider(provider)
-                .orElseThrow(() -> new IllegalArgumentException("Configuração de pagamento não encontrada"));
+                .orElseThrow(() -> new MissingPaymentConfigurationException(provider));
+    }
+
+    private Optional<PaymentConfig> fallbackConfig(User user, PaymentProvider provider) {
+        if (user == null) {
+            return Optional.empty();
+        }
+
+        PaymentConfig.PaymentConfigBuilder builder = PaymentConfig.builder()
+                .provider(provider)
+                .user(user);
+
+        switch (provider) {
+            case STRIPE -> {
+                if (!StringUtils.hasText(defaultStripeApiKey)) {
+                    return Optional.empty();
+                }
+                builder.apiKey(defaultStripeApiKey);
+            }
+            case BOLETO -> {
+                if (!StringUtils.hasText(defaultBoletoApiKey)) {
+                    return Optional.empty();
+                }
+                builder.apiKey(defaultBoletoApiKey);
+            }
+            case PIX -> {
+                if (!StringUtils.hasText(defaultPixApiKey)) {
+                    return Optional.empty();
+                }
+                builder.apiKey(defaultPixApiKey);
+            }
+            case PAYPAL -> {
+                if (!StringUtils.hasText(defaultPaypalClientId) || !StringUtils.hasText(defaultPaypalClientSecret)) {
+                    return Optional.empty();
+                }
+                builder.clientId(defaultPaypalClientId)
+                        .clientSecret(defaultPaypalClientSecret)
+                        .environment(StringUtils.hasText(defaultPaypalEnvironment) ? defaultPaypalEnvironment : null);
+            }
+            default -> {
+                return Optional.empty();
+            }
+        }
+
+        PaymentConfig fallback = builder.build();
+        if (user.getOrganizationId() != null) {
+            fallback.setOrganizationId(user.getOrganizationId());
+        }
+        return Optional.of(fallback);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,6 +44,11 @@ boleto.api.key=${BOLETO_API_KEY:}
 pix.api.url=${PIX_API_URL:https://pix.example.com}
 pix.api.key=${PIX_API_KEY:}
 
+# PayPal payment configuration
+paypal.client.id=${PAYPAL_CLIENT_ID:}
+paypal.client.secret=${PAYPAL_CLIENT_SECRET:}
+paypal.environment=${PAYPAL_ENVIRONMENT:sandbox}
+
 # Tracing (Spring Boot + Micrometer + OTLP)
 management.tracing.enabled=true
 management.tracing.sampling.probability=1.0

--- a/src/test/java/com/AIT/Optimanage/Services/Payment/PaymentConfigServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/Payment/PaymentConfigServiceTest.java
@@ -1,0 +1,82 @@
+package com.AIT.Optimanage.Services.Payment;
+
+import com.AIT.Optimanage.Models.Payment.PaymentConfig;
+import com.AIT.Optimanage.Models.Payment.PaymentProvider;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Repositories.Payment.PaymentConfigRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentConfigServiceTest {
+
+    @Mock
+    private PaymentConfigRepository repository;
+
+    private PaymentConfigService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PaymentConfigService(repository);
+    }
+
+    @Test
+    void shouldReturnPersistedConfigWhenAvailable() {
+        User user = new User();
+        user.setOrganizationId(10);
+        PaymentConfig stored = PaymentConfig.builder()
+                .provider(PaymentProvider.STRIPE)
+                .apiKey("persisted")
+                .user(user)
+                .build();
+        stored.setOrganizationId(10);
+
+        when(repository.findByUserAndProvider(user, PaymentProvider.STRIPE))
+                .thenReturn(Optional.of(stored));
+
+        PaymentConfig result = service.getConfig(user, PaymentProvider.STRIPE);
+
+        assertSame(stored, result);
+    }
+
+    @Test
+    void shouldFallbackToDefaultStripeCredentialsWhenMissing() {
+        User user = new User();
+        user.setOrganizationId(42);
+
+        when(repository.findByUserAndProvider(user, PaymentProvider.STRIPE))
+                .thenReturn(Optional.empty());
+
+        ReflectionTestUtils.setField(service, "defaultStripeApiKey", "sk_test_default");
+
+        PaymentConfig config = service.getConfig(user, PaymentProvider.STRIPE);
+
+        assertNotNull(config);
+        assertEquals(PaymentProvider.STRIPE, config.getProvider());
+        assertEquals("sk_test_default", config.getApiKey());
+        assertEquals(user.getOrganizationId(), config.getOrganizationId());
+        assertSame(user, config.getUser());
+    }
+
+    @Test
+    void shouldThrowWhenConfigMissingAndNoFallbackAvailable() {
+        User user = new User();
+
+        when(repository.findByUserAndProvider(user, PaymentProvider.STRIPE))
+                .thenReturn(Optional.empty());
+
+        ReflectionTestUtils.setField(service, "defaultStripeApiKey", "");
+
+        assertThrows(MissingPaymentConfigurationException.class,
+                () -> service.getConfig(user, PaymentProvider.STRIPE));
+    }
+}

--- a/src/test/java/com/AIT/Optimanage/Services/Payment/PaymentConfigServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/Payment/PaymentConfigServiceTest.java
@@ -9,8 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -49,32 +47,11 @@ class PaymentConfigServiceTest {
     }
 
     @Test
-    void shouldFallbackToDefaultStripeCredentialsWhenMissing() {
-        User user = new User();
-        user.setOrganizationId(42);
-
-        when(repository.findByUserAndProvider(user, PaymentProvider.STRIPE))
-                .thenReturn(Optional.empty());
-
-        ReflectionTestUtils.setField(service, "defaultStripeApiKey", "sk_test_default");
-
-        PaymentConfig config = service.getConfig(user, PaymentProvider.STRIPE);
-
-        assertNotNull(config);
-        assertEquals(PaymentProvider.STRIPE, config.getProvider());
-        assertEquals("sk_test_default", config.getApiKey());
-        assertEquals(user.getOrganizationId(), config.getOrganizationId());
-        assertSame(user, config.getUser());
-    }
-
-    @Test
-    void shouldThrowWhenConfigMissingAndNoFallbackAvailable() {
+    void shouldThrowWhenConfigMissing() {
         User user = new User();
 
         when(repository.findByUserAndProvider(user, PaymentProvider.STRIPE))
                 .thenReturn(Optional.empty());
-
-        ReflectionTestUtils.setField(service, "defaultStripeApiKey", "");
 
         assertThrows(MissingPaymentConfigurationException.class,
                 () -> service.getConfig(user, PaymentProvider.STRIPE));


### PR DESCRIPTION
## Summary
- add fallback logic to PaymentConfigService so new tenants can use configured default credentials when no persisted PaymentConfig exists
- surface missing payment configuration errors via a dedicated exception handler and register configurable PayPal defaults
- cover the fallback behavior with unit tests for PaymentConfigService

## Testing
- `./mvnw test` *(fails: unable to download Spring Boot parent POM because the Maven Central repository is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a239a9dc83248ad525e40c439875