### PR TITLE
Improve agenda scheduling validation and conflict checks

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Config/ClockConfig.java
+++ b/src/main/java/com/AIT/Optimanage/Config/ClockConfig.java
@@ -1,0 +1,15 @@
+package com.AIT.Optimanage.Config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock systemClock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Controllers/BaseController/V1BaseController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/BaseController/V1BaseController.java
@@ -3,6 +3,8 @@ package com.AIT.Optimanage.Controllers.BaseController;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.util.Map;
+
 public abstract class V1BaseController {
 
     protected <T> ResponseEntity<T> ok(T body) {
@@ -15,5 +17,9 @@ public abstract class V1BaseController {
 
     protected ResponseEntity<Void> noContent() {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    protected ResponseEntity<Map<String, String>> badRequest(String mensagem) {
+        return ResponseEntity.badRequest().body(Map.of("mensagem", mensagem));
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/Compra/CompraController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Compra/CompraController.java
@@ -121,9 +121,15 @@ public class CompraController extends V1BaseController {
     @PutMapping("/{idCompra}/agendar")
     @Operation(summary = "Agendar compra", description = "Agenda uma compra")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-      public ResponseEntity<CompraResponseDTO> agendarCompra(@PathVariable("idCompra") Integer idCompra,
-                                                 @RequestParam String dataAgendada) {
-          return ok(compraService.agendarCompra(idCompra, dataAgendada));
+      public ResponseEntity<?> agendarCompra(@PathVariable("idCompra") Integer idCompra,
+                                             @RequestParam String dataAgendada,
+                                             @RequestParam String horaAgendada,
+                                             @RequestParam(value = "duracaoMinutos", required = false) Integer duracaoMinutos) {
+          try {
+              return ok(compraService.agendarCompra(idCompra, dataAgendada, horaAgendada, duracaoMinutos));
+          } catch (IllegalArgumentException | IllegalStateException ex) {
+              return badRequest(ex.getMessage());
+          }
       }
 
     @PutMapping("/{idCompra}/finalizar-agendamento")

--- a/src/main/java/com/AIT/Optimanage/Controllers/Venda/VendaController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Venda/VendaController.java
@@ -153,10 +153,16 @@ public class VendaController extends V1BaseController {
     @PutMapping("/{idVenda}/agendar")
     @Operation(summary = "Agendar venda", description = "Agenda uma venda")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ResponseEntity<VendaResponseDTO> agendarVenda(@AuthenticationPrincipal User loggedUser,
-                                              @PathVariable("idVenda") Integer idVenda,
-                                              @RequestParam String dataAgendada) {
-        return ok(vendaService.agendarVenda(loggedUser, idVenda, dataAgendada));
+    public ResponseEntity<?> agendarVenda(@AuthenticationPrincipal User loggedUser,
+                                          @PathVariable("idVenda") Integer idVenda,
+                                          @RequestParam String dataAgendada,
+                                          @RequestParam String horaAgendada,
+                                          @RequestParam(value = "duracaoMinutos", required = false) Integer duracaoMinutos) {
+        try {
+            return ok(vendaService.agendarVenda(loggedUser, idVenda, dataAgendada, horaAgendada, duracaoMinutos));
+        } catch (IllegalArgumentException | IllegalStateException ex) {
+            return badRequest(ex.getMessage());
+        }
     }
 
     @PutMapping("/{idVenda}/finalizar-agendamento")

--- a/src/main/java/com/AIT/Optimanage/Models/Agenda/EventoAgenda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Agenda/EventoAgenda.java
@@ -6,7 +6,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Data
 @Builder
@@ -16,6 +18,8 @@ public class EventoAgenda {
     private TipoEvento tipo;
     private TipoEvento referencia;
     private LocalDate data;
+    private LocalTime hora;
+    private Duration duracao;
     private Integer id;
     private String titulo;
     private String descricao;

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
@@ -12,7 +12,9 @@ import lombok.*;
 import com.AIT.Optimanage.Models.AuditableEntity;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Data
@@ -38,6 +40,9 @@ public class Compra extends AuditableEntity implements OwnableEntity {
     @Column(nullable = false)
     private LocalDate dataEfetuacao;
     private LocalDate dataAgendada;
+    private LocalTime horaAgendada;
+    @Column(name = "duracao_estimada")
+    private Duration duracaoEstimada;
     @DecimalMin(value = "0.0")
     @Column(nullable = false, precision = 10, scale = 2)
     private BigDecimal valorFinal;

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraDTO.java
@@ -9,7 +9,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Data
@@ -22,6 +24,8 @@ public class CompraDTO {
     @NotNull
     private LocalDate dataEfetuacao = LocalDate.now();
     private LocalDate dataAgendada = null;
+    private LocalTime horaAgendada;
+    private Duration duracaoEstimada = Duration.ofHours(1);
     private LocalDate dataCobranca;
     @DecimalMin(value = "0.0")
     @NotNull

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraResponseDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraResponseDTO.java
@@ -7,7 +7,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Data
@@ -21,6 +23,8 @@ public class CompraResponseDTO {
     private Integer sequencialUsuario;
     private LocalDate dataEfetuacao;
     private LocalDate dataAgendada;
+    private LocalTime horaAgendada;
+    private Duration duracaoEstimada;
     private BigDecimal valorFinal;
     private String condicaoPagamento;
     private BigDecimal valorPendente;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaDTO.java
@@ -9,7 +9,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Data
@@ -22,6 +24,8 @@ public class VendaDTO {
     @NotNull
     private LocalDate dataEfetuacao = LocalDate.now();
     private LocalDate dataAgendada = null;
+    private LocalTime horaAgendada;
+    private Duration duracaoEstimada = Duration.ofHours(1);
     private LocalDate dataCobranca;
     @DecimalMin(value = "0.0")
     private BigDecimal descontoGeral = BigDecimal.ZERO;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaResponseDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaResponseDTO.java
@@ -8,7 +8,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Data
@@ -22,6 +24,8 @@ public class VendaResponseDTO {
     private Integer sequencialUsuario;
     private LocalDate dataEfetuacao;
     private LocalDate dataAgendada;
+    private LocalTime horaAgendada;
+    private Duration duracaoEstimada;
     private LocalDate dataCobranca;
     private BigDecimal valorTotal;
     private BigDecimal descontoGeral;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
@@ -13,7 +13,9 @@ import lombok.*;
 import com.AIT.Optimanage.Models.AuditableEntity;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Data
@@ -39,6 +41,9 @@ public class Venda extends AuditableEntity implements OwnableEntity {
     @Column(nullable = false)
     private LocalDate dataEfetuacao;
     private LocalDate dataAgendada;
+    private LocalTime horaAgendada;
+    @Column(name = "duracao_estimada")
+    private Duration duracaoEstimada;
     @Column(nullable = false)
     private LocalDate dataCobranca;
     @DecimalMin(value = "0.0")

--- a/src/main/java/com/AIT/Optimanage/Validation/AgendaValidator.java
+++ b/src/main/java/com/AIT/Optimanage/Validation/AgendaValidator.java
@@ -1,0 +1,251 @@
+package com.AIT.Optimanage.Validation;
+
+import com.AIT.Optimanage.Models.Compra.Compra;
+import com.AIT.Optimanage.Models.Compra.CompraServico;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Models.Venda.Venda;
+import com.AIT.Optimanage.Models.Venda.VendaServico;
+import com.AIT.Optimanage.Repositories.Compra.CompraRepository;
+import com.AIT.Optimanage.Repositories.Venda.VendaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class AgendaValidator {
+
+    private static final int DEFAULT_MAX_WINDOW_DAYS = 365;
+    private static final Duration DEFAULT_DURATION = Duration.ofHours(1);
+
+    private final CompraRepository compraRepository;
+    private final VendaRepository vendaRepository;
+    private final Clock clock;
+
+    public LocalDate validarDataAgendamento(String dataAgendada) {
+        return validarDataAgendamento(dataAgendada, DEFAULT_MAX_WINDOW_DAYS);
+    }
+
+    public LocalDate validarDataAgendamento(String dataAgendada, Integer janelaMaximaDias) {
+        if (dataAgendada == null || dataAgendada.isBlank()) {
+            throw new IllegalArgumentException("Informe a data do agendamento no formato yyyy-MM-dd.");
+        }
+
+        LocalDate data;
+        try {
+            data = LocalDate.parse(dataAgendada, DateTimeFormatter.ISO_LOCAL_DATE);
+        } catch (DateTimeParseException ex) {
+            throw new IllegalArgumentException("Data agendada deve estar no formato ISO (yyyy-MM-dd).");
+        }
+
+        LocalDate hoje = LocalDate.now(clock);
+        if (data.isBefore(hoje)) {
+            throw new IllegalArgumentException("Não é possível agendar para uma data no passado.");
+        }
+
+        if (janelaMaximaDias != null && janelaMaximaDias > 0) {
+            LocalDate limite = hoje.plusDays(janelaMaximaDias);
+            if (data.isAfter(limite)) {
+                throw new IllegalArgumentException(
+                        "A data informada ultrapassa o limite máximo de " + janelaMaximaDias + " dias.");
+            }
+        }
+        return data;
+    }
+
+    public LocalTime validarHoraAgendada(String horaAgendada) {
+        if (horaAgendada == null || horaAgendada.isBlank()) {
+            throw new IllegalArgumentException("Informe o horário do agendamento no formato HH:mm.");
+        }
+        try {
+            return LocalTime.parse(horaAgendada, DateTimeFormatter.ofPattern("HH:mm"));
+        } catch (DateTimeParseException ex) {
+            throw new IllegalArgumentException("Horário agendado deve estar no formato HH:mm.");
+        }
+    }
+
+    public Duration validarDuracao(Integer duracaoEmMinutos) {
+        if (duracaoEmMinutos == null) {
+            return DEFAULT_DURATION;
+        }
+        if (duracaoEmMinutos <= 0) {
+            throw new IllegalArgumentException("A duração deve ser informada em minutos e maior que zero.");
+        }
+        return Duration.ofMinutes(duracaoEmMinutos.longValue());
+    }
+
+    public void validarConflitosAgendamentoCompra(Compra compra, Integer userId, LocalDate data, LocalTime hora,
+                                                   Duration duracao) {
+        if (compra == null || data == null) {
+            return;
+        }
+
+        Integer organizationId = compra.getOrganizationId();
+        Agendamentos agendamentos = carregarAgendamentos(organizationId, userId, data);
+        verificarConflitosUsuario(agendamentos, data, hora, duracao, compra.getId(), null);
+
+        Set<Integer> recursos = extrairRecursosCompra(compra.getCompraServicos());
+        if (recursos.isEmpty()) {
+            return;
+        }
+
+        for (Compra outraCompra : agendamentos.compras()) {
+            if (Objects.equals(outraCompra.getId(), compra.getId())) {
+                continue;
+            }
+            if (recursosConflitantes(recursos, extrairRecursosCompra(outraCompra.getCompraServicos()))
+                    && intervaloConflitante(data, hora, duracao, outraCompra.getDataAgendada(),
+                    outraCompra.getHoraAgendada(), outraCompra.getDuracaoEstimada())) {
+                throw new IllegalArgumentException("Existe conflito de recursos (serviços) no período selecionado.");
+            }
+        }
+    }
+
+    public void validarConflitosAgendamentoVenda(User usuario, Venda venda, LocalDate data, LocalTime hora,
+                                                 Duration duracao) {
+        if (venda == null || data == null) {
+            return;
+        }
+
+        Integer organizationId = venda.getOrganizationId();
+        Integer userId = Optional.ofNullable(usuario).map(User::getId).orElse(venda.getCreatedBy());
+        Agendamentos agendamentos = carregarAgendamentos(organizationId, userId, data);
+        verificarConflitosUsuario(agendamentos, data, hora, duracao, null, venda.getId());
+
+        Integer clienteId = Optional.ofNullable(venda.getCliente()).map(cliente -> cliente.getId()).orElse(null);
+        if (clienteId != null) {
+            for (Venda outraVenda : agendamentos.vendas()) {
+                if (Objects.equals(outraVenda.getId(), venda.getId())) {
+                    continue;
+                }
+                Integer outroClienteId = Optional.ofNullable(outraVenda.getCliente())
+                        .map(cliente -> cliente.getId()).orElse(null);
+                if (Objects.equals(clienteId, outroClienteId)
+                        && intervaloConflitante(data, hora, duracao, outraVenda.getDataAgendada(),
+                        outraVenda.getHoraAgendada(), outraVenda.getDuracaoEstimada())) {
+                    throw new IllegalArgumentException("O cliente selecionado já possui um agendamento neste período.");
+                }
+            }
+        }
+
+        Set<Integer> recursos = extrairRecursosVenda(venda.getVendaServicos());
+        if (recursos.isEmpty()) {
+            return;
+        }
+
+        for (Venda outraVenda : agendamentos.vendas()) {
+            if (Objects.equals(outraVenda.getId(), venda.getId())) {
+                continue;
+            }
+            if (recursosConflitantes(recursos, extrairRecursosVenda(outraVenda.getVendaServicos()))
+                    && intervaloConflitante(data, hora, duracao, outraVenda.getDataAgendada(),
+                    outraVenda.getHoraAgendada(), outraVenda.getDuracaoEstimada())) {
+                throw new IllegalArgumentException("Existe conflito de recursos (serviços) no período selecionado.");
+            }
+        }
+    }
+
+    private Agendamentos carregarAgendamentos(Integer organizationId, Integer userId, LocalDate data) {
+        if (organizationId == null || userId == null || data == null) {
+            return new Agendamentos(List.of(), List.of());
+        }
+        List<Compra> compras = compraRepository.findAgendadasNoPeriodo(organizationId, userId, data, data);
+        List<Venda> vendas = vendaRepository.findAgendadasNoPeriodo(organizationId, userId, data, data);
+        return new Agendamentos(compras, vendas);
+    }
+
+    private void verificarConflitosUsuario(Agendamentos agendamentos, LocalDate data, LocalTime hora, Duration duracao,
+                                           Integer ignorarCompraId, Integer ignorarVendaId) {
+        for (Compra outraCompra : agendamentos.compras()) {
+            if (Objects.equals(outraCompra.getId(), ignorarCompraId)) {
+                continue;
+            }
+            if (intervaloConflitante(data, hora, duracao, outraCompra.getDataAgendada(),
+                    outraCompra.getHoraAgendada(), outraCompra.getDuracaoEstimada())) {
+                throw new IllegalArgumentException("Já existe um agendamento para este usuário no período informado.");
+            }
+        }
+
+        for (Venda outraVenda : agendamentos.vendas()) {
+            if (Objects.equals(outraVenda.getId(), ignorarVendaId)) {
+                continue;
+            }
+            if (intervaloConflitante(data, hora, duracao, outraVenda.getDataAgendada(),
+                    outraVenda.getHoraAgendada(), outraVenda.getDuracaoEstimada())) {
+                throw new IllegalArgumentException("Já existe um agendamento para este usuário no período informado.");
+            }
+        }
+    }
+
+    private boolean intervaloConflitante(LocalDate dataReferencia, LocalTime horaReferencia, Duration duracaoReferencia,
+                                         LocalDate outraData, LocalTime outraHora, Duration outraDuracao) {
+        if (dataReferencia == null || outraData == null || !dataReferencia.equals(outraData)) {
+            return false;
+        }
+
+        DateTimeRange atual = construirIntervalo(dataReferencia, horaReferencia, duracaoReferencia);
+        DateTimeRange existente = construirIntervalo(outraData, outraHora, outraDuracao);
+        return atual.inicio().isBefore(existente.fim()) && existente.inicio().isBefore(atual.fim());
+    }
+
+    private DateTimeRange construirIntervalo(LocalDate data, LocalTime hora, Duration duracao) {
+        LocalDateTime inicio = data.atStartOfDay();
+        LocalDateTime fim = data.atTime(LocalTime.MAX);
+
+        if (hora != null) {
+            inicio = data.atTime(hora);
+            Duration efetiva = (duracao == null || duracao.isZero() || duracao.isNegative())
+                    ? DEFAULT_DURATION : duracao;
+            LocalDateTime calculado = inicio.plus(efetiva);
+            if (calculado.toLocalDate().isAfter(data)) {
+                fim = data.atTime(LocalTime.MAX);
+            } else {
+                fim = calculado;
+            }
+        }
+
+        return new DateTimeRange(inicio, fim);
+    }
+
+    private Set<Integer> extrairRecursosCompra(Collection<CompraServico> servicos) {
+        return Optional.ofNullable(servicos).orElseGet(List::of).stream()
+                .map(servico -> Optional.ofNullable(servico.getServico())
+                        .map(s -> s.getId()).orElse(null))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<Integer> extrairRecursosVenda(Collection<VendaServico> servicos) {
+        return Optional.ofNullable(servicos).orElseGet(List::of).stream()
+                .map(servico -> Optional.ofNullable(servico.getServico())
+                        .map(s -> s.getId()).orElse(null))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    private boolean recursosConflitantes(Set<Integer> recursosAtuais, Set<Integer> recursosExistentes) {
+        if (recursosAtuais.isEmpty() || recursosExistentes.isEmpty()) {
+            return false;
+        }
+        return recursosAtuais.stream().anyMatch(recursosExistentes::contains);
+    }
+
+    private record Agendamentos(List<Compra> compras, List<Venda> vendas) {
+    }
+
+    private record DateTimeRange(LocalDateTime inicio, LocalDateTime fim) {
+    }
+}

--- a/src/test/java/com/AIT/Optimanage/Validation/AgendaValidatorTest.java
+++ b/src/test/java/com/AIT/Optimanage/Validation/AgendaValidatorTest.java
@@ -1,0 +1,127 @@
+package com.AIT.Optimanage.Validation;
+
+import com.AIT.Optimanage.Models.Cliente.Cliente;
+import com.AIT.Optimanage.Models.Compra.Compra;
+import com.AIT.Optimanage.Models.Compra.CompraServico;
+import com.AIT.Optimanage.Models.Servico;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Models.Venda.Venda;
+import com.AIT.Optimanage.Models.Venda.VendaServico;
+import com.AIT.Optimanage.Repositories.Compra.CompraRepository;
+import com.AIT.Optimanage.Repositories.Venda.VendaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgendaValidatorTest {
+
+    @Mock
+    private CompraRepository compraRepository;
+    @Mock
+    private VendaRepository vendaRepository;
+
+    private AgendaValidator agendaValidator;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(LocalDate.of(2024, 1, 10).atStartOfDay(ZoneId.systemDefault()).toInstant(),
+                ZoneId.systemDefault());
+        agendaValidator = new AgendaValidator(compraRepository, vendaRepository, clock);
+    }
+
+    @Test
+    void validarDataAgendamentoRejeitaDatasPassadas() {
+        assertThatThrownBy(() -> agendaValidator.validarDataAgendamento("2024-01-05"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("passado");
+    }
+
+    @Test
+    void validarConflitoPorClienteEmVenda() {
+        LocalDate data = LocalDate.of(2024, 1, 15);
+        LocalTime hora = LocalTime.of(10, 0);
+        Duration duracao = Duration.ofMinutes(90);
+
+        Cliente cliente = new Cliente();
+        cliente.setId(20);
+
+        Venda venda = Venda.builder().build();
+        venda.setId(1);
+        venda.setOrganizationId(5);
+        venda.setCreatedBy(8);
+        venda.setCliente(cliente);
+
+        Venda outraVenda = Venda.builder().build();
+        outraVenda.setId(2);
+        outraVenda.setOrganizationId(5);
+        outraVenda.setCreatedBy(8);
+        outraVenda.setCliente(cliente);
+        outraVenda.setDataAgendada(data);
+        outraVenda.setHoraAgendada(hora);
+        outraVenda.setDuracaoEstimada(Duration.ofMinutes(60));
+
+        when(compraRepository.findAgendadasNoPeriodo(eq(5), eq(8), eq(data), eq(data))).thenReturn(List.of());
+        when(vendaRepository.findAgendadasNoPeriodo(eq(5), eq(8), eq(data), eq(data)))
+                .thenReturn(List.of(outraVenda));
+
+        User usuario = User.builder().id(8).tenantId(5).build();
+
+        assertThatThrownBy(() -> agendaValidator.validarConflitosAgendamentoVenda(usuario, venda, data, hora, duracao))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cliente");
+    }
+
+    @Test
+    void validarAgendamentoSemConflitosTemSucesso() {
+        LocalDate data = LocalDate.of(2024, 1, 18);
+        LocalTime hora = LocalTime.of(9, 0);
+        Duration duracao = Duration.ofMinutes(60);
+
+        Servico servico = Servico.builder().id(33).build();
+        CompraServico compraServico = CompraServico.builder().servico(servico).build();
+        Compra compra = Compra.builder().build();
+        compra.setId(3);
+        compra.setOrganizationId(5);
+        compra.setCreatedBy(8);
+        compra.setCompraServicos(List.of(compraServico));
+
+        VendaServico vendaServico = VendaServico.builder().servico(servico).build();
+        Venda vendaExistente = Venda.builder().build();
+        vendaExistente.setId(4);
+        vendaExistente.setOrganizationId(5);
+        vendaExistente.setCreatedBy(8);
+        vendaExistente.setDataAgendada(data);
+        vendaExistente.setHoraAgendada(LocalTime.of(13, 0));
+        vendaExistente.setDuracaoEstimada(Duration.ofMinutes(60));
+        vendaExistente.setVendaServicos(List.of(vendaServico));
+
+        when(compraRepository.findAgendadasNoPeriodo(eq(5), eq(8), eq(data), eq(data)))
+                .thenReturn(List.of(compra));
+        when(vendaRepository.findAgendadasNoPeriodo(eq(5), eq(8), eq(data), eq(data)))
+                .thenReturn(List.of(vendaExistente));
+
+        Compra novaCompra = Compra.builder().build();
+        novaCompra.setId(9);
+        novaCompra.setOrganizationId(5);
+        novaCompra.setCreatedBy(8);
+        novaCompra.setCompraServicos(List.of(compraServico));
+
+        assertThatCode(() -> agendaValidator.validarConflitosAgendamentoCompra(novaCompra, 8, data, hora, duracao))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Summary
- centralize agenda scheduling validation in a dedicated component that enforces ISO date parsing, future-only windows and overlap detection against compras e vendas
- extend agenda-related models, DTOs and events to carry scheduled time and duration so conflicts are evaluated with higher precision
- adapt controllers and services to surface friendly feedback while adding tests that cover past-date rejection, conflicting bookings and successful scheduling

## Testing
- ./mvnw test *(fails: parent POM download blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cd98c005888324a2f63dc0c0b59863