### PR TITLE
Enforce tenant scoping in user management service

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Repositories/UserRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/UserRepository.java
@@ -1,19 +1,25 @@
 package com.AIT.Optimanage.Repositories;
 
 import com.AIT.Optimanage.Models.User.User;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
     public Optional<User> findByEmail(String email);
 
     long countByOrganizationIdAndAtivoTrue(Integer organizationId);
+
+    Page<User> findAllByOrganizationId(Integer organizationId, Pageable pageable);
+
+    Optional<User> findByIdAndOrganizationId(Integer id, Integer organizationId);
 
     @Modifying(clearAutomatically = true)
     @Query("update User u set u.organizationId = :organizationId where u.id = :userId")

--- a/src/test/java/com/AIT/Optimanage/Services/User/UsuarioServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/User/UsuarioServiceTest.java
@@ -1,0 +1,106 @@
+package com.AIT.Optimanage.Services.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.AIT.Optimanage.Controllers.User.dto.UserResponse;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Repositories.Organization.OrganizationRepository;
+import com.AIT.Optimanage.Repositories.PlanoRepository;
+import com.AIT.Optimanage.Repositories.UserRepository;
+import com.AIT.Optimanage.Security.CurrentUser;
+import com.AIT.Optimanage.Support.PlatformConstants;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UsuarioServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private PlanoRepository planoRepository;
+    @Mock private CacheManager cacheManager;
+    @Mock private BCryptPasswordEncoder passwordEncoder;
+
+    @InjectMocks private UsuarioService usuarioService;
+
+    private User currentUser;
+
+    @BeforeEach
+    void setUp() {
+        currentUser = User.builder().build();
+        currentUser.setId(1);
+        currentUser.setTenantId(10);
+        CurrentUser.set(currentUser);
+    }
+
+    @AfterEach
+    void tearDown() {
+        CurrentUser.clear();
+    }
+
+    @Test
+    void listarUsuariosRestringeAoTenantDoUsuarioAtual() {
+        Pageable pageable = PageRequest.of(0, 5);
+        User usuario = User.builder().nome("Maria").build();
+        usuario.setId(2);
+        usuario.setTenantId(10);
+        Page<User> usuarios = new PageImpl<>(List.of(usuario));
+
+        when(userRepository.findAllByOrganizationId(eq(10), eq(pageable))).thenReturn(usuarios);
+
+        Page<UserResponse> resposta = usuarioService.listarUsuarios(pageable);
+
+        assertThat(resposta.getContent()).hasSize(1);
+        verify(userRepository).findAllByOrganizationId(10, pageable);
+        verify(userRepository, never()).findAll(pageable);
+    }
+
+    @Test
+    void buscarUsuarioDeOutroTenantLancaAccessDenied() {
+        when(userRepository.findByIdAndOrganizationId(99, 10)).thenReturn(Optional.empty());
+        when(userRepository.existsById(99)).thenReturn(true);
+
+        assertThatThrownBy(() -> usuarioService.buscarUsuario(99))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("organização atual");
+
+        verify(userRepository).findByIdAndOrganizationId(99, 10);
+        verify(userRepository).existsById(99);
+    }
+
+    @Test
+    void organizacaoPlataformaMantemAcessoGlobal() {
+        currentUser.setTenantId(PlatformConstants.PLATFORM_ORGANIZATION_ID);
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<User> usuarios = new PageImpl<>(List.of());
+
+        when(userRepository.findAll(pageable)).thenReturn(usuarios);
+
+        Page<UserResponse> resposta = usuarioService.listarUsuarios(pageable);
+
+        assertThat(resposta.getContent()).isEmpty();
+        verify(userRepository).findAll(pageable);
+        verify(userRepository, never()).findAllByOrganizationId(anyInt(), any(Pageable.class));
+    }
+}


### PR DESCRIPTION
## Summary
- add tenant-scoped repository queries for listing and fetching users
- ensure UsuarioService filters operations by the current tenant while retaining platform-wide access when required
- cover cross-tenant access attempts with new unit tests

## Testing
- ./mvnw test *(fails: unable to resolve Spring Boot parent POM because the Maven Central repository is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaa95a2ec8324b481a8897410b0af