### PR TITLE
Refactor venda repository filter and add tests

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -24,8 +24,8 @@ public interface VendaRepository extends JpaRepository<Venda, Integer> {
             "LEFT JOIN FETCH vs.servico s " +
             "LEFT JOIN v.pagamentos pag " +
             "WHERE " +
-            "((:id IS NOT NULL AND v.organizationId = :organizationId AND v.sequencialUsuario = :id) " +
-            "OR (:organizationId IS NULL OR v.organizationId = :organizationId)) " +
+            "(:organizationId IS NULL OR v.organizationId = :organizationId) " +
+            "AND (:id IS NULL OR v.sequencialUsuario = :id) " +
             "AND (:clienteId IS NULL OR v.cliente.id = :clienteId) " +
             "AND (:dataInicial IS NULL OR v.dataEfetuacao >= :dataInicial) " +
             "AND (:dataFinal IS NULL OR v.dataEfetuacao <= :dataFinal) " +

--- a/src/test/java/com/AIT/Optimanage/Repositories/Venda/VendaRepositoryTest.java
+++ b/src/test/java/com/AIT/Optimanage/Repositories/Venda/VendaRepositoryTest.java
@@ -1,0 +1,130 @@
+package com.AIT.Optimanage.Repositories.Venda;
+
+import com.AIT.Optimanage.Models.Atividade;
+import com.AIT.Optimanage.Models.Cliente.Cliente;
+import com.AIT.Optimanage.Models.Enums.AtividadeAplicavelA;
+import com.AIT.Optimanage.Models.Enums.TipoAtividade;
+import com.AIT.Optimanage.Models.Enums.TipoPessoa;
+import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
+import com.AIT.Optimanage.Models.Venda.Venda;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class VendaRepositoryTest {
+
+    @Autowired
+    private VendaRepository vendaRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Venda vendaOrganizacaoUmSeqUm;
+    private Venda vendaOrganizacaoUmSeqDois;
+
+    @BeforeEach
+    void setUp() {
+        Cliente clienteOrganizacaoUm = createCliente(1, "Cliente Org1");
+        vendaOrganizacaoUmSeqUm = createVenda(clienteOrganizacaoUm, 1, BigDecimal.valueOf(100));
+        vendaOrganizacaoUmSeqDois = createVenda(clienteOrganizacaoUm, 2, BigDecimal.valueOf(200));
+
+        Cliente clienteOrganizacaoDois = createCliente(2, "Cliente Org2");
+        createVenda(clienteOrganizacaoDois, 3, BigDecimal.valueOf(300));
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("Deve filtrar por sequencialUsuario quando o id é informado")
+    void deveFiltrarPorSequencialQuandoIdInformado() {
+        Page<Venda> resultado = vendaRepository.buscarVendas(
+                vendaOrganizacaoUmSeqUm.getOrganizationId(),
+                vendaOrganizacaoUmSeqUm.getSequencialUsuario(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                PageRequest.of(0, 10)
+        );
+
+        assertThat(resultado.getContent())
+                .extracting(Venda::getId)
+                .containsExactly(vendaOrganizacaoUmSeqUm.getId());
+    }
+
+    @Test
+    @DisplayName("Não deve aplicar filtro por sequencialUsuario quando id é nulo")
+    void naoDeveFiltrarPorSequencialQuandoIdNulo() {
+        Page<Venda> resultado = vendaRepository.buscarVendas(
+                vendaOrganizacaoUmSeqUm.getOrganizationId(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                PageRequest.of(0, 10)
+        );
+
+        assertThat(resultado.getContent())
+                .extracting(Venda::getId)
+                .containsExactlyInAnyOrder(
+                        vendaOrganizacaoUmSeqUm.getId(),
+                        vendaOrganizacaoUmSeqDois.getId()
+                );
+    }
+
+    private Cliente createCliente(int organizationId, String nome) {
+        Atividade atividade = new Atividade();
+        atividade.setNomeAtividade("Atividade " + nome);
+        atividade.setTipo(TipoAtividade.PADRAO);
+        atividade.setAplicavelA(AtividadeAplicavelA.AMBOS);
+        atividade.setOrganizationId(organizationId);
+        entityManager.persist(atividade);
+
+        Cliente cliente = new Cliente();
+        cliente.setAtividade(atividade);
+        cliente.setDataCadastro(LocalDate.now());
+        cliente.setTipoPessoa(TipoPessoa.PF);
+        cliente.setOrigem("ORIGEM");
+        cliente.setAtivo(true);
+        cliente.setNome(nome);
+        cliente.setOrganizationId(organizationId);
+        entityManager.persist(cliente);
+
+        return cliente;
+    }
+
+    private Venda createVenda(Cliente cliente, int sequencialUsuario, BigDecimal valorTotal) {
+        Venda venda = new Venda();
+        venda.setCliente(cliente);
+        venda.setSequencialUsuario(sequencialUsuario);
+        venda.setDataEfetuacao(LocalDate.now());
+        venda.setDataCobranca(LocalDate.now());
+        venda.setValorTotal(valorTotal);
+        venda.setDescontoGeral(BigDecimal.ZERO);
+        venda.setValorFinal(valorTotal);
+        venda.setValorPendente(BigDecimal.ZERO);
+        venda.setStatus(StatusVenda.PENDENTE);
+        venda.setOrganizationId(cliente.getOrganizationId());
+        entityManager.persist(venda);
+        return venda;
+    }
+}


### PR DESCRIPTION
## Summary
- adjust the buscarVendas query so that the sequencialUsuario predicate is only applied when an id is provided while keeping the organization filter in place
- add a repository integration test that covers buscarVendas with and without the id filter

## Testing
- ./mvnw test *(fails: unable to download Spring Boot parent POM because the Maven Central host is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc08833a88324a27439098d2c5465