### PR TITLE
feat: add shared status transition policy

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/common/StatusTransitionPolicies.java
+++ b/src/main/java/com/AIT/Optimanage/Services/common/StatusTransitionPolicies.java
@@ -1,0 +1,100 @@
+package com.AIT.Optimanage.Services.common;
+
+import com.AIT.Optimanage.Models.Compra.Compra;
+import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
+import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
+import com.AIT.Optimanage.Models.Venda.Venda;
+
+import java.math.BigDecimal;
+import java.util.EnumSet;
+
+import static com.AIT.Optimanage.Services.common.StatusTransitionPolicy.allowFrom;
+import static com.AIT.Optimanage.Services.common.StatusTransitionPolicy.forbidFrom;
+import static com.AIT.Optimanage.Services.common.StatusTransitionPolicy.impossible;
+import static com.AIT.Optimanage.Services.common.StatusTransitionPolicy.requireCondition;
+
+public final class StatusTransitionPolicies {
+
+    private static final StatusTransitionPolicy<StatusCompra, Compra> COMPRA_POLICY =
+            StatusTransitionPolicy.<StatusCompra, Compra>builder(StatusCompra.class, "compra")
+                    .forTarget(StatusCompra.ORCAMENTO, impossible("Não é possível voltar para o status ORÇAMENTO."))
+                    .forTarget(StatusCompra.AGUARDANDO_EXECUCAO,
+                            allowFrom(EnumSet.of(StatusCompra.ORCAMENTO),
+                                    "Só é possível transformar um orçamento em pedido se estiver no status ORÇAMENTO."))
+                    .forTarget(StatusCompra.AGENDADA,
+                            forbidFrom(EnumSet.of(StatusCompra.CONCRETIZADO, StatusCompra.CANCELADO),
+                                    "Não é possivel agendar uma compra cancelada ou concretizada."))
+                    .forTarget(StatusCompra.AGUARDANDO_PAG,
+                            allowFrom(EnumSet.of(StatusCompra.AGUARDANDO_EXECUCAO, StatusCompra.ORCAMENTO,
+                                            StatusCompra.AGENDADA),
+                                    "A compra só pode aguardar pagamento se o pedido já foi realizado."))
+                    .forTarget(StatusCompra.PARCIALMENTE_PAGO,
+                            allowFrom(EnumSet.of(StatusCompra.AGUARDANDO_PAG, StatusCompra.AGUARDANDO_EXECUCAO),
+                                    "Uma compra só pode ser parcialmente paga se estiver aguardando pagamento ou já parcialmente paga."))
+                    .forTarget(StatusCompra.PAGO,
+                            allowFrom(EnumSet.of(StatusCompra.AGUARDANDO_PAG, StatusCompra.PARCIALMENTE_PAGO),
+                                    "A compra só pode ser paga se estiver aguardando pagamento ou parcialmente paga."))
+                    .forTarget(StatusCompra.CONCRETIZADO,
+                            allowFrom(EnumSet.of(StatusCompra.PAGO, StatusCompra.AGUARDANDO_EXECUCAO, StatusCompra.AGENDADA),
+                                    "A compra só pode ser finalizada se estiver paga, aguardando execução ou agendada."),
+                            requireCondition((current, target, compra) ->
+                                            compra.getValorPendente().compareTo(BigDecimal.ZERO) <= 0,
+                                    "A compra não pode ser finalizada enquanto houver saldo pendente."))
+                    .forTarget(StatusCompra.CANCELADO,
+                            forbidFrom(EnumSet.of(StatusCompra.CONCRETIZADO),
+                                    "Uma compra finalizada não pode ser cancelada."))
+                    .build();
+
+    private static final StatusTransitionPolicy<StatusVenda, Venda> VENDA_POLICY =
+            StatusTransitionPolicy.<StatusVenda, Venda>builder(StatusVenda.class, "venda")
+                    .forTarget(StatusVenda.ORCAMENTO, impossible("Não é possível voltar para o status ORÇAMENTO."))
+                    .forTarget(StatusVenda.PENDENTE,
+                            allowFrom(EnumSet.of(StatusVenda.ORCAMENTO),
+                                    "Só é possível transformar um orçamento em venda a partir do status ORCAMENTO."))
+                    .forTarget(StatusVenda.AGENDADA,
+                            forbidFrom(EnumSet.of(StatusVenda.CONCRETIZADA, StatusVenda.CANCELADA),
+                                    "Não é possivel agendar uma venda cancelada ou concretizada."))
+                    .forTarget(StatusVenda.AGUARDANDO_PAG,
+                            forbidFrom(EnumSet.of(StatusVenda.CONCRETIZADA, StatusVenda.CANCELADA),
+                                    "Uma venda CONCRETIZADA ou CANCELADA não pode voltar para o estado de aguardando pagamento."))
+                    .forTarget(StatusVenda.PARCIALMENTE_PAGA,
+                            forbidFrom(EnumSet.of(StatusVenda.CONCRETIZADA, StatusVenda.CANCELADA),
+                                    "Uma venda CONCRETIZADA ou CANCELADA não pode voltar para o estado de parcialmente paga."),
+                            requireCondition((current, target, venda) -> venda.getPagamentos() != null && !venda.getPagamentos().isEmpty(),
+                                    "A venda não pode ser parcialmente paga sem um pagamento anterior."),
+                            requireCondition((current, target, venda) ->
+                                            venda.getValorFinal() != null && venda.getValorPendente() != null &&
+                                                    venda.getValorFinal().compareTo(venda.getValorPendente()) != 0,
+                                    "A venda não pode ser parcialmente paga sem um pagamento anterior."))
+                    .forTarget(StatusVenda.PAGA,
+                            forbidFrom(EnumSet.of(StatusVenda.CONCRETIZADA, StatusVenda.CANCELADA),
+                                    "Uma venda CONCRETIZADA ou CANCELADA não pode voltar para o estado de paga."),
+                            requireCondition((current, target, venda) ->
+                                            venda.getValorPendente() != null &&
+                                                    venda.getValorPendente().compareTo(BigDecimal.ZERO) <= 0,
+                                    "A venda não pode ser paga sem o pagamento completo."))
+                    .forTarget(StatusVenda.CONCRETIZADA,
+                            forbidFrom(EnumSet.of(StatusVenda.CANCELADA),
+                                    "Uma venda cancelada não pode ser concretizada."),
+                            forbidFrom(EnumSet.of(StatusVenda.ORCAMENTO),
+                                    "Um orçamento não pode ser concretizado."),
+                            requireCondition((current, target, venda) ->
+                                            venda.getValorPendente() != null &&
+                                                    venda.getValorPendente().compareTo(BigDecimal.ZERO) <= 0,
+                                    "A venda não pode ser concretizada sem o pagamento completo."))
+                    .forTarget(StatusVenda.CANCELADA,
+                            forbidFrom(EnumSet.of(StatusVenda.CONCRETIZADA),
+                                    "Uma venda concretizada não pode ser cancelada."))
+                    .build();
+
+    private StatusTransitionPolicies() {
+    }
+
+    public static StatusTransitionPolicy<StatusCompra, Compra> compraPolicy() {
+        return COMPRA_POLICY;
+    }
+
+    public static StatusTransitionPolicy<StatusVenda, Venda> vendaPolicy() {
+        return VENDA_POLICY;
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Services/common/StatusTransitionPolicy.java
+++ b/src/main/java/com/AIT/Optimanage/Services/common/StatusTransitionPolicy.java
@@ -1,0 +1,105 @@
+package com.AIT.Optimanage.Services.common;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class StatusTransitionPolicy<S extends Enum<S>, C> {
+
+    private final String entityLabel;
+    private final Map<S, List<TransitionConstraint<S, C>>> constraints;
+
+    private StatusTransitionPolicy(String entityLabel, Map<S, List<TransitionConstraint<S, C>>> constraints) {
+        this.entityLabel = entityLabel;
+        this.constraints = constraints;
+    }
+
+    public void validate(S currentStatus, S targetStatus, C context) {
+        Objects.requireNonNull(currentStatus, "O status atual não pode ser nulo.");
+        Objects.requireNonNull(targetStatus, "O status de destino não pode ser nulo.");
+        if (currentStatus == targetStatus) {
+            throw new IllegalStateException("A " + entityLabel + " já está neste status.");
+        }
+
+        List<TransitionConstraint<S, C>> targetConstraints = constraints.get(targetStatus);
+        if (targetConstraints == null) {
+            throw new IllegalArgumentException("Status desconhecido.");
+        }
+
+        for (TransitionConstraint<S, C> constraint : targetConstraints) {
+            constraint.validate(currentStatus, targetStatus, context);
+        }
+    }
+
+    public static <S extends Enum<S>, C> Builder<S, C> builder(Class<S> enumType, String entityLabel) {
+        return new Builder<>(enumType, entityLabel);
+    }
+
+    public static final class Builder<S extends Enum<S>, C> {
+        private final EnumMap<S, List<TransitionConstraint<S, C>>> constraints;
+        private final String entityLabel;
+
+        private Builder(Class<S> enumType, String entityLabel) {
+            this.constraints = new EnumMap<>(enumType);
+            this.entityLabel = entityLabel;
+        }
+
+        @SafeVarargs
+        public final Builder<S, C> forTarget(S targetStatus, TransitionConstraint<S, C>... targetConstraints) {
+            List<TransitionConstraint<S, C>> constraintsList = new ArrayList<>();
+            if (targetConstraints != null && targetConstraints.length > 0) {
+                constraintsList.addAll(Arrays.asList(targetConstraints));
+            }
+            this.constraints.put(targetStatus, Collections.unmodifiableList(constraintsList));
+            return this;
+        }
+
+        public StatusTransitionPolicy<S, C> build() {
+            return new StatusTransitionPolicy<>(entityLabel, Collections.unmodifiableMap(constraints));
+        }
+    }
+
+    public interface TransitionCondition<S extends Enum<S>, C> {
+        boolean test(S currentStatus, S targetStatus, C context);
+    }
+
+    public static class TransitionConstraint<S extends Enum<S>, C> {
+        private final TransitionCondition<S, C> condition;
+        private final Supplier<String> messageSupplier;
+
+        private TransitionConstraint(TransitionCondition<S, C> condition, Supplier<String> messageSupplier) {
+            this.condition = condition;
+            this.messageSupplier = messageSupplier;
+        }
+
+        private void validate(S currentStatus, S targetStatus, C context) {
+            if (!condition.test(currentStatus, targetStatus, context)) {
+                throw new IllegalStateException(messageSupplier.get());
+            }
+        }
+    }
+
+    public static <S extends Enum<S>, C> TransitionConstraint<S, C> allowFrom(Set<S> allowedStatuses, String message) {
+        Set<S> immutableAllowed = Set.copyOf(allowedStatuses);
+        return new TransitionConstraint<>((current, target, context) -> immutableAllowed.contains(current), () -> message);
+    }
+
+    public static <S extends Enum<S>, C> TransitionConstraint<S, C> forbidFrom(Set<S> forbiddenStatuses, String message) {
+        Set<S> immutableForbidden = Set.copyOf(forbiddenStatuses);
+        return new TransitionConstraint<>((current, target, context) -> !immutableForbidden.contains(current), () -> message);
+    }
+
+    public static <S extends Enum<S>, C> TransitionConstraint<S, C> requireCondition(TransitionCondition<S, C> condition, String message) {
+        return new TransitionConstraint<>(condition, () -> message);
+    }
+
+    public static <S extends Enum<S>, C> TransitionConstraint<S, C> impossible(String message) {
+        return new TransitionConstraint<>((current, target, context) -> false, () -> message);
+    }
+}

--- a/src/test/java/com/AIT/Optimanage/Services/common/StatusTransitionPolicyTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/common/StatusTransitionPolicyTest.java
@@ -1,0 +1,110 @@
+package com.AIT.Optimanage.Services.common;
+
+import com.AIT.Optimanage.Models.Compra.Compra;
+import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
+import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
+import com.AIT.Optimanage.Models.Venda.Venda;
+import com.AIT.Optimanage.Models.Venda.VendaPagamento;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class StatusTransitionPolicyTest {
+
+    private final StatusTransitionPolicy<StatusCompra, Compra> compraPolicy = StatusTransitionPolicies.compraPolicy();
+    private final StatusTransitionPolicy<StatusVenda, Venda> vendaPolicy = StatusTransitionPolicies.vendaPolicy();
+
+    @Test
+    void devePermitirTransicaoValidaDeCompra() {
+        Compra compra = Compra.builder()
+                .status(StatusCompra.ORCAMENTO)
+                .valorPendente(BigDecimal.ZERO)
+                .build();
+
+        assertDoesNotThrow(() -> compraPolicy.validate(compra.getStatus(), StatusCompra.AGUARDANDO_EXECUCAO, compra));
+    }
+
+    @Test
+    void deveBloquearMesmaTransicaoDeCompra() {
+        Compra compra = Compra.builder()
+                .status(StatusCompra.AGUARDANDO_PAG)
+                .valorPendente(BigDecimal.TEN)
+                .build();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> compraPolicy.validate(compra.getStatus(), StatusCompra.AGUARDANDO_PAG, compra));
+        assertEquals("A compra já está neste status.", exception.getMessage());
+    }
+
+    @Test
+    void deveImpedirFinalizarCompraComSaldoPendente() {
+        Compra compra = Compra.builder()
+                .status(StatusCompra.AGUARDANDO_EXECUCAO)
+                .valorPendente(BigDecimal.ONE)
+                .build();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> compraPolicy.validate(compra.getStatus(), StatusCompra.CONCRETIZADO, compra));
+        assertEquals("A compra não pode ser finalizada enquanto houver saldo pendente.", exception.getMessage());
+    }
+
+    @Test
+    void devePermitirTransicaoValidaDeVenda() {
+        Venda venda = Venda.builder()
+                .status(StatusVenda.ORCAMENTO)
+                .valorPendente(BigDecimal.ZERO)
+                .valorFinal(BigDecimal.ZERO)
+                .build();
+
+        assertDoesNotThrow(() -> vendaPolicy.validate(venda.getStatus(), StatusVenda.PENDENTE, venda));
+    }
+
+    @Test
+    void deveImpedirVendaPagaSemSaldoQuitado() {
+        Venda venda = Venda.builder()
+                .status(StatusVenda.AGUARDANDO_PAG)
+                .valorPendente(BigDecimal.ONE)
+                .valorFinal(BigDecimal.TEN)
+                .pagamentos(List.of(VendaPagamento.builder().build()))
+                .build();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> vendaPolicy.validate(venda.getStatus(), StatusVenda.PAGA, venda));
+        assertEquals("A venda não pode ser paga sem o pagamento completo.", exception.getMessage());
+    }
+
+    @Test
+    void devePermitirVendaParcialmentePagaComPagamentoAnterior() {
+        Venda venda = Venda.builder()
+                .status(StatusVenda.AGUARDANDO_PAG)
+                .valorPendente(new BigDecimal("50.00"))
+                .valorFinal(new BigDecimal("100.00"))
+                .pagamentos(List.of(VendaPagamento.builder().build()))
+                .build();
+
+        assertDoesNotThrow(() -> vendaPolicy.validate(venda.getStatus(), StatusVenda.PARCIALMENTE_PAGA, venda));
+    }
+
+    @Test
+    void deveImpedirVendaParcialmentePagaSemPagamentosAnteriores() {
+        Venda venda = Venda.builder()
+                .status(StatusVenda.AGUARDANDO_PAG)
+                .valorPendente(vendaValorTotal())
+                .valorFinal(vendaValorTotal())
+                .pagamentos(List.of())
+                .build();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> vendaPolicy.validate(venda.getStatus(), StatusVenda.PARCIALMENTE_PAGA, venda));
+        assertEquals("A venda não pode ser parcialmente paga sem um pagamento anterior.", exception.getMessage());
+    }
+
+    private BigDecimal vendaValorTotal() {
+        return new BigDecimal("100.00");
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable StatusTransitionPolicy component and centralized policies for compra and venda transitions
- refactor CompraService and VendaService to delegate status validation to the shared policy
- add unit tests that cover valid and invalid transitions for purchases and sales

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM due to offline maven central)*

------
https://chatgpt.com/codex/tasks/task_e_68d1433451b88324b21bfa2bc5214fbc