### PR TITLE
Expand agenda events with schedules and birthdays

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Agenda/EventoAgenda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Agenda/EventoAgenda.java
@@ -14,6 +14,9 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class EventoAgenda {
     private TipoEvento tipo;
+    private TipoEvento referencia;
     private LocalDate data;
     private Integer id;
+    private String titulo;
+    private String descricao;
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Cliente/ClienteContatoRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Cliente/ClienteContatoRepository.java
@@ -13,4 +13,6 @@ public interface ClienteContatoRepository extends JpaRepository<ClienteContato, 
     List<ClienteContato> findAllByCliente_IdAndClienteOrganizationId(Integer idCliente, Integer organizationId);
 
     Optional<ClienteContato> findByIdAndCliente_IdAndClienteOrganizationId(Integer idContato, Integer idCliente, Integer organizationId);
+
+    List<ClienteContato> findAllByClienteOrganizationIdAndCreatedBy(Integer organizationId, Integer userId);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
@@ -3,9 +3,26 @@ package com.AIT.Optimanage.Repositories.Compra;
 import com.AIT.Optimanage.Models.Compra.Compra;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface CompraRepository extends JpaRepository<Compra, Integer>, JpaSpecificationExecutor<Compra> {
     Optional<Compra> findByIdAndOrganizationId(Integer idCompra, Integer organizationId);
+
+    @Query("""
+            SELECT c FROM Compra c
+            WHERE c.organizationId = :organizationId
+              AND c.createdBy = :userId
+              AND c.dataAgendada IS NOT NULL
+              AND (:inicio IS NULL OR c.dataAgendada >= :inicio)
+              AND (:fim IS NULL OR c.dataAgendada <= :fim)
+            """)
+    List<Compra> findAgendadasNoPeriodo(@Param("organizationId") Integer organizationId,
+                                        @Param("userId") Integer userId,
+                                        @Param("inicio") LocalDate inicio,
+                                        @Param("fim") LocalDate fim);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -57,4 +58,17 @@ public interface VendaRepository extends JpaRepository<Venda, Integer> {
             "JOIN FETCH vp.produto p " +
             "WHERE v.organizationId = :organizationId")
     List<Venda> findAllWithProdutosByOrganization(@Param("organizationId") Integer organizationId);
+
+    @Query("""
+            SELECT v FROM Venda v
+            WHERE v.organizationId = :organizationId
+              AND v.createdBy = :userId
+              AND v.dataAgendada IS NOT NULL
+              AND (:inicio IS NULL OR v.dataAgendada >= :inicio)
+              AND (:fim IS NULL OR v.dataAgendada <= :fim)
+            """)
+    List<Venda> findAgendadasNoPeriodo(@Param("organizationId") Integer organizationId,
+                                       @Param("userId") Integer userId,
+                                       @Param("inicio") LocalDate inicio,
+                                       @Param("fim") LocalDate fim);
 }

--- a/src/main/java/com/AIT/Optimanage/Services/AgendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/AgendaService.java
@@ -2,36 +2,52 @@ package com.AIT.Optimanage.Services;
 
 import com.AIT.Optimanage.Models.Agenda.AgendaSearch;
 import com.AIT.Optimanage.Models.Agenda.EventoAgenda;
+import com.AIT.Optimanage.Models.Compra.Compra;
 import com.AIT.Optimanage.Models.Compra.CompraPagamento;
 import com.AIT.Optimanage.Models.Enums.StatusPagamento;
 import com.AIT.Optimanage.Models.Enums.TipoEvento;
 import com.AIT.Optimanage.Models.Plano;
 import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Models.Venda.Venda;
 import com.AIT.Optimanage.Models.Venda.VendaPagamento;
+import com.AIT.Optimanage.Repositories.Cliente.ClienteContatoRepository;
+import com.AIT.Optimanage.Repositories.Compra.CompraRepository;
 import com.AIT.Optimanage.Repositories.Compra.PagamentoCompraRepository;
 import com.AIT.Optimanage.Repositories.Venda.PagamentoVendaRepository;
+import com.AIT.Optimanage.Repositories.Venda.VendaRepository;
 import com.AIT.Optimanage.Services.PlanoService;
-import lombok.RequiredArgsConstructor;
 import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.MonthDay;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
 
 @Service
 @RequiredArgsConstructor
 public class AgendaService {
     private final PagamentoCompraRepository pagamentoCompraRepository;
     private final PagamentoVendaRepository pagamentoVendaRepository;
+    private final CompraRepository compraRepository;
+    private final VendaRepository vendaRepository;
+    private final ClienteContatoRepository clienteContatoRepository;
     private final PlanoService planoService;
 
     public Page<EventoAgenda> listarEventos(User loggedUser, AgendaSearch pesquisa) {
@@ -43,47 +59,219 @@ public class AgendaService {
         if (!Boolean.TRUE.equals(plano.getAgendaHabilitada())) {
             throw new AccessDeniedException("Agenda não está habilitada no plano atual");
         }
-        Sort.Direction direction = Optional.ofNullable(pesquisa.getOrder()).filter(Sort.Direction::isDescending)
+
+        AgendaSearch filtros = ofNullable(pesquisa).orElseGet(AgendaSearch::new);
+
+        Sort.Direction direction = ofNullable(filtros.getOrder()).filter(Sort.Direction::isDescending)
                 .map(order -> Sort.Direction.DESC).orElse(Sort.Direction.ASC);
 
-        String sortBy = Optional.ofNullable(pesquisa.getSort()).orElse("data");
-        Pageable pageable = PageRequest.of(pesquisa.getPage(), pesquisa.getPageSize(), Sort.by(direction, sortBy));
+        String sortBy = ofNullable(filtros.getSort()).orElse("data");
+        int pageNumber = ofNullable(filtros.getPage()).orElse(0);
+        int pageSize = ofNullable(filtros.getPageSize()).orElse(20);
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(direction, sortBy));
 
         LocalDate now = LocalDate.now();
-        LocalDate inicio = Optional.ofNullable(pesquisa.getDataInicial()).orElse(now);
-        LocalDate fim = Optional.ofNullable(pesquisa.getDataFinal()).orElse(LocalDate.MAX);
+        LocalDate inicio = ofNullable(filtros.getDataInicial()).orElse(now);
+        LocalDate fim = filtros.getDataFinal();
 
         List<EventoAgenda> eventos = new ArrayList<>();
 
         Integer organizationId = loggedUser.getTenantId();
+        Integer userId = loggedUser.getId();
+
         List<CompraPagamento> compras = pagamentoCompraRepository
                 .findAllByCompraOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(organizationId, StatusPagamento.PENDENTE, now);
         compras.stream()
-                .filter(p -> !p.getDataVencimento().isBefore(inicio) && !p.getDataVencimento().isAfter(fim))
-                .forEach(p -> eventos.add(EventoAgenda.builder()
-                        .tipo(TipoEvento.PAGAMENTO)
-                        .data(p.getDataVencimento())
-                        .id(p.getId())
-                        .build()));
+                .filter(p -> withinRange(p.getDataVencimento(), inicio, fim))
+                .map(pagamento -> criarEvento(TipoEvento.PAGAMENTO, TipoEvento.COMPRA, pagamento.getDataVencimento(), pagamento.getId(),
+                        montarTituloPagamentoCompra(pagamento), montarDescricaoPagamentoCompra(pagamento)))
+                .forEach(eventos::add);
 
         List<VendaPagamento> vendas = pagamentoVendaRepository
                 .findAllByVendaOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(organizationId, StatusPagamento.PENDENTE, now);
         vendas.stream()
-                .filter(p -> !p.getDataVencimento().isBefore(inicio) && !p.getDataVencimento().isAfter(fim))
-                .forEach(p -> eventos.add(EventoAgenda.builder()
-                        .tipo(TipoEvento.PAGAMENTO)
-                        .data(p.getDataVencimento())
-                        .id(p.getId())
-                        .build()));
+                .filter(p -> withinRange(p.getDataVencimento(), inicio, fim))
+                .map(pagamento -> criarEvento(TipoEvento.PAGAMENTO, TipoEvento.VENDA, pagamento.getDataVencimento(), pagamento.getId(),
+                        montarTituloPagamentoVenda(pagamento), montarDescricaoPagamentoVenda(pagamento)))
+                .forEach(eventos::add);
 
-        eventos.sort(direction.isAscending()
-                ? Comparator.comparing(EventoAgenda::getData)
-                : Comparator.comparing(EventoAgenda::getData).reversed());
+        compraRepository.findAgendadasNoPeriodo(organizationId, userId, inicio, fim).stream()
+                .filter(compra -> withinRange(compra.getDataAgendada(), inicio, fim))
+                .map(compra -> criarEvento(TipoEvento.AGENDAMENTO, TipoEvento.COMPRA, compra.getDataAgendada(), compra.getId(),
+                        montarTituloCompra(compra), montarDescricaoCompra(compra)))
+                .forEach(eventos::add);
+
+        vendaRepository.findAgendadasNoPeriodo(organizationId, userId, inicio, fim).stream()
+                .filter(venda -> withinRange(venda.getDataAgendada(), inicio, fim))
+                .map(venda -> criarEvento(TipoEvento.AGENDAMENTO, TipoEvento.VENDA, venda.getDataAgendada(), venda.getId(),
+                        montarTituloVenda(venda), montarDescricaoVenda(venda)))
+                .forEach(eventos::add);
+
+        clienteContatoRepository.findAllByClienteOrganizationIdAndCreatedBy(organizationId, userId).stream()
+                .map(contato -> normalizarAniversario(contato.getAniversario(), inicio, fim)
+                        .map(data -> criarEvento(TipoEvento.ANIVERSARIO, TipoEvento.ANIVERSARIO, data, contato.getId(),
+                                contato.getNome(), "Aniversário de " + contato.getNome())))
+                .flatMap(Optional::stream)
+                .forEach(eventos::add);
+
+        Map<String, EventoAgenda> eventosUnicos = new LinkedHashMap<>();
+        for (EventoAgenda evento : eventos) {
+            if (evento.getData() == null) {
+                continue;
+            }
+            String chave = gerarChaveEvento(evento);
+            EventoAgenda existente = eventosUnicos.get(chave);
+            if (existente == null || evento.getData().isBefore(existente.getData())) {
+                eventosUnicos.put(chave, evento);
+            }
+        }
+
+        Comparator<EventoAgenda> comparator = Comparator.comparing(EventoAgenda::getData)
+                .thenComparing(evento -> ofNullable(evento.getTipo()).map(Enum::name).orElse(""))
+                .thenComparing(evento -> ofNullable(evento.getReferencia()).map(Enum::name).orElse(""))
+                .thenComparing(evento -> ofNullable(evento.getId()).orElse(0));
+
+        List<EventoAgenda> ordenados = new ArrayList<>(eventosUnicos.values());
+        ordenados.sort(direction.isAscending() ? comparator : comparator.reversed());
 
         int start = (int) pageable.getOffset();
-        int end = Math.min(start + pageable.getPageSize(), eventos.size());
-        List<EventoAgenda> content = start >= eventos.size() ? List.of() : eventos.subList(start, end);
+        int end = Math.min(start + pageable.getPageSize(), ordenados.size());
+        List<EventoAgenda> content = start >= ordenados.size() ? List.of() : ordenados.subList(start, end);
 
-        return new PageImpl<>(content, pageable, eventos.size());
+        return new PageImpl<>(content, pageable, ordenados.size());
+    }
+
+    private EventoAgenda criarEvento(TipoEvento tipo, TipoEvento referencia, LocalDate data, Integer id, String titulo, String descricao) {
+        return EventoAgenda.builder()
+                .tipo(tipo)
+                .referencia(referencia)
+                .data(data)
+                .id(id)
+                .titulo(titulo)
+                .descricao(descricao)
+                .build();
+    }
+
+    private boolean withinRange(LocalDate data, LocalDate inicio, LocalDate fim) {
+        if (data == null) {
+            return false;
+        }
+        if (data.isBefore(inicio)) {
+            return false;
+        }
+        return fim == null || !data.isAfter(fim);
+    }
+
+    private Optional<LocalDate> normalizarAniversario(String aniversario, LocalDate inicio, LocalDate fim) {
+        if (aniversario == null || aniversario.isBlank()) {
+            return Optional.empty();
+        }
+
+        MonthDay mesDia = parseMonthDay(aniversario.trim());
+        if (mesDia == null) {
+            return Optional.empty();
+        }
+
+        LocalDate data = ajustarParaAno(mesDia, inicio.getYear());
+        while (data != null && data.isBefore(inicio)) {
+            data = ajustarParaAno(mesDia, data.getYear() + 1);
+        }
+
+        if (data == null || (fim != null && data.isAfter(fim))) {
+            return Optional.empty();
+        }
+
+        return Optional.of(data);
+    }
+
+    private MonthDay parseMonthDay(String aniversario) {
+        for (DateTimeFormatter formatter : List.of(DateTimeFormatter.ISO_LOCAL_DATE, DateTimeFormatter.ofPattern("dd/MM/yyyy"))) {
+            try {
+                LocalDate parsed = LocalDate.parse(aniversario, formatter);
+                return MonthDay.of(parsed.getMonth(), parsed.getDayOfMonth());
+            } catch (DateTimeParseException ignored) {
+                // tenta próximo formato
+            }
+        }
+        for (DateTimeFormatter formatter : List.of(DateTimeFormatter.ofPattern("dd/MM"), DateTimeFormatter.ofPattern("dd-MM"))) {
+            try {
+                return MonthDay.parse(aniversario, formatter);
+            } catch (DateTimeParseException ignored) {
+                // tenta próximo formato
+            }
+        }
+        return null;
+    }
+
+    private LocalDate ajustarParaAno(MonthDay mesDia, int ano) {
+        try {
+            return mesDia.atYear(ano);
+        } catch (RuntimeException ex) {
+            if (mesDia.equals(MonthDay.of(2, 29))) {
+                return LocalDate.of(ano, 2, 28);
+            }
+            return null;
+        }
+    }
+
+    private String gerarChaveEvento(EventoAgenda evento) {
+        return String.join(":",
+                ofNullable(evento.getTipo()).map(Enum::name).orElse(""),
+                ofNullable(evento.getReferencia()).map(Enum::name).orElse(""),
+                ofNullable(evento.getId()).map(String::valueOf).orElse(""));
+    }
+
+    private String montarTituloPagamentoCompra(CompraPagamento pagamento) {
+        String numeroCompra = ofNullable(pagamento.getCompra())
+                .map(Compra::getSequencialUsuario)
+                .map(seq -> "#" + seq)
+                .orElse("");
+        return ("Pagamento de compra " + numeroCompra).trim();
+    }
+
+    private String montarDescricaoPagamentoCompra(CompraPagamento pagamento) {
+        return "Parcela de compra vence em " + pagamento.getDataVencimento();
+    }
+
+    private String montarTituloPagamentoVenda(VendaPagamento pagamento) {
+        String numeroVenda = ofNullable(pagamento.getVenda())
+                .map(Venda::getSequencialUsuario)
+                .map(seq -> "#" + seq)
+                .orElse("");
+        return ("Pagamento de venda " + numeroVenda).trim();
+    }
+
+    private String montarDescricaoPagamentoVenda(VendaPagamento pagamento) {
+        return "Parcela de venda vence em " + pagamento.getDataVencimento();
+    }
+
+    private String montarTituloCompra(Compra compra) {
+        return "Compra agendada #" + ofNullable(compra.getSequencialUsuario()).orElse(0);
+    }
+
+    private String montarDescricaoCompra(Compra compra) {
+        String fornecedor = ofNullable(compra.getFornecedor())
+                .map(f -> ofNullable(f.getNome()).orElse(null))
+                .filter(Objects::nonNull)
+                .orElse(null);
+        if (fornecedor != null && !fornecedor.isBlank()) {
+            return "Visita ao fornecedor " + fornecedor;
+        }
+        return ofNullable(compra.getObservacoes()).filter(obs -> !obs.isBlank()).orElse("Compra agendada");
+    }
+
+    private String montarTituloVenda(Venda venda) {
+        return "Venda agendada #" + ofNullable(venda.getSequencialUsuario()).orElse(0);
+    }
+
+    private String montarDescricaoVenda(Venda venda) {
+        String cliente = ofNullable(venda.getCliente())
+                .map(c -> ofNullable(c.getNome()).orElse(null))
+                .filter(Objects::nonNull)
+                .orElse(null);
+        if (cliente != null && !cliente.isBlank()) {
+            return "Contato com cliente " + cliente;
+        }
+        return ofNullable(venda.getObservacoes()).filter(obs -> !obs.isBlank()).orElse("Venda agendada");
     }
 }

--- a/src/test/java/com/AIT/Optimanage/Services/AgendaServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/AgendaServiceTest.java
@@ -1,0 +1,210 @@
+package com.AIT.Optimanage.Services;
+
+import com.AIT.Optimanage.Models.Agenda.AgendaSearch;
+import com.AIT.Optimanage.Models.Agenda.EventoAgenda;
+import com.AIT.Optimanage.Models.Cliente.ClienteContato;
+import com.AIT.Optimanage.Models.Compra.Compra;
+import com.AIT.Optimanage.Models.Compra.CompraPagamento;
+import com.AIT.Optimanage.Models.Enums.StatusPagamento;
+import com.AIT.Optimanage.Models.Enums.TipoEvento;
+import com.AIT.Optimanage.Models.Plano;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Models.Venda.Venda;
+import com.AIT.Optimanage.Models.Venda.VendaPagamento;
+import com.AIT.Optimanage.Repositories.Cliente.ClienteContatoRepository;
+import com.AIT.Optimanage.Repositories.Compra.CompraRepository;
+import com.AIT.Optimanage.Repositories.Compra.PagamentoCompraRepository;
+import com.AIT.Optimanage.Repositories.Venda.PagamentoVendaRepository;
+import com.AIT.Optimanage.Repositories.Venda.VendaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgendaServiceTest {
+
+    @Mock private PagamentoCompraRepository pagamentoCompraRepository;
+    @Mock private PagamentoVendaRepository pagamentoVendaRepository;
+    @Mock private CompraRepository compraRepository;
+    @Mock private VendaRepository vendaRepository;
+    @Mock private ClienteContatoRepository clienteContatoRepository;
+    @Mock private PlanoService planoService;
+
+    @InjectMocks private AgendaService agendaService;
+
+    private User usuario;
+    private Plano planoHabilitado;
+
+    @BeforeEach
+    void setUp() {
+        usuario = User.builder().build();
+        usuario.setId(5);
+        usuario.setTenantId(42);
+
+        planoHabilitado = Plano.builder().agendaHabilitada(true).build();
+        when(planoService.obterPlanoUsuario(usuario)).thenReturn(Optional.of(planoHabilitado));
+    }
+
+    @Test
+    void listarEventosIncluiPagamentosAgendamentosEAniversarios() {
+        LocalDate inicio = LocalDate.of(2024, 1, 10);
+        LocalDate fim = inicio.plusDays(5);
+
+        AgendaSearch pesquisa = AgendaSearch.builder()
+                .page(0)
+                .pageSize(10)
+                .dataInicial(inicio)
+                .dataFinal(fim)
+                .build();
+
+        Compra compra = Compra.builder()
+                .sequencialUsuario(120)
+                .dataAgendada(inicio.plusDays(3))
+                .observacoes("Reunião com fornecedor")
+                .build();
+        compra.setId(7);
+
+        Venda venda = Venda.builder()
+                .sequencialUsuario(220)
+                .dataAgendada(inicio.plusDays(4))
+                .observacoes("Apresentação para cliente")
+                .build();
+        venda.setId(8);
+
+        CompraPagamento pagamentoCompra = CompraPagamento.builder()
+                .dataVencimento(inicio.plusDays(1))
+                .valorPago(BigDecimal.ZERO)
+                .statusPagamento(StatusPagamento.PENDENTE)
+                .compra(compra)
+                .build();
+        pagamentoCompra.setId(11);
+
+        VendaPagamento pagamentoVenda = VendaPagamento.builder()
+                .dataVencimento(inicio.plusDays(2))
+                .valorPago(BigDecimal.ZERO)
+                .statusPagamento(StatusPagamento.PENDENTE)
+                .venda(venda)
+                .build();
+        pagamentoVenda.setId(22);
+
+        ClienteContato contato = ClienteContato.builder()
+                .nome("Maria Silva")
+                .aniversario("15/01")
+                .build();
+        contato.setId(33);
+
+        when(pagamentoCompraRepository.findAllByCompraOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(
+                eq(usuario.getTenantId()), eq(StatusPagamento.PENDENTE), any(LocalDate.class)))
+                .thenReturn(List.of(pagamentoCompra));
+        when(pagamentoVendaRepository.findAllByVendaOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(
+                eq(usuario.getTenantId()), eq(StatusPagamento.PENDENTE), any(LocalDate.class)))
+                .thenReturn(List.of(pagamentoVenda));
+        when(compraRepository.findAgendadasNoPeriodo(usuario.getTenantId(), usuario.getId(), inicio, fim))
+                .thenReturn(List.of(compra));
+        when(vendaRepository.findAgendadasNoPeriodo(usuario.getTenantId(), usuario.getId(), inicio, fim))
+                .thenReturn(List.of(venda));
+        when(clienteContatoRepository.findAllByClienteOrganizationIdAndCreatedBy(usuario.getTenantId(), usuario.getId()))
+                .thenReturn(List.of(contato));
+
+        Page<EventoAgenda> pagina = agendaService.listarEventos(usuario, pesquisa);
+
+        assertThat(pagina.getTotalElements()).isEqualTo(5);
+        assertThat(pagina.getContent())
+                .extracting(EventoAgenda::getTipo)
+                .contains(TipoEvento.PAGAMENTO, TipoEvento.AGENDAMENTO, TipoEvento.ANIVERSARIO);
+
+        assertThat(pagina.getContent())
+                .filteredOn(evento -> evento.getTipo() == TipoEvento.AGENDAMENTO && evento.getReferencia() == TipoEvento.COMPRA)
+                .isNotEmpty();
+        assertThat(pagina.getContent())
+                .filteredOn(evento -> evento.getTipo() == TipoEvento.AGENDAMENTO && evento.getReferencia() == TipoEvento.VENDA)
+                .isNotEmpty();
+        assertThat(pagina.getContent())
+                .filteredOn(evento -> evento.getTipo() == TipoEvento.ANIVERSARIO)
+                .first()
+                .extracting(EventoAgenda::getData)
+                .isEqualTo(LocalDate.of(2024, 1, 15));
+
+        assertThat(pagina.getContent())
+                .allMatch(evento -> evento.getTitulo() != null && !evento.getTitulo().isBlank());
+    }
+
+    @Test
+    void listarEventosRespeitaJanelaDeDatas() {
+        LocalDate inicio = LocalDate.of(2024, 6, 1);
+        LocalDate fim = inicio.plusDays(3);
+
+        AgendaSearch pesquisa = AgendaSearch.builder()
+                .page(0)
+                .pageSize(10)
+                .dataInicial(inicio)
+                .dataFinal(fim)
+                .build();
+
+        CompraPagamento pagamentoDentro = CompraPagamento.builder()
+                .dataVencimento(inicio.plusDays(1))
+                .statusPagamento(StatusPagamento.PENDENTE)
+                .build();
+        pagamentoDentro.setId(10);
+
+        CompraPagamento pagamentoFora = CompraPagamento.builder()
+                .dataVencimento(inicio.plusDays(10))
+                .statusPagamento(StatusPagamento.PENDENTE)
+                .build();
+        pagamentoFora.setId(11);
+
+        Compra compraDentro = Compra.builder()
+                .dataAgendada(inicio.plusDays(2))
+                .sequencialUsuario(1)
+                .build();
+        compraDentro.setId(1);
+
+        Compra compraFora = Compra.builder()
+                .dataAgendada(inicio.plusDays(7))
+                .sequencialUsuario(2)
+                .build();
+        compraFora.setId(2);
+
+        ClienteContato contatoFora = ClienteContato.builder()
+                .nome("Contato Externo")
+                .aniversario("10/06")
+                .build();
+        contatoFora.setId(5);
+
+        when(pagamentoCompraRepository.findAllByCompraOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(
+                eq(usuario.getTenantId()), eq(StatusPagamento.PENDENTE), any(LocalDate.class)))
+                .thenReturn(List.of(pagamentoDentro, pagamentoFora));
+        when(pagamentoVendaRepository.findAllByVendaOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(
+                eq(usuario.getTenantId()), eq(StatusPagamento.PENDENTE), any(LocalDate.class)))
+                .thenReturn(List.of());
+        when(compraRepository.findAgendadasNoPeriodo(usuario.getTenantId(), usuario.getId(), inicio, fim))
+                .thenReturn(List.of(compraDentro, compraFora));
+        when(vendaRepository.findAgendadasNoPeriodo(usuario.getTenantId(), usuario.getId(), inicio, fim))
+                .thenReturn(List.of());
+        when(clienteContatoRepository.findAllByClienteOrganizationIdAndCreatedBy(usuario.getTenantId(), usuario.getId()))
+                .thenReturn(List.of(contatoFora));
+
+        Page<EventoAgenda> pagina = agendaService.listarEventos(usuario, pesquisa);
+
+        assertThat(pagina.getTotalElements()).isEqualTo(2);
+        assertThat(pagina.getContent())
+                .allMatch(evento -> !evento.getData().isBefore(inicio) && !evento.getData().isAfter(fim));
+        assertThat(pagina.getContent())
+                .extracting(EventoAgenda::getTipo)
+                .doesNotContain(TipoEvento.ANIVERSARIO);
+    }
+}


### PR DESCRIPTION
## Summary
- include repository queries to fetch scheduled compras e vendas filtered by usuário e período
- expand agenda events with richer metadata, deduplication, scheduled items and normalized aniversários
- add service tests cobrindo eventos combinados e filtragem por janela de datas

## Testing
- ./mvnw test *(fails: unable to resolve parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5b9ef55083249a56904826f0eb18