### PR TITLE
Adicionar helper para reverter estoque ao desfazer compras

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -302,8 +302,10 @@ public class CompraService {
         Plano plano = obterPlanoAtual();
         garantirPagamentosHabilitados(plano);
         Compra compra = getCompra(idCompra);
-        reverterEstoqueCompra(compra, "Estorno integral da compra #" + compra.getId());
-        if (compra.getStatus() == StatusCompra.CONCRETIZADO || compra.getStatus() == StatusCompra.PAGO) {
+        boolean deveReverterEstoque = compra.getStatus() == StatusCompra.CONCRETIZADO
+                || compra.getStatus() == StatusCompra.PAGO;
+        if (deveReverterEstoque) {
+            reverterEstoqueCompra(compra, "Estorno integral da compra #" + compra.getId());
             atualizarStatus(compra, StatusCompra.AGUARDANDO_PAG);
         }
         compra.setValorPendente(compra.getValorFinal());
@@ -402,8 +404,8 @@ public class CompraService {
     @CacheEvict(value = "compras", allEntries = true)
     public CompraResponseDTO cancelarCompra(Integer idCompra) {
         Compra compra = getCompra(idCompra);
-        reverterEstoqueCompra(compra, "Cancelamento da compra #" + compra.getId());
         atualizarStatus(compra, StatusCompra.CANCELADO);
+        reverterEstoqueCompra(compra, "Cancelamento da compra #" + compra.getId());
         Compra salvo = compraRepository.save(compra);
         return compraMapper.toResponse(salvo);
     }


### PR DESCRIPTION
## Summary
- adicionar helper reutilizável para reverter o estoque dos produtos de uma compra
- utilizar o helper durante edições, cancelamentos e estornos integrais de compras com descrições específicas

## Testing
- `./mvnw -q -DskipTests compile` *(falhou: Non-resolvable parent POM devido a falta de acesso à internet)*

------
https://chatgpt.com/codex/tasks/task_e_68d17807df648324974b53267f2b8a2b