### PR TITLE
Fix purchase validation message and add unit test

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Validation/CompraValidator.java
+++ b/src/main/java/com/AIT/Optimanage/Validation/CompraValidator.java
@@ -27,7 +27,7 @@ public class CompraValidator {
             throw new IllegalArgumentException("Usuário não tem permissão para criar orçamentos");
         }
         if (compraDTO.hasNoItems()) {
-            throw new IllegalArgumentException("Uma venda deve ter no mínimo um produto ou serviço");
+            throw new IllegalArgumentException("Uma compra deve ter no mínimo um produto ou serviço");
         }
     }
 }

--- a/src/test/java/com/AIT/Optimanage/Validation/CompraValidatorTest.java
+++ b/src/test/java/com/AIT/Optimanage/Validation/CompraValidatorTest.java
@@ -1,0 +1,39 @@
+package com.AIT.Optimanage.Validation;
+
+import com.AIT.Optimanage.Models.Compra.DTOs.CompraDTO;
+import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
+import com.AIT.Optimanage.Security.CurrentUser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CompraValidatorTest {
+
+    private final CompraValidator validator = new CompraValidator();
+
+    @AfterEach
+    void tearDown() {
+        CurrentUser.clear();
+    }
+
+    @Test
+    void validarCompraSemItensLancaMensagemEspecificaParaCompra() {
+        CompraDTO dto = CompraDTO.builder()
+                .fornecedorId(1)
+                .dataEfetuacao(LocalDate.now())
+                .status(StatusCompra.AGUARDANDO_EXECUCAO)
+                .produtos(List.of())
+                .servicos(List.of())
+                .build();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> validator.validarCompra(dto));
+
+        assertEquals("Uma compra deve ter no mínimo um produto ou serviço", exception.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- adjust the purchase validator error message to refer to "compra"
- add a unit test covering the validation error when a purchase has no items

## Testing
- ./mvnw test *(fails: unable to resolve parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc05fb6308324a1dd4d6131dda485