### PR TITLE
Fix ProdutoPontuacao creation in RecommendationService

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/RecommendationService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/RecommendationService.java
@@ -119,7 +119,7 @@ public class RecommendationService {
                     score += COMPATIBILIDADE_BONUS;
                 }
 
-                ProdutoPontuacao dados = pontuacaoDetalhada.computeIfAbsent(produtoId, ProdutoPontuacao::new);
+                ProdutoPontuacao dados = pontuacaoDetalhada.computeIfAbsent(produtoId, k -> new ProdutoPontuacao());
                 dados.adicionar(score, quantidade, produto);
             }
         }


### PR DESCRIPTION
## Summary
- fix RecommendationService map initialization to instantiate ProdutoPontuacao without constructor arguments

## Testing
- mvn -q -DskipTests package *(fails: network is unreachable when resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d13d3135e48324ad210862bb71c2a8