### PR TITLE
Refatorar criação de organização para aplicar tenant definitivo

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
@@ -2,9 +2,16 @@ package com.AIT.Optimanage.Repositories.Organization;
 
 import com.AIT.Optimanage.Models.Organization.Organization;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrganizationRepository extends JpaRepository<Organization, Integer> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Organization o set o.organizationId = :organizationId where o.id = :organizationId")
+    void updateOrganizationTenant(@Param("organizationId") Integer organizationId);
 }
 

--- a/src/main/java/com/AIT/Optimanage/Repositories/UserRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/UserRepository.java
@@ -2,6 +2,9 @@ package com.AIT.Optimanage.Repositories;
 
 import com.AIT.Optimanage.Models.User.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,4 +14,8 @@ public interface UserRepository extends JpaRepository<User, Integer> {
     public Optional<User> findByEmail(String email);
 
     long countByOrganizationIdAndAtivoTrue(Integer organizationId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update User u set u.organizationId = :organizationId where u.id = :userId")
+    void updateOrganizationTenant(@Param("userId") Integer userId, @Param("organizationId") Integer organizationId);
 }


### PR DESCRIPTION
## Summary
- ajusta o fluxo de `criarOrganizacao` para gravar owner e organização com o tenant definitivo e restaurar o `TenantContext`
- adiciona métodos de atualização de tenant nos repositórios de usuários e organizações
- cria teste unitário garantindo que owner e organização recebem o `orgId` gerado

## Testing
- `./mvnw test` *(falhou: dependências Maven indisponíveis no ambiente de execução)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5469e2e483248d78e18b4a4f1674