### PR TITLE
Fix product/service cache eviction and add regression tests

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
@@ -54,7 +54,7 @@ public class ProdutoService {
     }
 
     @Transactional
-    @CacheEvict(value = "produtos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId()")
+    @CacheEvict(value = "produtos", allEntries = true)
     public ProdutoResponse cadastrarProduto(ProdutoRequest request) {
         User loggedUser = CurrentUser.get();
         if (loggedUser == null) {
@@ -77,7 +77,7 @@ public class ProdutoService {
     }
 
     @Transactional
-    @CacheEvict(value = "produtos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId()")
+    @CacheEvict(value = "produtos", allEntries = true)
     public ProdutoResponse editarProduto(Integer idProduto, ProdutoRequest request) {
         Produto produtoSalvo = buscarProdutoAtivo(idProduto);
         Produto produto = produtoMapper.toEntity(request);
@@ -88,7 +88,7 @@ public class ProdutoService {
     }
 
     @Transactional
-    @CacheEvict(value = "produtos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId()")
+    @CacheEvict(value = "produtos", allEntries = true)
     public void excluirProduto(Integer idProduto) {
         Produto produto = buscarProdutoAtivo(idProduto);
         produto.setAtivo(false);

--- a/src/main/java/com/AIT/Optimanage/Services/ServicoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ServicoService.java
@@ -54,7 +54,7 @@ public class ServicoService {
     }
 
     @Transactional
-    @CacheEvict(value = "servicos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId()")
+    @CacheEvict(value = "servicos", allEntries = true)
     public ServicoResponse cadastrarServico(ServicoRequest request) {
         User loggedUser = CurrentUser.get();
         if (loggedUser == null) {
@@ -76,7 +76,7 @@ public class ServicoService {
     }
 
     @Transactional
-    @CacheEvict(value = "servicos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId()")
+    @CacheEvict(value = "servicos", allEntries = true)
     public ServicoResponse editarServico(Integer idServico, ServicoRequest request) {
         User loggedUser = CurrentUser.get();
         Servico servicoSalvo = buscarServicoAtivo(idServico);
@@ -88,7 +88,7 @@ public class ServicoService {
     }
 
     @Transactional
-    @CacheEvict(value = "servicos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId()")
+    @CacheEvict(value = "servicos", allEntries = true)
     public void excluirServico(Integer idServico) {
         User loggedUser = CurrentUser.get();
         Servico servico = buscarServicoAtivo(idServico);

--- a/src/test/java/com/AIT/Optimanage/Services/ProdutoServiceCacheEvictTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/ProdutoServiceCacheEvictTest.java
@@ -1,0 +1,176 @@
+package com.AIT.Optimanage.Services;
+
+import com.AIT.Optimanage.Config.CacheConfig;
+import com.AIT.Optimanage.Controllers.dto.ProdutoRequest;
+import com.AIT.Optimanage.Controllers.dto.ProdutoResponse;
+import com.AIT.Optimanage.Mappers.ProdutoMapper;
+import com.AIT.Optimanage.Models.Plano;
+import com.AIT.Optimanage.Models.Produto;
+import com.AIT.Optimanage.Models.Search;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Repositories.ProdutoRepository;
+import com.AIT.Optimanage.Security.CurrentUser;
+import com.AIT.Optimanage.Services.PlanoService;
+import com.AIT.Optimanage.Support.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(classes = {ProdutoService.class, CacheConfig.class}, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class ProdutoServiceCacheEvictTest {
+
+    @Autowired
+    private ProdutoService produtoService;
+
+    @MockBean
+    private ProdutoRepository produtoRepository;
+
+    @MockBean
+    private ProdutoMapper produtoMapper;
+
+    @MockBean
+    private PlanoService planoService;
+
+    private User user;
+    private Search defaultSearch;
+    private Search alternativeSearch;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(1);
+        user.setTenantId(1);
+        CurrentUser.set(user);
+        TenantContext.setTenantId(1);
+
+        defaultSearch = Search.builder()
+                .page(0)
+                .pageSize(10)
+                .sort("id")
+                .order(Sort.Direction.ASC)
+                .build();
+
+        alternativeSearch = defaultSearch.toBuilder()
+                .sort("nome")
+                .order(Sort.Direction.DESC)
+                .build();
+
+        when(produtoRepository.findAllByOrganizationIdAndAtivoTrue(anyInt(), any(Pageable.class)))
+                .thenAnswer(invocation -> new PageImpl<>(List.of(new Produto())));
+        when(produtoMapper.toResponse(any(Produto.class))).thenAnswer(invocation -> new ProdutoResponse());
+        when(produtoMapper.toEntity(any(ProdutoRequest.class))).thenAnswer(invocation -> {
+            ProdutoRequest request = invocation.getArgument(0);
+            Produto produto = new Produto();
+            produto.setSequencialUsuario(request.getSequencialUsuario());
+            produto.setCodigoReferencia(request.getCodigoReferencia());
+            produto.setNome(request.getNome());
+            produto.setCusto(request.getCusto());
+            produto.setValorVenda(request.getValorVenda());
+            produto.setQtdEstoque(request.getQtdEstoque());
+            produto.setAtivo(request.getAtivo() != null ? request.getAtivo() : Boolean.TRUE);
+            return produto;
+        });
+        when(produtoRepository.save(any(Produto.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        CurrentUser.clear();
+        TenantContext.clear();
+        Mockito.reset(produtoRepository, produtoMapper, planoService);
+    }
+
+    private void primeCache() {
+        produtoService.listarProdutos(defaultSearch);
+        produtoService.listarProdutos(defaultSearch);
+        produtoService.listarProdutos(alternativeSearch);
+        produtoService.listarProdutos(alternativeSearch);
+    }
+
+    private ProdutoRequest buildRequest() {
+        return ProdutoRequest.builder()
+                .sequencialUsuario(1)
+                .codigoReferencia("SKU-1")
+                .nome("Produto")
+                .custo(BigDecimal.ONE)
+                .valorVenda(BigDecimal.TEN)
+                .qtdEstoque(5)
+                .ativo(true)
+                .build();
+    }
+
+    @Test
+    void cadastrarProdutoEvictsAllCachedFilters() {
+        primeCache();
+        verify(produtoRepository, times(2)).findAllByOrganizationIdAndAtivoTrue(eq(1), any(Pageable.class));
+
+        Plano plano = new Plano();
+        plano.setMaxProdutos(10);
+        when(planoService.obterPlanoUsuario(user)).thenReturn(Optional.of(plano));
+        when(produtoRepository.countByOrganizationIdAndAtivoTrue(1)).thenReturn(1L);
+
+        produtoService.cadastrarProduto(buildRequest());
+
+        produtoService.listarProdutos(defaultSearch);
+        produtoService.listarProdutos(alternativeSearch);
+
+        verify(produtoRepository, times(4)).findAllByOrganizationIdAndAtivoTrue(eq(1), any(Pageable.class));
+    }
+
+    @Test
+    void editarProdutoEvictsAllCachedFilters() {
+        primeCache();
+        verify(produtoRepository, times(2)).findAllByOrganizationIdAndAtivoTrue(eq(1), any(Pageable.class));
+
+        Produto existente = new Produto();
+        existente.setId(10);
+        existente.setTenantId(1);
+        existente.setAtivo(true);
+        when(produtoRepository.findByIdAndOrganizationIdAndAtivoTrue(10, 1)).thenReturn(Optional.of(existente));
+
+        produtoService.editarProduto(10, buildRequest());
+
+        produtoService.listarProdutos(defaultSearch);
+        produtoService.listarProdutos(alternativeSearch);
+
+        verify(produtoRepository, times(4)).findAllByOrganizationIdAndAtivoTrue(eq(1), any(Pageable.class));
+    }
+
+    @Test
+    void excluirProdutoEvictsAllCachedFilters() {
+        primeCache();
+        verify(produtoRepository, times(2)).findAllByOrganizationIdAndAtivoTrue(eq(1), any(Pageable.class));
+
+        Produto existente = new Produto();
+        existente.setId(20);
+        existente.setTenantId(1);
+        existente.setAtivo(true);
+        when(produtoRepository.findByIdAndOrganizationIdAndAtivoTrue(20, 1)).thenReturn(Optional.of(existente));
+
+        produtoService.excluirProduto(20);
+
+        produtoService.listarProdutos(defaultSearch);
+        produtoService.listarProdutos(alternativeSearch);
+
+        verify(produtoRepository, times(4)).findAllByOrganizationIdAndAtivoTrue(eq(1), any(Pageable.class));
+    }
+}
+

--- a/src/test/java/com/AIT/Optimanage/Services/ServicoServiceCacheEvictTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/ServicoServiceCacheEvictTest.java
@@ -1,0 +1,176 @@
+package com.AIT.Optimanage.Services;
+
+import com.AIT.Optimanage.Config.CacheConfig;
+import com.AIT.Optimanage.Controllers.dto.ServicoRequest;
+import com.AIT.Optimanage.Controllers.dto.ServicoResponse;
+import com.AIT.Optimanage.Mappers.ServicoMapper;
+import com.AIT.Optimanage.Models.Plano;
+import com.AIT.Optimanage.Models.Search;
+import com.AIT.Optimanage.Models.Servico;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Repositories.ServicoRepository;
+import com.AIT.Optimanage.Security.CurrentUser;
+import com.AIT.Optimanage.Services.PlanoService;
+import com.AIT.Optimanage.Support.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(classes = {ServicoService.class, CacheConfig.class}, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class ServicoServiceCacheEvictTest {
+
+    @Autowired
+    private ServicoService servicoService;
+
+    @MockBean
+    private ServicoRepository servicoRepository;
+
+    @MockBean
+    private ServicoMapper servicoMapper;
+
+    @MockBean
+    private PlanoService planoService;
+
+    private User user;
+    private Search defaultSearch;
+    private Search alternativeSearch;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(1);
+        user.setTenantId(1);
+        CurrentUser.set(user);
+        TenantContext.setTenantId(1);
+
+        defaultSearch = Search.builder()
+                .page(0)
+                .pageSize(10)
+                .sort("id")
+                .order(Sort.Direction.ASC)
+                .build();
+
+        alternativeSearch = defaultSearch.toBuilder()
+                .sort("nome")
+                .order(Sort.Direction.DESC)
+                .build();
+
+        when(servicoRepository.findAllByOrganizationIdAndAtivoTrue(anyInt(), any(Pageable.class)))
+                .thenAnswer(invocation -> new PageImpl<>(List.of(new Servico())));
+        when(servicoMapper.toResponse(any(Servico.class))).thenAnswer(invocation -> new ServicoResponse());
+        when(servicoMapper.toEntity(any(ServicoRequest.class))).thenAnswer(invocation -> {
+            ServicoRequest request = invocation.getArgument(0);
+            Servico servico = new Servico();
+            servico.setSequencialUsuario(request.getSequencialUsuario());
+            servico.setNome(request.getNome());
+            servico.setDescricao(request.getDescricao());
+            servico.setCusto(request.getCusto());
+            servico.setValorVenda(request.getValorVenda());
+            servico.setTempoExecucao(request.getTempoExecucao());
+            servico.setAtivo(request.getAtivo() != null ? request.getAtivo() : Boolean.TRUE);
+            return servico;
+        });
+        when(servicoRepository.save(any(Servico.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        CurrentUser.clear();
+        TenantContext.clear();
+        Mockito.reset(servicoRepository, servicoMapper, planoService);
+    }
+
+    private void primeCache() {
+        servicoService.listarServicos(defaultSearch);
+        servicoService.listarServicos(defaultSearch);
+        servicoService.listarServicos(alternativeSearch);
+        servicoService.listarServicos(alternativeSearch);
+    }
+
+    private ServicoRequest buildRequest() {
+        return ServicoRequest.builder()
+                .sequencialUsuario(1)
+                .nome("Servico")
+                .descricao("desc")
+                .custo(BigDecimal.ONE)
+                .valorVenda(BigDecimal.TEN)
+                .tempoExecucao(30)
+                .ativo(true)
+                .build();
+    }
+
+    @Test
+    void cadastrarServicoEvictsAllCachedFilters() {
+        primeCache();
+        verify(servicoRepository, times(2)).findAllByOrganizationIdAndAtivoTrue(eq(1), any(Pageable.class));
+
+        Plano plano = new Plano();
+        plano.setMaxServicos(10);
+        when(planoService.obterPlanoUsuario(user)).thenReturn(Optional.of(plano));
+        when(servicoRepository.countByOrganizationIdAndAtivoTrue(1)).thenReturn(1L);
+
+        servicoService.cadastrarServico(buildRequest());
+
+        servicoService.listarServicos(defaultSearch);
+        servicoService.listarServicos(alternativeSearch);
+
+        verify(servicoRepository, times(4)).findAllByOrganizationIdAndAtivoTrue(eq(1), any(Pageable.class));
+    }
+
+    @Test
+    void editarServicoEvictsAllCachedFilters() {
+        primeCache();
+        verify(servicoRepository, times(2)).findAllByOrganizationIdAndAtivoTrue(eq(1), any(Pageable.class));
+
+        Servico existente = new Servico();
+        existente.setId(10);
+        existente.setTenantId(1);
+        existente.setAtivo(true);
+        when(servicoRepository.findByIdAndOrganizationIdAndAtivoTrue(10, 1)).thenReturn(Optional.of(existente));
+
+        servicoService.editarServico(10, buildRequest());
+
+        servicoService.listarServicos(defaultSearch);
+        servicoService.listarServicos(alternativeSearch);
+
+        verify(servicoRepository, times(4)).findAllByOrganizationIdAndAtivoTrue(eq(1), any(Pageable.class));
+    }
+
+    @Test
+    void excluirServicoEvictsAllCachedFilters() {
+        primeCache();
+        verify(servicoRepository, times(2)).findAllByOrganizationIdAndAtivoTrue(eq(1), any(Pageable.class));
+
+        Servico existente = new Servico();
+        existente.setId(20);
+        existente.setTenantId(1);
+        existente.setAtivo(true);
+        when(servicoRepository.findByIdAndOrganizationIdAndAtivoTrue(20, 1)).thenReturn(Optional.of(existente));
+
+        servicoService.excluirServico(20);
+
+        servicoService.listarServicos(defaultSearch);
+        servicoService.listarServicos(alternativeSearch);
+
+        verify(servicoRepository, times(4)).findAllByOrganizationIdAndAtivoTrue(eq(1), any(Pageable.class));
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure ProdutoService and ServicoService evict all cached entries after mutations to avoid stale filtered listings
- add regression tests covering cache invalidation after create, edit, and delete operations for both services

## Testing
- `./mvnw test` *(fails: unable to resolve Spring Boot parent due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaa5edd748324a47e502e16217cd7