### PR TITLE
Add missing JsonProperty imports to entity models

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
@@ -3,6 +3,7 @@ package com.AIT.Optimanage.Models.Compra;
 import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
 import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import com.AIT.Optimanage.Models.OwnableEntity;

--- a/src/main/java/com/AIT/Optimanage/Models/Produto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Produto.java
@@ -3,6 +3,7 @@ package com.AIT.Optimanage.Models;
 import com.AIT.Optimanage.Models.Venda.Compatibilidade.Compatibilidade;
 import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;

--- a/src/main/java/com/AIT/Optimanage/Models/Servico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Servico.java
@@ -3,6 +3,7 @@ package com.AIT.Optimanage.Models;
 import com.AIT.Optimanage.Models.Venda.Compatibilidade.Compatibilidade;
 import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import lombok.*;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
@@ -4,6 +4,7 @@ import com.AIT.Optimanage.Models.Cliente.Cliente;
 import com.AIT.Optimanage.Models.Venda.Related.Alteracao;
 import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import com.AIT.Optimanage.Models.OwnableEntity;


### PR DESCRIPTION
## Summary
- add the missing `JsonProperty` import to the Compra, Produto, Servico, and Venda entities so their annotated accessors compile

## Testing
- ./mvnw -q -DskipTests package *(fails: unable to resolve parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd54b178d483249db04d2c40a99895