### PR TITLE
Refatorar criação de organização para definir tenant

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
@@ -2,9 +2,15 @@ package com.AIT.Optimanage.Repositories.Organization;
 
 import com.AIT.Optimanage.Models.Organization.Organization;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrganizationRepository extends JpaRepository<Organization, Integer> {
+
+    @Modifying
+    @Query("update Organization o set o.organizationId = :organizationId where o.id = :organizationId")
+    void updateOrganizationId(Integer organizationId);
 }
 

--- a/src/main/java/com/AIT/Optimanage/Repositories/UserRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/UserRepository.java
@@ -2,6 +2,8 @@ package com.AIT.Optimanage.Repositories;
 
 import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,4 +13,8 @@ public interface UserRepository extends JpaRepository<User, Integer> {
     public Optional<User> findByEmail(String email);
 
     long countByOrganizationIdAndAtivoTrue(Integer organizationId);
+
+    @Modifying
+    @Query("update User u set u.organizationId = :organizationId where u.id = :userId")
+    void updateOrganizationId(Integer userId, Integer organizationId);
 }

--- a/src/main/java/com/AIT/Optimanage/Services/Organization/OrganizationService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Organization/OrganizationService.java
@@ -41,49 +41,59 @@ public class OrganizationService {
 
         validarLimiteUsuarios(plano, 0, 1);
 
-        // Create owner user first
-        UserRequest ownerReq = request.getOwner();
-        User owner = User.builder()
-                .nome(ownerReq.getNome())
-                .sobrenome(ownerReq.getSobrenome())
-                .email(ownerReq.getEmail())
-                .senha(passwordEncoder.encode(ownerReq.getSenha()))
-                .role(Role.OWNER)
-                .ativo(true)
-                .build();
-        // Temporarily set tenant to 0 until organization is persisted
-        owner.setTenantId(0);
-        owner = userRepository.save(owner);
+        Integer previousTenant = TenantContext.getTenantId();
+        try {
+            Integer creatorTenant = creator.getTenantId();
+            TenantContext.setTenantId(creatorTenant != null ? creatorTenant : PlatformConstants.PLATFORM_ORGANIZATION_ID);
 
-        Organization organization = Organization.builder()
-                .ownerUser(owner)
-                .planoAtivoId(plano)
-                .cnpj(request.getCnpj())
-                .razaoSocial(request.getRazaoSocial())
-                .nomeFantasia(request.getNomeFantasia())
-                .telefone(request.getTelefone())
-                .email(request.getEmail())
-                .permiteOrcamento(request.getPermiteOrcamento())
-                .dataAssinatura(request.getDataAssinatura())
-                .build();
-        organization.setTenantId(0);
-        organization = organizationRepository.save(organization);
+            // Create owner user first
+            UserRequest ownerReq = request.getOwner();
+            User owner = User.builder()
+                    .nome(ownerReq.getNome())
+                    .sobrenome(ownerReq.getSobrenome())
+                    .email(ownerReq.getEmail())
+                    .senha(passwordEncoder.encode(ownerReq.getSenha()))
+                    .role(Role.OWNER)
+                    .ativo(true)
+                    .build();
+            owner = userRepository.save(owner);
 
-        // Update tenant for owner and organization to the generated id
-        Integer orgId = organization.getId();
-        owner.setTenantId(orgId);
-        owner.setOrganization(organization);
-        userRepository.save(owner);
-        organization.setTenantId(orgId);
-        organizationRepository.save(organization);
+            Organization organization = Organization.builder()
+                    .ownerUser(owner)
+                    .planoAtivoId(plano)
+                    .cnpj(request.getCnpj())
+                    .razaoSocial(request.getRazaoSocial())
+                    .nomeFantasia(request.getNomeFantasia())
+                    .telefone(request.getTelefone())
+                    .email(request.getEmail())
+                    .permiteOrcamento(request.getPermiteOrcamento())
+                    .dataAssinatura(request.getDataAssinatura())
+                    .build();
+            organization = organizationRepository.save(organization);
 
-        return OrganizationResponse.builder()
+            // Update tenant for owner and organization to the generated id
+            Integer orgId = organization.getId();
+            userRepository.updateOrganizationId(owner.getId(), orgId);
+            organizationRepository.updateOrganizationId(orgId);
+
+            owner.setTenantId(orgId);
+            owner.setOrganization(organization);
+            organization.setTenantId(orgId);
+
+            return OrganizationResponse.builder()
                 .id(orgId)
                 .cnpj(organization.getCnpj())
                 .razaoSocial(organization.getRazaoSocial())
                 .nomeFantasia(organization.getNomeFantasia())
                 .ownerUserId(owner.getId())
                 .build();
+        } finally {
+            if (previousTenant != null) {
+                TenantContext.setTenantId(previousTenant);
+            } else {
+                TenantContext.clear();
+            }
+        }
     }
 
     private void validarPermissaoCriacao(User creator) {

--- a/src/test/java/com/AIT/Optimanage/Services/Organization/OrganizationServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/Organization/OrganizationServiceTest.java
@@ -1,0 +1,135 @@
+package com.AIT.Optimanage.Services.Organization;
+
+import com.AIT.Optimanage.Controllers.User.dto.UserRequest;
+import com.AIT.Optimanage.Controllers.dto.OrganizationRequest;
+import com.AIT.Optimanage.Models.Organization.Organization;
+import com.AIT.Optimanage.Models.Plano;
+import com.AIT.Optimanage.Models.User.Role;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Repositories.Organization.OrganizationRepository;
+import com.AIT.Optimanage.Repositories.PlanoRepository;
+import com.AIT.Optimanage.Repositories.UserRepository;
+import com.AIT.Optimanage.Services.Organization.OrganizationService;
+import com.AIT.Optimanage.Support.PlatformConstants;
+import com.AIT.Optimanage.Support.TenantContext;
+import com.AIT.Optimanage.Config.JwtService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrganizationServiceTest {
+
+    @Mock
+    private OrganizationRepository organizationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PlanoRepository planoRepository;
+
+    @Mock
+    private JwtService jwtService;
+
+    private OrganizationService organizationService;
+
+    @BeforeEach
+    void setUp() {
+        organizationService = new OrganizationService(
+                organizationRepository,
+                userRepository,
+                planoRepository,
+                new BCryptPasswordEncoder(),
+                jwtService
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void criarOrganizacaoDefineTenantFinalParaOwnerEOrganization() {
+        Plano plano = Plano.builder()
+                .nome("Premium")
+                .valor(100.0f)
+                .duracaoDias(30)
+                .qtdAcessos(10)
+                .maxUsuarios(5)
+                .build();
+        plano.setId(2);
+        plano.setTenantId(PlatformConstants.PLATFORM_ORGANIZATION_ID);
+
+        when(planoRepository.findById(2)).thenReturn(Optional.of(plano));
+
+        AtomicReference<User> savedOwnerRef = new AtomicReference<>();
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            user.setId(10);
+            savedOwnerRef.set(user);
+            return user;
+        });
+
+        AtomicReference<Organization> savedOrganizationRef = new AtomicReference<>();
+        when(organizationRepository.save(any(Organization.class))).thenAnswer(invocation -> {
+            Organization organization = invocation.getArgument(0);
+            organization.setId(50);
+            savedOrganizationRef.set(organization);
+            return organization;
+        });
+
+        OrganizationRequest request = OrganizationRequest.builder()
+                .cnpj("12345678901234")
+                .razaoSocial("Empresa Exemplo")
+                .nomeFantasia("Exemplo")
+                .telefone("11999999999")
+                .email("contato@exemplo.com")
+                .permiteOrcamento(true)
+                .dataAssinatura(LocalDate.now())
+                .planoId(2)
+                .owner(UserRequest.builder()
+                        .nome("Owner")
+                        .sobrenome("Example")
+                        .email("owner@example.com")
+                        .senha("senha123")
+                        .role(Role.OWNER)
+                        .build())
+                .build();
+
+        User creator = User.builder()
+                .role(Role.ADMIN)
+                .ativo(true)
+                .build();
+        creator.setTenantId(PlatformConstants.PLATFORM_ORGANIZATION_ID);
+
+        TenantContext.setTenantId(999);
+
+        organizationService.criarOrganizacao(request, creator);
+
+        verify(userRepository).updateOrganizationId(10, 50);
+        verify(organizationRepository).updateOrganizationId(50);
+
+        assertThat(savedOwnerRef.get()).isNotNull();
+        assertThat(savedOwnerRef.get().getOrganizationId()).isEqualTo(50);
+
+        assertThat(savedOrganizationRef.get()).isNotNull();
+        assertThat(savedOrganizationRef.get().getOrganizationId()).isEqualTo(50);
+
+        assertThat(TenantContext.getTenantId()).isEqualTo(999);
+    }
+}


### PR DESCRIPTION
## Summary
- ajusta o fluxo de criação de organização para atualizar owner e organização com o tenant definitivo e restaurar o TenantContext original
- adiciona métodos específicos nos repositórios de usuário e organização para atualizar o organization_id via @Modifying
- cria teste unitário que cobre a criação de organização e verifica a atribuição correta do tenant nos registros persistidos

## Testing
- `./mvnw test` *(falhou: falta de acesso à internet para resolver dependências do parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cd45e88d4c8324afec7ce36e2d6a97