### PR TITLE
feat: allow negotiated product cost in purchases

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraProdutoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraProdutoDTO.java
@@ -1,10 +1,13 @@
 package com.AIT.Optimanage.Models.Compra.DTOs;
 
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
 
 @Data
 @NoArgsConstructor
@@ -16,4 +19,12 @@ public class CompraProdutoDTO {
     @NotNull
     @Min(1)
     private Integer quantidade;
+
+    @DecimalMin(value = "0.0", inclusive = false, message = "O valor unitário deve ser maior que zero")
+    private BigDecimal valorUnitario;
+
+    public CompraProdutoDTO(Integer produtoId, Integer quantidade) {
+        this.produtoId = produtoId;
+        this.quantidade = quantidade;
+    }
 }

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -386,15 +386,17 @@ public class CompraService {
         return produtosDTO.stream()
                 .map(produtoDTO -> {
                     Produto produto = produtoService.buscarProdutoAtivo(produtoDTO.getProdutoId());
-                    BigDecimal valorFinalProduto = produto.getValorVenda()
+                    BigDecimal valorUnitario = Optional.ofNullable(produtoDTO.getValorUnitario())
+                            .orElse(produto.getCusto());
+                    BigDecimal valorTotal = valorUnitario
                             .multiply(BigDecimal.valueOf(produtoDTO.getQuantidade()));
 
                     return CompraProduto.builder()
                             .compra(compra)
                             .produto(produto)
-                            .valorUnitario(produto.getValorVenda())
+                            .valorUnitario(valorUnitario)
                             .quantidade(produtoDTO.getQuantidade())
-                            .valorTotal(valorFinalProduto)
+                            .valorTotal(valorTotal)
                             .build();
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
## Summary
- allow purchases to receive an optional negotiated unit cost in `CompraProdutoDTO` with validation support
- ensure `CompraService` persists the informed cost (or the product cost as fallback) when calculating totals
- extend `CompraServiceTest` coverage to validate explicit and fallback cost scenarios and resulting inventory adjustments

## Testing
- `./mvnw test` *(fails: dependency download blocked by offline Maven Central access)*

------
https://chatgpt.com/codex/tasks/task_e_68cd895f337c8324b0147e6e2233401d