### PR TITLE
Handle venda reversals restoring inventory

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -356,7 +356,11 @@ public class VendaService {
             }
         });
         venda.setValorPendente(Optional.ofNullable(venda.getValorFinal()).orElse(BigDecimal.ZERO));
-        atualizarStatus(venda, StatusVenda.AGUARDANDO_PAG);
+        if (venda.getStatus() == StatusVenda.CONCRETIZADA) {
+            venda.setStatus(StatusVenda.AGUARDANDO_PAG);
+        } else {
+            atualizarStatus(venda, StatusVenda.AGUARDANDO_PAG);
+        }
         Venda salvo = vendaRepository.save(venda);
         return vendaMapper.toResponse(salvo);
     }


### PR DESCRIPTION
## Summary
- allow `estornarVendaIntegral` to bypass `atualizarStatus` when undoing a concretized sale so the status rolls back to `AGUARDANDO_PAG`

## Testing
- ⚠️ `./mvnw -Dtest=VendaServiceTest test` *(fails: unable to download parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d155592bc483249a1254322fbab3d0