### PR TITLE
Refactor data ownership to organization tenant

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteResponse.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class ClienteResponse {
     private Integer id;
-    private Integer ownerUserId;
+    private Integer organizationId;
     private Integer atividadeId;
     private LocalDate dataCadastro;
     private TipoPessoa tipoPessoa;

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/FornecedorResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/FornecedorResponse.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class FornecedorResponse {
     private Integer id;
-    private Integer ownerUserId;
+    private Integer organizationId;
     private Integer atividadeId;
     private LocalDate dataCadastro;
     private TipoPessoa tipoPessoa;

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoResponse.java
@@ -14,7 +14,7 @@ import java.math.BigDecimal;
 public class ProdutoResponse {
 
     private Integer id;
-    private Integer ownerUserId;
+    private Integer organizationId;
     private Integer fornecedorId;
     private Integer sequencialUsuario;
     private String codigoReferencia;

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ServicoResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ServicoResponse.java
@@ -13,7 +13,7 @@ import java.math.BigDecimal;
 public class ServicoResponse {
 
     private Integer id;
-    private Integer ownerUserId;
+    private Integer organizationId;
     private Integer fornecedorId;
     private Integer sequencialUsuario;
     private String nome;

--- a/src/main/java/com/AIT/Optimanage/Mappers/ClienteMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/ClienteMapper.java
@@ -13,7 +13,6 @@ import org.mapstruct.ReportingPolicy;
 public interface ClienteMapper {
 
     @Mapping(target = "atividade", source = "atividadeId", qualifiedByName = "idToAtividade")
-    @Mapping(target = "ownerUser", ignore = true)
     @Mapping(target = "ativo", source = "ativo", defaultValue = "true")
     Cliente toEntity(ClienteRequest request);
 
@@ -21,7 +20,7 @@ public interface ClienteMapper {
     ClienteRequest toRequest(Cliente cliente);
 
     @Mapping(target = "atividadeId", source = "atividade.id")
-    @Mapping(target = "ownerUserId", source = "ownerUser.id")
+    @Mapping(target = "organizationId", source = "organizationId")
     ClienteResponse toResponse(Cliente cliente);
 
     @Named("idToAtividade")

--- a/src/main/java/com/AIT/Optimanage/Mappers/FornecedorMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/FornecedorMapper.java
@@ -13,14 +13,13 @@ import org.mapstruct.ReportingPolicy;
 public interface FornecedorMapper {
 
     @Mapping(target = "atividade", source = "atividadeId", qualifiedByName = "idToAtividade")
-    @Mapping(target = "ownerUser", ignore = true)
     @Mapping(target = "ativo", source = "ativo", defaultValue = "true")
     Fornecedor toEntity(FornecedorRequest request);
 
     @Mapping(target = "atividadeId", source = "atividade.id")
     FornecedorRequest toRequest(Fornecedor fornecedor);
 
-    @Mapping(target = "ownerUserId", source = "ownerUser.id")
+    @Mapping(target = "organizationId", source = "organizationId")
     @Mapping(target = "atividadeId", source = "atividade.id")
     FornecedorResponse toResponse(Fornecedor fornecedor);
 

--- a/src/main/java/com/AIT/Optimanage/Mappers/ProdutoMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/ProdutoMapper.java
@@ -13,14 +13,13 @@ import org.mapstruct.ReportingPolicy;
 public interface ProdutoMapper {
 
     @Mapping(target = "fornecedor", source = "fornecedorId", qualifiedByName = "idToFornecedor")
-    @Mapping(target = "ownerUser", ignore = true)
     Produto toEntity(ProdutoRequest request);
 
     @Mapping(target = "fornecedorId", source = "fornecedor.id")
     ProdutoRequest toRequest(Produto produto);
 
     @Mapping(target = "fornecedorId", source = "fornecedor.id")
-    @Mapping(target = "ownerUserId", source = "ownerUser.id")
+    @Mapping(target = "organizationId", source = "organizationId")
     ProdutoResponse toResponse(Produto produto);
 
     @Named("idToFornecedor")

--- a/src/main/java/com/AIT/Optimanage/Mappers/ServicoMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/ServicoMapper.java
@@ -13,11 +13,10 @@ import org.mapstruct.ReportingPolicy;
 public interface ServicoMapper {
 
     @Mapping(target = "fornecedor", source = "fornecedorId", qualifiedByName = "idToFornecedor")
-    @Mapping(target = "ownerUser", ignore = true)
     Servico toEntity(ServicoRequest request);
 
     @Mapping(target = "fornecedorId", source = "fornecedor.id")
-    @Mapping(target = "ownerUserId", source = "ownerUser.id")
+    @Mapping(target = "organizationId", source = "organizationId")
     ServicoResponse toResponse(Servico servico);
 
     @Mapping(target = "fornecedorId", source = "fornecedor.id")

--- a/src/main/java/com/AIT/Optimanage/Models/Atividade.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Atividade.java
@@ -2,9 +2,6 @@ package com.AIT.Optimanage.Models;
 
 import com.AIT.Optimanage.Models.Enums.AtividadeAplicavelA;
 import com.AIT.Optimanage.Models.Enums.TipoAtividade;
-import com.AIT.Optimanage.Models.User.User;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;
@@ -17,16 +14,6 @@ import com.AIT.Optimanage.Models.AuditableEntity;
 @Entity
 @EntityListeners(OwnerEntityListener.class)
 public class Atividade extends AuditableEntity implements OwnableEntity {
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = true)
-    private User ownerUser;
-
-    @JsonProperty("owner_user_id")
-    public Integer getOwnerUserId() {
-        return ownerUser != null ? ownerUser.getId() : null;
-    }
-
     @Column(nullable = false)
     private String nomeAtividade;
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/AIT/Optimanage/Models/Audit/OwnerEntityListener.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Audit/OwnerEntityListener.java
@@ -1,7 +1,6 @@
 package com.AIT.Optimanage.Models.Audit;
 
 import com.AIT.Optimanage.Models.OwnableEntity;
-import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Security.CurrentUser;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
@@ -10,21 +9,20 @@ public class OwnerEntityListener {
 
     @PrePersist
     public void prePersist(Object entity) {
-        setOwnerUser(entity);
+        ensureOrganization(entity);
     }
 
     @PreUpdate
     public void preUpdate(Object entity) {
-        setOwnerUser(entity);
+        ensureOrganization(entity);
     }
 
-    private void setOwnerUser(Object entity) {
-        if (entity instanceof OwnableEntity) {
-            OwnableEntity ownable = (OwnableEntity) entity;
-            if (ownable.getOwnerUser() == null) {
-                User current = CurrentUser.get();
-                if (current != null) {
-                    ownable.setOwnerUser(current);
+    private void ensureOrganization(Object entity) {
+        if (entity instanceof OwnableEntity ownable) {
+            if (ownable.getOrganizationId() == null) {
+                Integer organizationId = CurrentUser.getOrganizationId();
+                if (organizationId != null) {
+                    ownable.setOrganizationId(organizationId);
                 }
             }
         }

--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
@@ -2,7 +2,6 @@ package com.AIT.Optimanage.Models.Cliente;
 
 import com.AIT.Optimanage.Models.Atividade;
 import com.AIT.Optimanage.Models.Enums.TipoPessoa;
-import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
@@ -21,16 +20,6 @@ import java.util.List;
 @Entity
 @EntityListeners(OwnerEntityListener.class)
 public class Cliente extends AuditableEntity implements OwnableEntity {
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)
-    private User ownerUser;
-
-    @JsonProperty("owner_user_id")
-    public Integer getOwnerUserId() {
-        return ownerUser != null ? ownerUser.getId() : null;
-    }
-
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "atividade_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
@@ -2,9 +2,7 @@ package com.AIT.Optimanage.Models.Compra;
 
 import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
 import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
-import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import com.AIT.Optimanage.Models.OwnableEntity;
@@ -23,16 +21,6 @@ import java.util.List;
 @Entity
 @EntityListeners(OwnerEntityListener.class)
 public class Compra extends AuditableEntity implements OwnableEntity {
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)
-    private User ownerUser;
-
-    @JsonProperty("owner_user_id")
-    public Integer getOwnerUserId() {
-        return ownerUser != null ? ownerUser.getId() : null;
-    }
-
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     private Fornecedor fornecedor;

--- a/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
@@ -2,7 +2,6 @@ package com.AIT.Optimanage.Models.Fornecedor;
 
 import com.AIT.Optimanage.Models.Atividade;
 import com.AIT.Optimanage.Models.Enums.TipoPessoa;
-import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
@@ -23,16 +22,6 @@ import java.util.List;
 @Entity
 @EntityListeners(OwnerEntityListener.class)
 public class Fornecedor extends AuditableEntity implements OwnableEntity {
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)
-    private User ownerUser;
-
-    @JsonProperty("owner_user_id")
-    public Integer getOwnerUserId() {
-        return ownerUser != null ? ownerUser.getId() : null;
-    }
-
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "atividade_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Funcionario.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Funcionario.java
@@ -1,8 +1,5 @@
 package com.AIT.Optimanage.Models;
 
-import com.AIT.Optimanage.Models.User.User;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;
@@ -15,16 +12,6 @@ import com.AIT.Optimanage.Models.AuditableEntity;
 @Entity
 @EntityListeners(OwnerEntityListener.class)
 public class Funcionario extends AuditableEntity implements OwnableEntity {
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)
-    private User ownerUser;
-
-    @JsonProperty("owner_user_id")
-    public Integer getOwnerUserId() {
-        return ownerUser != null ? ownerUser.getId() : null;
-    }
-
     @Column(nullable = false)
     private Integer sequencialUsuario;
     @Column(nullable = false, length = 64)

--- a/src/main/java/com/AIT/Optimanage/Models/Inventory/InventoryHistory.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Inventory/InventoryHistory.java
@@ -4,7 +4,6 @@ import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import com.AIT.Optimanage.Models.BaseEntity;
 import com.AIT.Optimanage.Models.OwnableEntity;
 import com.AIT.Optimanage.Models.Produto;
-import com.AIT.Optimanage.Models.User.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -28,10 +27,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @EntityListeners(OwnerEntityListener.class)
 public class InventoryHistory extends BaseEntity implements OwnableEntity {
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)
-    private User ownerUser;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "produto_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/OwnableEntity.java
+++ b/src/main/java/com/AIT/Optimanage/Models/OwnableEntity.java
@@ -1,11 +1,9 @@
 package com.AIT.Optimanage.Models;
 
-import com.AIT.Optimanage.Models.User.User;
-
 /**
- * Contract for entities that are owned by a {@link User}.
+ * Contract for entities that belong to a specific organization.
  */
 public interface OwnableEntity {
-    User getOwnerUser();
-    void setOwnerUser(User ownerUser);
+    Integer getOrganizationId();
+    void setOrganizationId(Integer organizationId);
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Produto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Produto.java
@@ -2,9 +2,7 @@ package com.AIT.Optimanage.Models;
 
 import com.AIT.Optimanage.Models.Venda.Compatibilidade.Compatibilidade;
 import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
-import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;
@@ -20,16 +18,6 @@ import java.util.List;
 @Entity
 @EntityListeners(OwnerEntityListener.class)
 public class Produto extends AuditableEntity implements OwnableEntity {
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)
-    private User ownerUser;
-
-    @JsonProperty("owner_user_id")
-    public Integer getOwnerUserId() {
-        return ownerUser != null ? ownerUser.getId() : null;
-    }
-
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fornecedor_id", referencedColumnName = "id", nullable = true)

--- a/src/main/java/com/AIT/Optimanage/Models/Servico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Servico.java
@@ -2,9 +2,7 @@ package com.AIT.Optimanage.Models;
 
 import com.AIT.Optimanage.Models.Venda.Compatibilidade.Compatibilidade;
 import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
-import com.AIT.Optimanage.Models.User.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;
@@ -20,16 +18,6 @@ import java.util.List;
 @Entity
 @EntityListeners(OwnerEntityListener.class)
 public class Servico extends AuditableEntity implements OwnableEntity {
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)
-    private User ownerUser;
-
-    @JsonProperty("owner_user_id")
-    public Integer getOwnerUserId() {
-        return ownerUser != null ? ownerUser.getId() : null;
-    }
-
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fornecedor_id", referencedColumnName = "id", nullable = true)

--- a/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
@@ -1,7 +1,5 @@
 package com.AIT.Optimanage.Models.User;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import com.AIT.Optimanage.Models.OwnableEntity;
@@ -15,16 +13,6 @@ import com.AIT.Optimanage.Models.AuditableEntity;
 @Entity
 @EntityListeners(OwnerEntityListener.class)
 public class Contador extends AuditableEntity implements OwnableEntity {
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)
-    private User ownerUser;
-
-    @JsonProperty("owner_user_id")
-    public Integer getOwnerUserId() {
-        return ownerUser != null ? ownerUser.getId() : null;
-    }
-
     @Column(nullable = false)
     private Tabela nomeTabela;
     @Column(nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Compatibilidade/ContextoCompatibilidade.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Compatibilidade/ContextoCompatibilidade.java
@@ -1,7 +1,5 @@
 package com.AIT.Optimanage.Models.Venda.Compatibilidade;
 
-import com.AIT.Optimanage.Models.User.User;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import com.AIT.Optimanage.Models.OwnableEntity;
@@ -18,11 +16,6 @@ import com.AIT.Optimanage.Models.AuditableEntity;
 @Entity
 @EntityListeners(OwnerEntityListener.class)
 public class ContextoCompatibilidade extends AuditableEntity implements OwnableEntity {
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)
-    private User ownerUser;
-
     @Column(nullable = false)
     private String nome; // Ex: "Ford Fiesta 1.6 2014", "Windows 10", "Idosos acima de 60 anos"
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
@@ -1,11 +1,9 @@
 package com.AIT.Optimanage.Models.Venda;
 
 import com.AIT.Optimanage.Models.Cliente.Cliente;
-import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Models.Venda.Related.Alteracao;
 import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import com.AIT.Optimanage.Models.OwnableEntity;
@@ -24,16 +22,6 @@ import java.util.List;
 @Entity
 @EntityListeners(OwnerEntityListener.class)
 public class Venda extends AuditableEntity implements OwnableEntity {
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_user_id", referencedColumnName = "id", nullable = false)
-    private User ownerUser;
-
-    @JsonProperty("owner_user_id")
-    public Integer getOwnerUserId() {
-        return ownerUser != null ? ownerUser.getId() : null;
-    }
-
     @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "cliente_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Repositories/Cliente/ClienteRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Cliente/ClienteRepository.java
@@ -2,7 +2,6 @@ package com.AIT.Optimanage.Repositories.Cliente;
 
 import com.AIT.Optimanage.Models.Cliente.Cliente;
 import com.AIT.Optimanage.Models.Enums.TipoPessoa;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,24 +15,24 @@ import java.util.Optional;
 @Repository
 public interface ClienteRepository extends JpaRepository<Cliente, Integer> {
 
-    List<Cliente> findByOwnerUserAndAtivoTrue(User ownerUser);
+    List<Cliente> findByOrganizationIdAndAtivoTrue(Integer organizationId);
 
     @Query("SELECT DISTINCT c FROM Cliente c " +
             "LEFT JOIN c.enderecos e " +
             "WHERE " +
-            "(:userId IS NULL OR c.ownerUser.id = :userId) AND " +
+            "(:organizationId IS NULL OR c.organizationId = :organizationId) AND " +
             "(:id IS NULL OR c.id = :id) AND " +
             "(:nome IS NULL OR LOWER(c.nome) LIKE LOWER(CONCAT('%', :nome, '%')) " +
-            "OR LOWER(c.nomeFantasia) LIKE LOWER(CONCAT('%', :nome, '%'))) AND " +
+            "    OR LOWER(c.nomeFantasia) LIKE LOWER(CONCAT('%', :nome, '%'))) AND " +
             "(:cpfOuCnpj IS NULL OR " +
-            " REPLACE(REPLACE(REPLACE(c.cpf, '.', ''), '-', ''), '/', '') = REPLACE(REPLACE(REPLACE(:cpfOuCnpj, '.', ''), '-', ''), '/', '') " +
-            " OR REPLACE(REPLACE(REPLACE(c.cnpj, '.', ''), '-', ''), '/', '') = REPLACE(REPLACE(REPLACE(:cpfOuCnpj, '.', ''), '-', ''), '/', '')) AND " +
+            "    REPLACE(REPLACE(REPLACE(c.cpf, '.', ''), '-', ''), '/', '') = REPLACE(REPLACE(REPLACE(:cpfOuCnpj, '.', ''), '-', ''), '/', '') " +
+            "    OR REPLACE(REPLACE(REPLACE(c.cnpj, '.', ''), '-', ''), '/', '') = REPLACE(REPLACE(REPLACE(:cpfOuCnpj, '.', ''), '-', ''), '/', '')) AND " +
             "(:atividade IS NULL OR c.atividade.id = :atividade) AND " +
             "(:estado IS NULL OR EXISTS (SELECT 1 FROM ClienteEndereco e WHERE e.cliente.id = c.id AND e.estado = :estado)) AND " +
             "(:tipoPessoa IS NULL OR c.tipoPessoa = :tipoPessoa) AND " +
             "(:ativo IS NULL OR c.ativo = :ativo)")
     Page<Cliente> buscarClientes(
-            @Param("userId") Integer userId,
+            @Param("organizationId") Integer organizationId,
             @Param("id") Integer id,
             @Param("nome") String nome,
             @Param("cpfOuCnpj") String cpfOuCnpj,
@@ -44,9 +43,9 @@ public interface ClienteRepository extends JpaRepository<Cliente, Integer> {
             Pageable pageable
     );
 
-    Optional<Cliente> findByIdAndOwnerUserAndAtivoTrue(Integer idCliente, User loggedUser);
+    Optional<Cliente> findByIdAndOrganizationIdAndAtivoTrue(Integer idCliente, Integer organizationId);
 
-    Optional<Cliente> findByIdAndOwnerUser(Integer idCliente, User loggedUser);
+    Optional<Cliente> findByIdAndOrganizationId(Integer idCliente, Integer organizationId);
 
     long countByOrganizationIdAndAtivoTrue(Integer organizationId);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraFilters.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraFilters.java
@@ -21,8 +21,8 @@ public class CompraFilters {
         // Classe utilitária
     }
 
-    public static Specification<Compra> hasOwner(Integer ownerId) {
-        return (root, query, cb) -> cb.equal(root.get("ownerUser").get("id"), ownerId);
+    public static Specification<Compra> hasOrganization(Integer organizationId) {
+        return (root, query, cb) -> cb.equal(root.get("organizationId"), organizationId);
     }
 
     public static Specification<Compra> hasSequencialUsuario(Integer id) {

--- a/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
@@ -1,12 +1,11 @@
 package com.AIT.Optimanage.Repositories.Compra;
 
 import com.AIT.Optimanage.Models.Compra.Compra;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.Optional;
 
 public interface CompraRepository extends JpaRepository<Compra, Integer>, JpaSpecificationExecutor<Compra> {
-    Optional<Compra> findByIdAndOwnerUser(Integer idCompra, User loggedUser);
+    Optional<Compra> findByIdAndOrganizationId(Integer idCompra, Integer organizationId);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Fornecedor/FornecedorRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Fornecedor/FornecedorRepository.java
@@ -2,7 +2,6 @@ package com.AIT.Optimanage.Repositories.Fornecedor;
 
 import com.AIT.Optimanage.Models.Enums.TipoPessoa;
 import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,24 +14,22 @@ import java.util.Optional;
 @Repository
 public interface FornecedorRepository extends JpaRepository<Fornecedor, Integer> {
 
-
     @Query("SELECT DISTINCT f FROM Fornecedor f " +
             "LEFT JOIN f.enderecos e " +
             "WHERE " +
-            "(:userId IS NULL OR f.ownerUser.id = :userId) AND " +
-            "(:id IS NULL OR f.id = :id) OR " +
-            "(:userId IS NULL OR f.ownerUser.id = :userId) AND " +
+            "(:organizationId IS NULL OR f.organizationId = :organizationId) AND " +
+            "(:id IS NULL OR f.id = :id) AND " +
             "(:nome IS NULL OR LOWER(f.nome) LIKE LOWER(CONCAT('%', :nome, '%')) " +
-            "OR LOWER(f.nomeFantasia) LIKE LOWER(CONCAT('%', :nome, '%'))) AND " +
+            "    OR LOWER(f.nomeFantasia) LIKE LOWER(CONCAT('%', :nome, '%'))) AND " +
             "(:cpfOuCnpj IS NULL OR " +
-            " REPLACE(REPLACE(REPLACE(f.cpf, '.', ''), '-', ''), '/', '') = REPLACE(REPLACE(REPLACE(:cpfOuCnpj, '.', ''), '-', ''), '/', '') " +
-            " OR REPLACE(REPLACE(REPLACE(f.cnpj, '.', ''), '-', ''), '/', '') = REPLACE(REPLACE(REPLACE(:cpfOuCnpj, '.', ''), '-', ''), '/', '')) AND " +
+            "    REPLACE(REPLACE(REPLACE(f.cpf, '.', ''), '-', ''), '/', '') = REPLACE(REPLACE(REPLACE(:cpfOuCnpj, '.', ''), '-', ''), '/', '') " +
+            "    OR REPLACE(REPLACE(REPLACE(f.cnpj, '.', ''), '-', ''), '/', '') = REPLACE(REPLACE(REPLACE(:cpfOuCnpj, '.', ''), '-', ''), '/', '')) AND " +
             "(:atividade IS NULL OR f.atividade.id = :atividade) AND " +
             "(:estado IS NULL OR EXISTS (SELECT 1 FROM ClienteEndereco e WHERE e.cliente.id = f.id AND e.estado = :estado)) AND " +
             "(:tipoPessoa IS NULL OR f.tipoPessoa = :tipoPessoa) AND " +
             "(:ativo IS NULL OR f.ativo = :ativo)")
     Page<Fornecedor> buscarFornecedores(
-            @Param("userId") Integer userId,
+            @Param("organizationId") Integer organizationId,
             @Param("id") Integer id,
             @Param("nome") String nome,
             @Param("cpfOuCnpj") String cpfOuCnpj,
@@ -43,11 +40,11 @@ public interface FornecedorRepository extends JpaRepository<Fornecedor, Integer>
             Pageable pageable
     );
 
-    Optional<Fornecedor> findByIdAndOwnerUserAndAtivoTrue(Integer idFornecedor, User loggedUser);
+    Optional<Fornecedor> findByIdAndOrganizationIdAndAtivoTrue(Integer idFornecedor, Integer organizationId);
 
-    Optional<Fornecedor> findByIdAndOwnerUserAndAtivoFalse(Integer idFornecedor, User loggedUser);
+    Optional<Fornecedor> findByIdAndOrganizationIdAndAtivoFalse(Integer idFornecedor, Integer organizationId);
 
-    Optional<Fornecedor> findByIdAndOwnerUser(Integer idFornecedor, User loggedUser);
+    Optional<Fornecedor> findByIdAndOrganizationId(Integer idFornecedor, Integer organizationId);
 
     long countByOrganizationIdAndAtivoTrue(Integer organizationId);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
@@ -1,14 +1,10 @@
 package com.AIT.Optimanage.Repositories.Organization;
 
 import com.AIT.Optimanage.Models.Organization.Organization;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface OrganizationRepository extends JpaRepository<Organization, Integer> {
-    Optional<Organization> findByOwnerUser(User ownerUser);
 }
 

--- a/src/main/java/com/AIT/Optimanage/Repositories/ProdutoRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/ProdutoRepository.java
@@ -1,7 +1,6 @@
 package com.AIT.Optimanage.Repositories;
 
 import com.AIT.Optimanage.Models.Produto;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,11 +13,11 @@ import java.util.Optional;
 @Repository
 public interface ProdutoRepository extends JpaRepository<Produto, Integer> {
 
-    Page<Produto> findAllByOwnerUserAndAtivoTrue(User loggedUser, Pageable pageable);
+    Page<Produto> findAllByOrganizationIdAndAtivoTrue(Integer organizationId, Pageable pageable);
 
-    Optional<Produto> findByIdAndOwnerUserAndAtivoTrue(Integer idProduto, User loggedUser);
+    Optional<Produto> findByIdAndOrganizationIdAndAtivoTrue(Integer idProduto, Integer organizationId);
 
-    Optional<Produto> findByIdAndOwnerUser(Integer idProduto, User loggedUser);
+    Optional<Produto> findByIdAndOrganizationId(Integer idProduto, Integer organizationId);
 
     @Modifying
     @Query("update Produto p set p.qtdEstoque = p.qtdEstoque - :quantidade where p.id = :id and p.qtdEstoque >= :quantidade")

--- a/src/main/java/com/AIT/Optimanage/Repositories/ServicoRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/ServicoRepository.java
@@ -1,7 +1,6 @@
 package com.AIT.Optimanage.Repositories;
 
 import com.AIT.Optimanage.Models.Servico;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,11 +11,11 @@ import java.util.Optional;
 @Repository
 public interface ServicoRepository extends JpaRepository<Servico, Integer> {
 
-    Page<Servico> findAllByOwnerUserAndAtivoTrue(User ownerUser, Pageable pageable);
+    Page<Servico> findAllByOrganizationIdAndAtivoTrue(Integer organizationId, Pageable pageable);
 
-    Optional<Servico> findByIdAndOwnerUserAndAtivoTrue(Integer idServico, User ownerUser);
+    Optional<Servico> findByIdAndOrganizationIdAndAtivoTrue(Integer idServico, Integer organizationId);
 
-    Optional<Servico> findByIdAndOwnerUser(Integer idServico, User ownerUser);
+    Optional<Servico> findByIdAndOrganizationId(Integer idServico, Integer organizationId);
 
     long countByOrganizationIdAndAtivoTrue(Integer organizationId);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/Compatibilidade/ContextoCompatibilidadeRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/Compatibilidade/ContextoCompatibilidadeRepository.java
@@ -1,7 +1,6 @@
 package com.AIT.Optimanage.Repositories.Venda.Compatibilidade;
 
 import com.AIT.Optimanage.Models.Venda.Compatibilidade.ContextoCompatibilidade;
-import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,7 +11,7 @@ import java.util.Optional;
 
 @Repository
 public interface ContextoCompatibilidadeRepository extends JpaRepository<ContextoCompatibilidade, Integer> {
-    Optional<ContextoCompatibilidade> findByOwnerUserAndNome(User loggedUser, String nome);
+    Optional<ContextoCompatibilidade> findByOrganizationIdAndNome(Integer organizationId, String nome);
 
-    Page<ContextoCompatibilidade> findAllByOwnerUser(User loggedUser, Pageable pageable);
+    Page<ContextoCompatibilidade> findAllByOrganizationId(Integer organizationId, Pageable pageable);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/PagamentoVendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/PagamentoVendaRepository.java
@@ -1,7 +1,6 @@
 package com.AIT.Optimanage.Repositories.Venda;
 
 import com.AIT.Optimanage.Models.Enums.StatusPagamento;
-import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Models.Venda.Venda;
 import com.AIT.Optimanage.Models.Venda.VendaPagamento;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,13 +12,13 @@ import java.util.Optional;
 
 @Repository
 public interface PagamentoVendaRepository extends JpaRepository<VendaPagamento, Integer> {
-    List<VendaPagamento> findAllByVendaIdAndVendaOwnerUser(Integer idVenda, User loggedUser);
+    List<VendaPagamento> findAllByVendaIdAndVendaOrganizationId(Integer idVenda, Integer organizationId);
 
-    List<VendaPagamento> findAllByVendaIdAndVendaOwnerUserAndStatusPagamento(Integer idVenda, User loggedUser, StatusPagamento statusPagamento);
+    List<VendaPagamento> findAllByVendaIdAndVendaOrganizationIdAndStatusPagamento(Integer idVenda, Integer organizationId, StatusPagamento statusPagamento);
 
-    Optional<VendaPagamento> findByIdAndVendaOwnerUser(Integer idPagamento, User loggedUser);
+    Optional<VendaPagamento> findByIdAndVendaOrganizationId(Integer idPagamento, Integer organizationId);
 
-    Optional<VendaPagamento> findByIdAndVendaAndVendaOwnerUser(Integer idPagamento, Venda venda, User loggedUser);
+    Optional<VendaPagamento> findByIdAndVendaAndVendaOrganizationId(Integer idPagamento, Venda venda, Integer organizationId);
 
-    List<VendaPagamento> findAllByVendaOwnerUserAndStatusPagamentoAndDataVencimentoAfter(User loggedUser, StatusPagamento statusPagamento, LocalDate dataVencimento);
+    List<VendaPagamento> findAllByVendaOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(Integer organizationId, StatusPagamento statusPagamento, LocalDate dataVencimento);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -1,6 +1,5 @@
 package com.AIT.Optimanage.Repositories.Venda;
 
-import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Models.Enums.FormaPagamento;
 import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
 import com.AIT.Optimanage.Models.Venda.Venda;
@@ -24,8 +23,8 @@ public interface VendaRepository extends JpaRepository<Venda, Integer> {
             "LEFT JOIN FETCH vs.servico s " +
             "LEFT JOIN v.pagamentos pag " +
             "WHERE " +
-            "((:id IS NOT NULL AND v.ownerUser.id = :userId AND v.sequencialUsuario = :id) " +
-            "OR (:userId IS NULL OR v.ownerUser.id = :userId)) " +
+            "((:id IS NOT NULL AND v.organizationId = :organizationId AND v.sequencialUsuario = :id) " +
+            "OR (:organizationId IS NULL OR v.organizationId = :organizationId)) " +
             "AND (:clienteId IS NULL OR v.cliente.id = :clienteId) " +
             "AND (:dataInicial IS NULL OR v.dataEfetuacao >= :dataInicial) " +
             "AND (:dataFinal IS NULL OR v.dataEfetuacao <= :dataFinal) " +
@@ -33,7 +32,7 @@ public interface VendaRepository extends JpaRepository<Venda, Integer> {
             "AND (:pago IS NULL OR (CASE WHEN v.valorPendente <= 0 THEN TRUE ELSE FALSE END) = :pago) " +
             "AND (:formaPagamento IS NULL OR EXISTS (SELECT 1 FROM VendaPagamento pagSub WHERE pagSub.venda.id = v.id AND pagSub.formaPagamento = :formaPagamento))")
     Page<Venda> buscarVendas(
-            @Param("userId") Integer userId,
+            @Param("organizationId") Integer organizationId,
             @Param("id") Integer id,
             @Param("clienteId") Integer clienteId,
             @Param("dataInicial") String dataInicial,
@@ -44,18 +43,18 @@ public interface VendaRepository extends JpaRepository<Venda, Integer> {
             Pageable pageable
     );
 
-    Optional<Venda> findByIdAndOwnerUser(Integer idVenda, User loggedUser);
+    Optional<Venda> findByIdAndOrganizationId(Integer idVenda, Integer organizationId);
 
     @Query("SELECT vp.produto.id AS produtoId, SUM(vp.quantidade) AS totalQuantidade " +
             "FROM Venda v JOIN v.vendaProdutos vp " +
-            "WHERE v.cliente.id = :clienteId AND v.ownerUser.id = :userId " +
+            "WHERE v.cliente.id = :clienteId AND v.organizationId = :organizationId " +
             "GROUP BY vp.produto.id ORDER BY totalQuantidade DESC")
     List<Object[]> findTopProdutosByCliente(@Param("clienteId") Integer clienteId,
-                                            @Param("userId") Integer userId);
+                                            @Param("organizationId") Integer organizationId);
 
     @Query("SELECT DISTINCT v FROM Venda v " +
             "JOIN FETCH v.vendaProdutos vp " +
             "JOIN FETCH vp.produto p " +
-            "WHERE v.ownerUser.id = :userId")
-    List<Venda> findAllWithProdutosByOwnerUser(@Param("userId") Integer userId);
+            "WHERE v.organizationId = :organizationId")
+    List<Venda> findAllWithProdutosByOrganization(@Param("organizationId") Integer organizationId);
 }

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -83,6 +83,10 @@ public class CompraService {
     @Transactional(readOnly = true)
     public Page<CompraResponseDTO> listarCompras(CompraSearch pesquisa) {
         User loggedUser = CurrentUser.get();
+        Integer organizationId = CurrentUser.getOrganizationId();
+        if (organizationId == null) {
+            throw new EntityNotFoundException("Organização não encontrada");
+        }
         // Configuração de paginação e ordenação
         Sort.Direction direction = Optional.ofNullable(pesquisa.getOrder()).filter(Sort.Direction::isDescending)
                 .map(order -> Sort.Direction.DESC).orElse(Sort.Direction.ASC);
@@ -91,7 +95,7 @@ public class CompraService {
         Pageable pageable = PageRequest.of(pesquisa.getPage(), pesquisa.getPageSize(), Sort.by(direction, sortBy));
 
         Specification<Compra> spec = FilterBuilder
-                .of(CompraFilters.hasOwner(loggedUser.getId()))
+                .of(CompraFilters.hasOrganization(organizationId))
                 .and(pesquisa.getId(), CompraFilters::hasSequencialUsuario)
                 .and(pesquisa.getFornecedorId(), CompraFilters::hasFornecedor)
                 .and(pesquisa.getDataInicial(), d -> CompraFilters.dataEfetuacaoAfter(LocalDate.parse(d)))
@@ -106,8 +110,11 @@ public class CompraService {
     }
 
     private Compra getCompra(Integer idCompra) {
-        User loggedUser = CurrentUser.get();
-        return compraRepository.findByIdAndOwnerUser(idCompra, loggedUser)
+        Integer organizationId = CurrentUser.getOrganizationId();
+        if (organizationId == null) {
+            throw new EntityNotFoundException("Organização não encontrada");
+        }
+        return compraRepository.findByIdAndOrganizationId(idCompra, organizationId)
                 .orElseThrow(() -> new RuntimeException("Compra não encontrada"));
     }
 
@@ -156,6 +163,7 @@ public class CompraService {
         novaCompra.setValorPendente(valorTotal.subtract(valorPago));
 
         
+        novaCompra.setTenantId(organizationId);
         compraRepository.save(novaCompra);
         compraProdutoRepository.saveAll(compraProdutos);
         compraServicoRepository.saveAll(compraServicos);
@@ -187,6 +195,7 @@ public class CompraService {
                 .status(compraDTO.getStatus())
                 .observacoes(compraDTO.getObservacoes())
                 .build();
+        compraAtualizada.setTenantId(compra.getOrganizationId());
 
         compra.getCompraProdutos().forEach(cp ->
                 inventoryService.reduzir(cp.getProduto().getId(), cp.getQuantidade(), InventorySource.COMPRA,

--- a/src/main/java/com/AIT/Optimanage/Services/InventoryService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/InventoryService.java
@@ -81,7 +81,6 @@ public class InventoryService {
                                     Integer referenciaId, String descricao) {
         InventoryHistory historico = InventoryHistory.builder()
                 .produto(produto)
-                .ownerUser(produto.getOwnerUser())
                 .action(action)
                 .source(source)
                 .referenceId(referenciaId)

--- a/src/main/java/com/AIT/Optimanage/Services/User/UsuarioService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/User/UsuarioService.java
@@ -71,7 +71,7 @@ public class UsuarioService {
     @Transactional
     public UserResponse atualizarPlanoAtivo(Integer id, Integer novoPlanoId) {
         User usuario = getUsuario(id);
-        Organization organization = organizationRepository.findByOwnerUser(usuario)
+        Organization organization = organizationRepository.findById(usuario.getOrganizationId())
                 .orElseThrow(() -> new EntityNotFoundException("Informações do usuário não encontradas"));
         Plano plano = planoRepository.findById(novoPlanoId)
                 .orElseThrow(() -> new EntityNotFoundException("Plano não encontrado"));

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/PagamentoVendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/PagamentoVendaService.java
@@ -6,6 +6,7 @@ import com.AIT.Optimanage.Models.Enums.StatusPagamento;
 import com.AIT.Optimanage.Models.Venda.Venda;
 import com.AIT.Optimanage.Models.Venda.VendaPagamento;
 import com.AIT.Optimanage.Repositories.Venda.PagamentoVendaRepository;
+import com.AIT.Optimanage.Security.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,20 +20,36 @@ public class PagamentoVendaService {
     private final PagamentoVendaRepository pagamentoVendaRepository;
 
     public List<VendaPagamento> listarPagamentosVenda(User loggedUser, Integer idVenda) {
-        return pagamentoVendaRepository.findAllByVendaIdAndVendaOwnerUser(idVenda, loggedUser);
+        Integer organizationId = loggedUser != null ? loggedUser.getTenantId() : CurrentUser.getOrganizationId();
+        if (organizationId == null) {
+            throw new RuntimeException("Organização não encontrada");
+        }
+        return pagamentoVendaRepository.findAllByVendaIdAndVendaOrganizationId(idVenda, organizationId);
     }
 
     public List<VendaPagamento> listarPagamentosRealizadosVenda(User loggedUser, Integer idVenda) {
-        return pagamentoVendaRepository.findAllByVendaIdAndVendaOwnerUserAndStatusPagamento(idVenda, loggedUser, StatusPagamento.PAGO);
+        Integer organizationId = loggedUser != null ? loggedUser.getTenantId() : CurrentUser.getOrganizationId();
+        if (organizationId == null) {
+            throw new RuntimeException("Organização não encontrada");
+        }
+        return pagamentoVendaRepository.findAllByVendaIdAndVendaOrganizationIdAndStatusPagamento(idVenda, organizationId, StatusPagamento.PAGO);
     }
 
     private VendaPagamento listarUmPagamentoVenda(User loggedUser, Venda venda, Integer idPagamento) {
-        return pagamentoVendaRepository.findByIdAndVendaAndVendaOwnerUser(idPagamento, venda, loggedUser)
+        Integer organizationId = loggedUser != null ? loggedUser.getTenantId() : CurrentUser.getOrganizationId();
+        if (organizationId == null) {
+            throw new RuntimeException("Organização não encontrada");
+        }
+        return pagamentoVendaRepository.findByIdAndVendaAndVendaOrganizationId(idPagamento, venda, organizationId)
                 .orElseThrow(() -> new RuntimeException("Pagamento não encontrado"));
     }
 
     public VendaPagamento listarUmPagamento(User loggedUser, Integer idPagamento) {
-        return pagamentoVendaRepository.findByIdAndVendaOwnerUser(idPagamento, loggedUser)
+        Integer organizationId = loggedUser != null ? loggedUser.getTenantId() : CurrentUser.getOrganizationId();
+        if (organizationId == null) {
+            throw new RuntimeException("Organização não encontrada");
+        }
+        return pagamentoVendaRepository.findByIdAndVendaOrganizationId(idPagamento, organizationId)
                 .orElseThrow(() -> new RuntimeException("Pagamento não encontrado"));
     }
 

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -42,6 +42,7 @@ import com.AIT.Optimanage.Services.ServicoService;
 import com.AIT.Optimanage.Services.User.ContadorService;
 import com.AIT.Optimanage.Services.PlanoService;
 import com.AIT.Optimanage.Validation.VendaValidator;
+import com.AIT.Optimanage.Security.CurrentUser;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -87,6 +88,10 @@ public class VendaService {
     @Cacheable(value = "vendas", key = "#loggedUser.id + '-' + #pesquisa.hashCode()")
     @Transactional(readOnly = true)
     public Page<VendaResponseDTO> listarVendas(User loggedUser, VendaSearch pesquisa) {
+        Integer organizationId = loggedUser != null ? loggedUser.getTenantId() : CurrentUser.getOrganizationId();
+        if (organizationId == null) {
+            throw new EntityNotFoundException("Organização não encontrada");
+        }
         // Configuração de paginação e ordenação
         Sort.Direction direction = Optional.ofNullable(pesquisa.getOrder()).filter(Sort.Direction::isDescending)
                 .map(order -> Sort.Direction.DESC).orElse(Sort.Direction.ASC);
@@ -96,7 +101,7 @@ public class VendaService {
 
         // Realiza a busca no repositório com os filtros definidos e associando o usuario logado
         return vendaRepository.buscarVendas(
-                loggedUser.getId(),
+                organizationId,
                 pesquisa.getId(),
                 pesquisa.getClienteId(),
                 pesquisa.getDataInicial(),
@@ -108,7 +113,11 @@ public class VendaService {
     }
 
     private Venda getVenda(User loggedUser, Integer idVenda) {
-        return vendaRepository.findByIdAndOwnerUser(idVenda, loggedUser)
+        Integer organizationId = loggedUser != null ? loggedUser.getTenantId() : CurrentUser.getOrganizationId();
+        if (organizationId == null) {
+            throw new EntityNotFoundException("Organização não encontrada");
+        }
+        return vendaRepository.findByIdAndOrganizationId(idVenda, organizationId)
                 .orElseThrow(() -> new EntityNotFoundException("Venda não encontrada"));
     }
 
@@ -127,6 +136,10 @@ public class VendaService {
 
         Cliente cliente = clienteService.listarUmCliente(vendaDTO.getClienteId());
         Contador contador = contadorService.BuscarContador(Tabela.VENDA);
+        Integer organizationId = loggedUser != null ? loggedUser.getTenantId() : CurrentUser.getOrganizationId();
+        if (organizationId == null) {
+            throw new EntityNotFoundException("Organização não encontrada");
+        }
         Venda novaVenda = Venda.builder()
                 .cliente(cliente)
                 .sequencialUsuario(contador.getContagemAtual())
@@ -163,6 +176,7 @@ public class VendaService {
         novaVenda.setValorPendente(valorFinal.subtract(valorPago));
         novaVenda.setVendaProdutos(vendaProdutos);
         novaVenda.setVendaServicos(vendaServicos);
+        novaVenda.setTenantId(organizationId);
 
         vendaRepository.save(novaVenda);
         vendaProdutoRepository.saveAll(vendaProdutos);
@@ -196,6 +210,7 @@ public class VendaService {
                 .status(vendaDTO.getStatus())
                 .observacoes(vendaDTO.getObservacoes())
                 .build();
+        vendaAtualizada.setTenantId(venda.getOrganizationId());
 
         // Devolve estoque dos produtos antigos e remove os registros
         venda.getVendaProdutos().forEach(vp ->

--- a/src/main/java/com/AIT/Optimanage/Support/PlatformDataInitializer.java
+++ b/src/main/java/com/AIT/Optimanage/Support/PlatformDataInitializer.java
@@ -65,6 +65,7 @@ public class PlatformDataInitializer implements ApplicationRunner {
                 .ativo(true)
                 .build();
         owner.setId(1);
+        owner.setTenantId(1);
         userRepository.save(owner);
 
         Organization organization = Organization.builder()
@@ -77,6 +78,7 @@ public class PlatformDataInitializer implements ApplicationRunner {
                 .dataAssinatura(LocalDate.now())
                 .build();
         organization.setId(1);
+        organization.setTenantId(1);
         organizationRepository.save(organization);
 
         owner.setOrganization(organization);

--- a/src/test/java/com/AIT/Optimanage/Models/Audit/OwnerEntityListenerTest.java
+++ b/src/test/java/com/AIT/Optimanage/Models/Audit/OwnerEntityListenerTest.java
@@ -29,7 +29,7 @@ class OwnerEntityListenerTest {
     }
 
     @Test
-    void prePersistSetsOwnerUserWhenNull() {
+    void prePersistSetsOrganizationWhenNull() {
         TenantContext.setTenantId(1);
         User user = User.builder()
                 .nome("John")
@@ -49,7 +49,7 @@ class OwnerEntityListenerTest {
 
         ctx = entityManager.persistAndFlush(ctx);
 
-        assertNotNull(ctx.getOwnerUser());
-        assertEquals(user.getId(), ctx.getOwnerUser().getId());
+        assertNotNull(ctx.getOrganizationId());
+        assertEquals(1, ctx.getOrganizationId());
     }
 }

--- a/src/test/java/com/AIT/Optimanage/Repositories/ProdutoRepositoryConcurrencyTest.java
+++ b/src/test/java/com/AIT/Optimanage/Repositories/ProdutoRepositoryConcurrencyTest.java
@@ -1,8 +1,6 @@
 package com.AIT.Optimanage.Repositories;
 
 import com.AIT.Optimanage.Models.Produto;
-import com.AIT.Optimanage.Models.User.Role;
-import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Support.TenantContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,28 +27,16 @@ class ProdutoRepositoryConcurrencyTest {
     private ProdutoRepository produtoRepository;
 
     @Autowired
-    private UserRepository userRepository;
-
     @Autowired
     private PlatformTransactionManager transactionManager;
 
     private TransactionTemplate transactionTemplate;
-
-    private User owner;
 
     @BeforeEach
     void setup() {
         TenantContext.setTenantId(1);
         transactionTemplate = new TransactionTemplate(transactionManager);
         transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-        owner = User.builder()
-                .nome("John")
-                .sobrenome("Doe")
-                .email("john@doe.com")
-                .senha("pwd")
-                .role(Role.OPERADOR)
-                .build();
-        userRepository.save(owner);
     }
 
     @AfterEach
@@ -60,7 +46,6 @@ class ProdutoRepositoryConcurrencyTest {
 
     private Produto novoProduto(int estoqueInicial) {
         Produto produto = Produto.builder()
-                .ownerUser(owner)
                 .sequencialUsuario(1)
                 .codigoReferencia("SKU")
                 .nome("Produto")
@@ -69,6 +54,7 @@ class ProdutoRepositoryConcurrencyTest {
                 .qtdEstoque(estoqueInicial)
                 .ativo(true)
                 .build();
+        produto.setTenantId(1);
         return produtoRepository.save(produto);
     }
 

--- a/src/test/java/com/AIT/Optimanage/Services/Compra/CompraServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/Compra/CompraServiceTest.java
@@ -55,6 +55,7 @@ class CompraServiceTest {
     void setup() {
         user = User.builder().build();
         user.setId(1);
+        user.setTenantId(1);
         CurrentUser.set(user);
     }
 
@@ -66,7 +67,6 @@ class CompraServiceTest {
     @Test
     void agendarCompraAtualizaStatusEData() {
         Compra compra = Compra.builder()
-                .ownerUser(user)
                 .sequencialUsuario(1)
                 .dataEfetuacao(LocalDate.now())
                 .valorFinal(BigDecimal.valueOf(100))
@@ -75,8 +75,9 @@ class CompraServiceTest {
                 .compraProdutos(Collections.singletonList(new CompraProduto()))
                 .build();
         compra.setId(10);
+        compra.setTenantId(1);
 
-        when(compraRepository.findByIdAndOwnerUser(10, user)).thenReturn(Optional.of(compra));
+        when(compraRepository.findByIdAndOrganizationId(10, 1)).thenReturn(Optional.of(compra));
         when(compraRepository.save(compra)).thenReturn(compra);
         when(compraMapper.toResponse(compra)).thenReturn(new CompraResponseDTO());
 
@@ -89,7 +90,6 @@ class CompraServiceTest {
     @Test
     void finalizarAgendamentoCompraSemPagamentoDefineStatusAguardandoPag() {
         Compra compra = Compra.builder()
-                .ownerUser(user)
                 .sequencialUsuario(1)
                 .dataEfetuacao(LocalDate.now())
                 .valorFinal(BigDecimal.valueOf(100))
@@ -98,8 +98,9 @@ class CompraServiceTest {
                 .compraProdutos(Collections.singletonList(new CompraProduto()))
                 .build();
         compra.setId(11);
+        compra.setTenantId(1);
 
-        when(compraRepository.findByIdAndOwnerUser(11, user)).thenReturn(Optional.of(compra));
+        when(compraRepository.findByIdAndOrganizationId(11, 1)).thenReturn(Optional.of(compra));
         when(compraRepository.save(compra)).thenReturn(compra);
         when(compraMapper.toResponse(compra)).thenReturn(new CompraResponseDTO());
 
@@ -111,7 +112,6 @@ class CompraServiceTest {
     @Test
     void finalizarAgendamentoCompraComPagamentoCompletoDefineStatusConcretizado() {
         Compra compra = Compra.builder()
-                .ownerUser(user)
                 .sequencialUsuario(1)
                 .dataEfetuacao(LocalDate.now())
                 .valorFinal(BigDecimal.valueOf(100))
@@ -120,8 +120,9 @@ class CompraServiceTest {
                 .compraProdutos(Collections.singletonList(new CompraProduto()))
                 .build();
         compra.setId(12);
+        compra.setTenantId(1);
 
-        when(compraRepository.findByIdAndOwnerUser(12, user)).thenReturn(Optional.of(compra));
+        when(compraRepository.findByIdAndOrganizationId(12, 1)).thenReturn(Optional.of(compra));
         when(compraRepository.save(compra)).thenReturn(compra);
         when(compraMapper.toResponse(compra)).thenReturn(new CompraResponseDTO());
 


### PR DESCRIPTION
## Summary
- replace the `OwnableEntity` contract and entity listener so multi-tenant data is tied to an organization instead of a user
- update entity models, mappers, repositories, and services to persist and query by organization_id and expose the new identifier in API DTOs
- align supporting tests and initializers with the organization-based ownership model

## Testing
- mvn test *(fails: unable to download parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a9c4e47c832480a6199a80d925e7