### PR TITLE
Validate venda discounts and round totals

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaDTO.java
@@ -24,6 +24,7 @@ public class VendaDTO {
     private LocalDate dataAgendada = null;
     private LocalDate dataCobranca;
     @DecimalMin(value = "0.0")
+    @DecimalMax(value = "100.0")
     private BigDecimal descontoGeral = BigDecimal.ZERO;
     private String condicaoPagamento;
     @Min(0)

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaProdutoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaProdutoDTO.java
@@ -1,5 +1,7 @@
 package com.AIT.Optimanage.Models.Venda.DTOs;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -17,5 +19,7 @@ public class VendaProdutoDTO {
     @Min(1)
     private Integer quantidade;
 
+    @DecimalMin(value = "0.0")
+    @DecimalMax(value = "100.0")
     private BigDecimal desconto = BigDecimal.ZERO;
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaServicoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaServicoDTO.java
@@ -1,5 +1,7 @@
 package com.AIT.Optimanage.Models.Venda.DTOs;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -19,5 +21,8 @@ public class VendaServicoDTO {
     @Min(1)
     private Integer quantidade;
 
+    @DecimalMin(value = "0.0")
+    @DecimalMax(value = "100.0")
     private BigDecimal desconto = BigDecimal.ZERO;
 }
+

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -62,6 +62,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.math.RoundingMode;
 
 @Service
 @RequiredArgsConstructor
@@ -167,15 +168,15 @@ public class VendaService {
         BigDecimal valorServicos = vendaServicos.stream()
                 .map(VendaServico::getValorFinal)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
-        BigDecimal valorTotal = valorProdutos.add(valorServicos);
+        BigDecimal valorTotal = valorProdutos.add(valorServicos).setScale(2, RoundingMode.HALF_UP);
 
         BigDecimal valorPago = BigDecimal.ZERO;
 
         novaVenda.setValorTotal(valorTotal);
         BigDecimal valorFinal = valorTotal.multiply(BigDecimal.valueOf(100).subtract(novaVenda.getDescontoGeral()))
-                .divide(BigDecimal.valueOf(100));
+                .divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
         novaVenda.setValorFinal(valorFinal);
-        novaVenda.setValorPendente(valorFinal.subtract(valorPago));
+        novaVenda.setValorPendente(valorFinal.subtract(valorPago).setScale(2, RoundingMode.HALF_UP));
         novaVenda.setVendaProdutos(vendaProdutos);
         novaVenda.setVendaServicos(vendaServicos);
         novaVenda.setTenantId(organizationId);
@@ -226,7 +227,7 @@ public class VendaService {
         BigDecimal valorServicos = vendaServicos.stream()
                 .map(VendaServico::getValorFinal)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
-        BigDecimal valorTotal = valorProdutos.add(valorServicos);
+        BigDecimal valorTotal = valorProdutos.add(valorServicos).setScale(2, RoundingMode.HALF_UP);
 
         BigDecimal valorPago = venda.getPagamentos() == null
                 ? BigDecimal.ZERO
@@ -234,9 +235,9 @@ public class VendaService {
 
         venda.setValorTotal(valorTotal);
         BigDecimal valorFinalAtualizado = valorTotal.multiply(BigDecimal.valueOf(100).subtract(descontoGeralAtualizado))
-                .divide(BigDecimal.valueOf(100));
+                .divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
         venda.setValorFinal(valorFinalAtualizado);
-        venda.setValorPendente(valorFinalAtualizado.subtract(valorPago));
+        venda.setValorPendente(valorFinalAtualizado.subtract(valorPago).setScale(2, RoundingMode.HALF_UP));
         venda.setVendaProdutos(vendaProdutos);
         venda.setVendaServicos(vendaServicos);
         atualizarStatus(venda, vendaDTO.getStatus());
@@ -443,11 +444,14 @@ public class VendaService {
         return produtosDTO.stream()
                 .map(produtoDTO -> {
                     Produto produto = produtoService.buscarProdutoAtivo(produtoDTO.getProdutoId());
-                    BigDecimal valorProduto = produto.getValorVenda().multiply(BigDecimal.valueOf(produtoDTO.getQuantidade()));
+                    BigDecimal valorProduto = produto.getValorVenda()
+                            .multiply(BigDecimal.valueOf(produtoDTO.getQuantidade()))
+                            .setScale(2, RoundingMode.HALF_UP);
                     BigDecimal descontoPercentual = Optional.ofNullable(produtoDTO.getDesconto()).orElse(BigDecimal.ZERO);
-                    BigDecimal descontoProduto = valorProduto
-                            .multiply(descontoPercentual.divide(BigDecimal.valueOf(100)));
-                    BigDecimal valorFinalProduto = valorProduto.subtract(descontoProduto);
+                    BigDecimal descontoProduto = valorProduto.multiply(descontoPercentual)
+                            .divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+                    BigDecimal valorFinalProduto = valorProduto.subtract(descontoProduto)
+                            .setScale(2, RoundingMode.HALF_UP);
 
                     VendaProduto vendaProduto = new VendaProduto();
                     vendaProduto.setVenda(venda);
@@ -480,11 +484,14 @@ public class VendaService {
         return servicosDTO.stream()
             .map(servicoDTO -> {
                 Servico servico = servicoService.buscarServicoAtivo(servicoDTO.getServicoId());
-                BigDecimal valorServico = servico.getValorVenda().multiply(BigDecimal.valueOf(servicoDTO.getQuantidade()));
+                BigDecimal valorServico = servico.getValorVenda()
+                        .multiply(BigDecimal.valueOf(servicoDTO.getQuantidade()))
+                        .setScale(2, RoundingMode.HALF_UP);
                 BigDecimal descontoPercentual = Optional.ofNullable(servicoDTO.getDesconto()).orElse(BigDecimal.ZERO);
-                BigDecimal descontoServico = valorServico
-                        .multiply(descontoPercentual.divide(BigDecimal.valueOf(100)));
-                BigDecimal valorFinalServico = valorServico.subtract(descontoServico);
+                BigDecimal descontoServico = valorServico.multiply(descontoPercentual)
+                        .divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+                BigDecimal valorFinalServico = valorServico.subtract(descontoServico)
+                        .setScale(2, RoundingMode.HALF_UP);
 
                 VendaServico vendaServico = new VendaServico();
                 vendaServico.setVenda(venda);

--- a/src/main/java/com/AIT/Optimanage/Validation/VendaValidator.java
+++ b/src/main/java/com/AIT/Optimanage/Validation/VendaValidator.java
@@ -5,6 +5,7 @@ import com.AIT.Optimanage.Models.Venda.DTOs.VendaDTO;
 import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @Component
@@ -33,6 +34,21 @@ public class VendaValidator {
         }
         if (vendaDTO.hasNoItems()) {
             throw new IllegalArgumentException("Uma venda deve ter no mínimo um produto ou serviço");
+        }
+
+        vendaDTO.getProdutos().forEach(produtoDTO -> validarDescontoPercentual(
+                produtoDTO.getDesconto(), "de produto"));
+        vendaDTO.getServicos().forEach(servicoDTO -> validarDescontoPercentual(
+                servicoDTO.getDesconto(), "de serviço"));
+        validarDescontoPercentual(vendaDTO.getDescontoGeral(), "geral");
+    }
+
+    private void validarDescontoPercentual(BigDecimal desconto, String contexto) {
+        if (desconto == null) {
+            return;
+        }
+        if (desconto.compareTo(BigDecimal.ZERO) < 0 || desconto.compareTo(BigDecimal.valueOf(100)) > 0) {
+            throw new IllegalArgumentException("Desconto " + contexto + " deve estar entre 0% e 100%");
         }
     }
 }

--- a/src/test/java/com/AIT/Optimanage/Services/Venda/VendaServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/Venda/VendaServiceTest.java
@@ -157,7 +157,7 @@ class VendaServiceTest {
         doNothing().when(vendaProdutoRepository).deleteByVenda(any(Venda.class));
         doNothing().when(vendaServicoRepository).deleteByVenda(any(Venda.class));
 
-        VendaProdutoDTO novoProdutoDTO = new VendaProdutoDTO(3, 2, new BigDecimal("10.00"));
+        VendaProdutoDTO novoProdutoDTO = new VendaProdutoDTO(3, 2, new BigDecimal("33.333"));
         VendaServicoDTO novoServicoDTO = new VendaServicoDTO(4, 1, BigDecimal.ZERO);
 
         VendaDTO vendaDTO = VendaDTO.builder()
@@ -186,9 +186,12 @@ class VendaServiceTest {
         assertSame(venda, novoProduto.getVenda());
         assertNotNull(venda.getVendaServicos());
         assertEquals(1, venda.getVendaServicos().size());
-        assertSame(venda, venda.getVendaServicos().get(0).getVenda());
-        assertEquals(0, new BigDecimal("180.00").compareTo(venda.getValorPendente()));
-        assertEquals(0, new BigDecimal("230.00").compareTo(venda.getValorTotal()));
+        VendaServico novoServico = venda.getVendaServicos().get(0);
+        assertSame(venda, novoServico.getVenda());
+        assertEquals(0, new BigDecimal("50.00").compareTo(novoServico.getValorFinal()));
+        assertEquals(0, new BigDecimal("133.33").compareTo(venda.getValorPendente()));
+        assertEquals(0, new BigDecimal("183.33").compareTo(venda.getValorTotal()));
+        assertEquals(0, new BigDecimal("183.33").compareTo(venda.getValorFinal()));
         assertEquals(StatusVenda.AGUARDANDO_PAG, venda.getStatus());
         assertEquals(BigDecimal.ZERO, venda.getDescontoGeral());
 
@@ -202,7 +205,9 @@ class VendaServiceTest {
         ArgumentCaptor<List<VendaProduto>> produtosCaptor = ArgumentCaptor.forClass(List.class);
         verify(vendaProdutoRepository).saveAll(produtosCaptor.capture());
         assertEquals(1, produtosCaptor.getValue().size());
-        assertSame(venda, produtosCaptor.getValue().get(0).getVenda());
+        VendaProduto produtoCapturado = produtosCaptor.getValue().get(0);
+        assertSame(venda, produtoCapturado.getVenda());
+        assertEquals(0, new BigDecimal("133.33").compareTo(produtoCapturado.getValorFinal()));
     }
 
     private Produto criarProdutoNovo() {

--- a/src/test/java/com/AIT/Optimanage/Validation/VendaValidatorTest.java
+++ b/src/test/java/com/AIT/Optimanage/Validation/VendaValidatorTest.java
@@ -1,0 +1,80 @@
+package com.AIT.Optimanage.Validation;
+
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Models.Venda.DTOs.VendaDTO;
+import com.AIT.Optimanage.Models.Venda.DTOs.VendaProdutoDTO;
+import com.AIT.Optimanage.Models.Venda.DTOs.VendaServicoDTO;
+import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class VendaValidatorTest {
+
+    private final VendaValidator validator = new VendaValidator();
+
+    @Test
+    void validarVendaAceitaDescontosNoLimite() {
+        VendaDTO dto = VendaDTO.builder()
+                .clienteId(1)
+                .dataEfetuacao(LocalDate.now())
+                .dataCobranca(LocalDate.now())
+                .status(StatusVenda.PENDENTE)
+                .descontoGeral(new BigDecimal("100.0"))
+                .produtos(List.of(new VendaProdutoDTO(1, 1, new BigDecimal("0"))))
+                .servicos(List.of(new VendaServicoDTO(1, 1, new BigDecimal("100"))))
+                .build();
+
+        assertDoesNotThrow(() -> validator.validarVenda(dto, new User()));
+    }
+
+    @Test
+    void validarVendaRejeitaDescontoGeralMaiorQueCem() {
+        VendaDTO dto = VendaDTO.builder()
+                .clienteId(1)
+                .dataEfetuacao(LocalDate.now())
+                .dataCobranca(LocalDate.now())
+                .status(StatusVenda.PENDENTE)
+                .descontoGeral(new BigDecimal("100.01"))
+                .produtos(List.of(new VendaProdutoDTO(1, 1, BigDecimal.ZERO)))
+                .servicos(List.of(new VendaServicoDTO(1, 1, BigDecimal.ZERO)))
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validarVenda(dto, new User()));
+    }
+
+    @Test
+    void validarVendaRejeitaDescontoDeProdutoForaDaFaixa() {
+        VendaDTO dto = VendaDTO.builder()
+                .clienteId(1)
+                .dataEfetuacao(LocalDate.now())
+                .dataCobranca(LocalDate.now())
+                .status(StatusVenda.PENDENTE)
+                .descontoGeral(BigDecimal.ZERO)
+                .produtos(List.of(new VendaProdutoDTO(1, 1, new BigDecimal("150"))))
+                .servicos(List.of(new VendaServicoDTO(1, 1, BigDecimal.ZERO)))
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validarVenda(dto, new User()));
+    }
+
+    @Test
+    void validarVendaRejeitaDescontoDeServicoNegativo() {
+        VendaDTO dto = VendaDTO.builder()
+                .clienteId(1)
+                .dataEfetuacao(LocalDate.now())
+                .dataCobranca(LocalDate.now())
+                .status(StatusVenda.PENDENTE)
+                .descontoGeral(BigDecimal.ZERO)
+                .produtos(List.of(new VendaProdutoDTO(1, 1, BigDecimal.ZERO)))
+                .servicos(List.of(new VendaServicoDTO(1, 1, new BigDecimal("-0.5"))))
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validarVenda(dto, new User()));
+    }
+}


### PR DESCRIPTION
## Summary
- add validation annotations to limit percentual discounts in venda DTOs
- harden VendaValidator against out-of-range discounts
- normalize venda totals and item values to two decimal places and extend tests for rounding/limits

## Testing
- ./mvnw test *(fails: network is unreachable when resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9a0cfdd88324a29d3bd6c90d0d92