### PR TITLE
Restrict inventory monitoring feature by plan permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Todos os recursos (exceto autenticação) usam o prefixo `/api/v1` e exigem um t
 - `POST /api/v1/produtos` &ndash; criar produto.
 - `PUT /api/v1/produtos/{idProduto}` &ndash; atualizar produto.
 - `DELETE /api/v1/produtos/{idProduto}` &ndash; remover produto.
+- Campos de controle de estoque: `estoqueMinimo` e `prazoReposicaoDias` permitem definir limites mínimos e o tempo médio de reposição para alimentar o monitoramento automático.
 
 ### Serviços
 - `GET /api/v1/servicos`
@@ -137,6 +138,13 @@ Todos os recursos (exceto autenticação) usam o prefixo `/api/v1` e exigem um t
 ### Analytics
 - `GET /api/v1/analytics/resumo` &ndash; resumo de vendas, compras e lucro.
 - `GET /api/v1/analytics/previsao` &ndash; previsão de demanda com regressão linear.
+- `GET /api/v1/analytics/estoque-critico` &ndash; lista itens com estoque crítico ou em risco de ruptura, incluindo projeção de dias restantes e sugestão de compra.
+  - Disponível apenas para organizações cujo plano tenha `monitoramentoEstoqueHabilitado = true`.
+
+### Monitoramento de estoque
+- Um job agendado diário (padrão `0 0 6 * * *`, configurável via `inventory.monitoring.cron`) reprocessa o consumo médio dos últimos 30 dias a partir do `InventoryHistory`.
+- Para cada produto ativo, o serviço calcula os dias restantes considerando o estoque atual, o consumo médio e o prazo de reposição configurado.
+- Alertas críticos ou de atenção são persistidos na tabela `inventory_alert` e expostos pelo endpoint de analytics quando o plano atual possuir a permissão de monitoramento de estoque.
 
 ## Execução
 1. Requisitos: Java 17+ e Maven.

--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
@@ -1,5 +1,6 @@
 package com.AIT.Optimanage.Analytics;
 
+import com.AIT.Optimanage.Analytics.DTOs.InventoryAlertDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PrevisaoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.ResumoDTO;
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
@@ -8,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/analytics")
@@ -24,6 +27,11 @@ public class AnalyticsController extends V1BaseController {
     @GetMapping("/previsao")
     public ResponseEntity<PrevisaoDTO> previsao() {
         return ok(analyticsService.preverDemanda());
+    }
+
+    @GetMapping("/estoque-critico")
+    public ResponseEntity<List<InventoryAlertDTO>> estoqueCritico() {
+        return ok(analyticsService.listarAlertasEstoque());
     }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
@@ -1,21 +1,27 @@
 package com.AIT.Optimanage.Analytics;
 
+import com.AIT.Optimanage.Analytics.DTOs.InventoryAlertDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PrevisaoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.ResumoDTO;
 import com.AIT.Optimanage.Models.Compra.Compra;
+import com.AIT.Optimanage.Models.Inventory.InventoryAlert;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Security.CurrentUser;
 import com.AIT.Optimanage.Models.Venda.Venda;
 import com.AIT.Optimanage.Repositories.Compra.CompraRepository;
 import com.AIT.Optimanage.Repositories.Venda.VendaRepository;
+import com.AIT.Optimanage.Services.InventoryMonitoringService;
+import com.AIT.Optimanage.Services.PlanoService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.math3.stat.regression.SimpleRegression;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +29,8 @@ public class AnalyticsService {
 
     private final VendaRepository vendaRepository;
     private final CompraRepository compraRepository;
+    private final InventoryMonitoringService inventoryMonitoringService;
+    private final PlanoService planoService;
 
     public ResumoDTO obterResumo() {
         User user = CurrentUser.get();
@@ -75,6 +83,43 @@ public class AnalyticsService {
 
         double forecast = regression.predict(i);
         return new PrevisaoDTO(BigDecimal.valueOf(forecast));
+    }
+
+    public List<InventoryAlertDTO> listarAlertasEstoque() {
+        User user = CurrentUser.get();
+        if (user == null) {
+            throw new EntityNotFoundException("Usuário não autenticado");
+        }
+        Integer organizationId = CurrentUser.getOrganizationId();
+        if (organizationId == null) {
+            throw new EntityNotFoundException("Organização não encontrada");
+        }
+        if (!planoService.isMonitoramentoEstoqueHabilitado(organizationId)) {
+            throw new AccessDeniedException("Monitoramento de estoque não está habilitado no plano atual");
+        }
+        List<InventoryAlert> alertas = inventoryMonitoringService.recalcularAlertasOrganizacao(organizationId);
+        if (alertas.isEmpty()) {
+            return List.of();
+        }
+        return alertas.stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private InventoryAlertDTO toDto(InventoryAlert alert) {
+        return InventoryAlertDTO.builder()
+                .produtoId(alert.getProduto().getId())
+                .nomeProduto(alert.getProduto().getNome())
+                .severity(alert.getSeverity())
+                .estoqueAtual(alert.getEstoqueAtual())
+                .estoqueMinimo(alert.getEstoqueMinimo())
+                .prazoReposicaoDias(alert.getPrazoReposicaoDias())
+                .consumoMedioDiario(alert.getConsumoMedioDiario())
+                .diasRestantes(alert.getDiasRestantes())
+                .dataEstimadaRuptura(alert.getDataEstimadaRuptura())
+                .quantidadeSugerida(alert.getQuantidadeSugerida())
+                .mensagem(alert.getMensagem())
+                .build();
     }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/InventoryAlertDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/InventoryAlertDTO.java
@@ -1,0 +1,29 @@
+package com.AIT.Optimanage.Analytics.DTOs;
+
+import com.AIT.Optimanage.Models.Inventory.InventoryAlertSeverity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InventoryAlertDTO {
+
+    private Integer produtoId;
+    private String nomeProduto;
+    private InventoryAlertSeverity severity;
+    private Integer estoqueAtual;
+    private Integer estoqueMinimo;
+    private Integer prazoReposicaoDias;
+    private BigDecimal consumoMedioDiario;
+    private Integer diasRestantes;
+    private LocalDate dataEstimadaRuptura;
+    private Integer quantidadeSugerida;
+    private String mensagem;
+}

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoQuotaResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoQuotaResponse.java
@@ -25,6 +25,7 @@ public class PlanoQuotaResponse {
     private Boolean recomendacoesHabilitadas;
     private Boolean pagamentosHabilitados;
     private Boolean suportePrioritario;
+    private Boolean monitoramentoEstoqueHabilitado;
     private Integer usuariosUtilizados;
     private Integer usuariosRestantes;
     private Integer produtosUtilizados;

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoRequest.java
@@ -58,5 +58,8 @@ public class PlanoRequest {
 
     @NotNull
     private Boolean suportePrioritario;
+
+    @NotNull
+    private Boolean monitoramentoEstoqueHabilitado;
 }
 

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoResponse.java
@@ -25,5 +25,6 @@ public class PlanoResponse {
     private Boolean recomendacoesHabilitadas;
     private Boolean pagamentosHabilitados;
     private Boolean suportePrioritario;
+    private Boolean monitoramentoEstoqueHabilitado;
 }
 

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoRequest.java
@@ -42,4 +42,10 @@ public class ProdutoRequest {
 
     private Boolean terceirizado;
     private Boolean ativo;
+
+    @PositiveOrZero
+    private Integer estoqueMinimo;
+
+    @PositiveOrZero
+    private Integer prazoReposicaoDias;
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoResponse.java
@@ -26,4 +26,6 @@ public class ProdutoResponse {
     private Integer qtdEstoque;
     private Boolean terceirizado;
     private Boolean ativo;
+    private Integer estoqueMinimo;
+    private Integer prazoReposicaoDias;
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Inventory/InventoryAlert.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Inventory/InventoryAlert.java
@@ -1,0 +1,52 @@
+package com.AIT.Optimanage.Models.Inventory;
+
+import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
+import com.AIT.Optimanage.Models.AuditableEntity;
+import com.AIT.Optimanage.Models.OwnableEntity;
+import com.AIT.Optimanage.Models.Produto;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@EntityListeners(OwnerEntityListener.class)
+public class InventoryAlert extends AuditableEntity implements OwnableEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "produto_id", nullable = false)
+    private Produto produto;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private InventoryAlertSeverity severity;
+
+    @Column(name = "dias_restantes")
+    private Integer diasRestantes;
+
+    @Column(name = "consumo_medio_diario", nullable = false, precision = 12, scale = 2)
+    private BigDecimal consumoMedioDiario;
+
+    @Column(name = "estoque_atual", nullable = false)
+    private Integer estoqueAtual;
+
+    @Column(name = "estoque_minimo", nullable = false)
+    private Integer estoqueMinimo;
+
+    @Column(name = "prazo_reposicao_dias", nullable = false)
+    private Integer prazoReposicaoDias;
+
+    @Column(name = "quantidade_sugerida", nullable = false)
+    private Integer quantidadeSugerida;
+
+    @Column(name = "data_estimada_ruptura")
+    private LocalDate dataEstimadaRuptura;
+
+    @Column(length = 255)
+    private String mensagem;
+}

--- a/src/main/java/com/AIT/Optimanage/Models/Inventory/InventoryAlertSeverity.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Inventory/InventoryAlertSeverity.java
@@ -1,0 +1,6 @@
+package com.AIT.Optimanage.Models.Inventory;
+
+public enum InventoryAlertSeverity {
+    CRITICAL,
+    WARNING
+}

--- a/src/main/java/com/AIT/Optimanage/Models/Inventory/InventoryHistory.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Inventory/InventoryHistory.java
@@ -1,7 +1,7 @@
 package com.AIT.Optimanage.Models.Inventory;
 
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
-import com.AIT.Optimanage.Models.BaseEntity;
+import com.AIT.Optimanage.Models.AuditableEntity;
 import com.AIT.Optimanage.Models.OwnableEntity;
 import com.AIT.Optimanage.Models.Produto;
 import jakarta.persistence.Column;
@@ -26,7 +26,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Entity
 @EntityListeners(OwnerEntityListener.class)
-public class InventoryHistory extends BaseEntity implements OwnableEntity {
+public class InventoryHistory extends AuditableEntity implements OwnableEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "produto_id", referencedColumnName = "id", nullable = false)

--- a/src/main/java/com/AIT/Optimanage/Models/Plano.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Plano.java
@@ -55,4 +55,8 @@ public class Plano extends AuditableEntity {
     @Column(nullable = false)
     private Boolean suportePrioritario = false;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean monitoramentoEstoqueHabilitado = false;
+
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Produto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Produto.java
@@ -43,6 +43,14 @@ public class Produto extends AuditableEntity implements OwnableEntity {
     private BigDecimal valorVenda;
     @Column(nullable = false)
     private Integer qtdEstoque;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Integer estoqueMinimo = 0;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Integer prazoReposicaoDias = 0;
     private Boolean terceirizado;
     @Column(nullable = false)
     private Boolean ativo = true;

--- a/src/main/java/com/AIT/Optimanage/Repositories/InventoryAlertRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/InventoryAlertRepository.java
@@ -1,0 +1,19 @@
+package com.AIT.Optimanage.Repositories;
+
+import com.AIT.Optimanage.Models.Inventory.InventoryAlert;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface InventoryAlertRepository extends JpaRepository<InventoryAlert, Integer> {
+
+    List<InventoryAlert> findByOrganizationIdOrderBySeverityDescDiasRestantesAsc(Integer organizationId);
+
+    @Modifying
+    @Query("delete from InventoryAlert alert where alert.organizationId = :organizationId")
+    void deleteByOrganizationId(Integer organizationId);
+}

--- a/src/main/java/com/AIT/Optimanage/Repositories/InventoryHistoryRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/InventoryHistoryRepository.java
@@ -1,9 +1,19 @@
 package com.AIT.Optimanage.Repositories;
 
+import com.AIT.Optimanage.Models.Inventory.InventoryAction;
 import com.AIT.Optimanage.Models.Inventory.InventoryHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Repository
 public interface InventoryHistoryRepository extends JpaRepository<InventoryHistory, Integer> {
+
+    List<InventoryHistory> findByProdutoIdAndOrganizationIdAndActionAndCreatedAtAfterOrderByCreatedAtAsc(
+            Integer produtoId,
+            Integer organizationId,
+            InventoryAction action,
+            LocalDateTime createdAt);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/ProdutoRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/ProdutoRepository.java
@@ -23,6 +23,8 @@ public interface ProdutoRepository extends JpaRepository<Produto, Integer> {
 
     List<Produto> findAllByIdInAndOrganizationIdAndAtivoTrueAndDisponivelVendaTrue(Collection<Integer> ids, Integer organizationId);
 
+    List<Produto> findAllByOrganizationIdAndAtivoTrue(Integer organizationId);
+
     @Modifying
     @Query("update Produto p set p.qtdEstoque = p.qtdEstoque - :quantidade where p.id = :id and p.qtdEstoque >= :quantidade")
     int reduzirEstoque(Integer id, Integer quantidade);

--- a/src/main/java/com/AIT/Optimanage/Services/InventoryMonitoringService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/InventoryMonitoringService.java
@@ -1,0 +1,238 @@
+package com.AIT.Optimanage.Services;
+
+import com.AIT.Optimanage.Models.Inventory.InventoryAction;
+import com.AIT.Optimanage.Models.Inventory.InventoryAlert;
+import com.AIT.Optimanage.Models.Inventory.InventoryAlertSeverity;
+import com.AIT.Optimanage.Models.Inventory.InventoryHistory;
+import com.AIT.Optimanage.Models.Produto;
+import com.AIT.Optimanage.Repositories.InventoryAlertRepository;
+import com.AIT.Optimanage.Repositories.InventoryHistoryRepository;
+import com.AIT.Optimanage.Repositories.ProdutoRepository;
+import com.AIT.Optimanage.Services.PlanoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class InventoryMonitoringService {
+
+    private static final int CONSUMPTION_LOOKBACK_DAYS = 30;
+
+    private final ProdutoRepository produtoRepository;
+    private final InventoryHistoryRepository historyRepository;
+    private final InventoryAlertRepository alertRepository;
+    private final PlanoService planoService;
+    private final Clock clock;
+
+    @Scheduled(cron = "${inventory.monitoring.cron:0 0 6 * * *}")
+    @Transactional
+    public void executarAnaliseAgendada() {
+        List<Produto> todosProdutos = produtoRepository.findAll();
+        Map<Integer, List<Produto>> produtosPorOrganizacao = todosProdutos.stream()
+                .filter(produto -> produto.getOrganizationId() != null)
+                .filter(produto -> Boolean.TRUE.equals(produto.getAtivo()))
+                .collect(Collectors.groupingBy(Produto::getOrganizationId));
+
+        produtosPorOrganizacao.forEach((organizationId, produtos) -> {
+            try {
+                if (!planoService.isMonitoramentoEstoqueHabilitado(organizationId)) {
+                    alertRepository.deleteByOrganizationId(organizationId);
+                    return;
+                }
+                recalcularAlertas(organizationId, produtos);
+            } catch (Exception e) {
+                log.error("Falha ao recalcular alertas de estoque para a organização {}", organizationId, e);
+            }
+        });
+    }
+
+    @Transactional
+    public List<InventoryAlert> recalcularAlertasOrganizacao(Integer organizationId) {
+        if (!planoService.isMonitoramentoEstoqueHabilitado(organizationId)) {
+            alertRepository.deleteByOrganizationId(organizationId);
+            return Collections.emptyList();
+        }
+        List<Produto> produtos = produtoRepository.findAllByOrganizationIdAndAtivoTrue(organizationId);
+        return recalcularAlertas(organizationId, produtos);
+    }
+
+    @Transactional
+    public List<InventoryAlert> recalcularAlertas(Integer organizationId, List<Produto> produtos) {
+        if (organizationId == null) {
+            return Collections.emptyList();
+        }
+        if (!planoService.isMonitoramentoEstoqueHabilitado(organizationId)) {
+            alertRepository.deleteByOrganizationId(organizationId);
+            return Collections.emptyList();
+        }
+        List<InventoryAlert> alertas = produtos.stream()
+                .map(this::avaliarProduto)
+                .flatMap(Optional::stream)
+                .toList();
+
+        alertRepository.deleteByOrganizationId(organizationId);
+        if (!alertas.isEmpty()) {
+            alertas.forEach(alerta -> alerta.setTenantId(organizationId));
+            alertRepository.saveAll(alertas);
+        }
+        return alertas;
+    }
+
+    @Transactional(readOnly = true)
+    public List<InventoryAlert> listarAlertasOrganizacao(Integer organizationId) {
+        if (!planoService.isMonitoramentoEstoqueHabilitado(organizationId)) {
+            return Collections.emptyList();
+        }
+        return alertRepository.findByOrganizationIdOrderBySeverityDescDiasRestantesAsc(organizationId);
+    }
+
+    private Optional<InventoryAlert> avaliarProduto(Produto produto) {
+        Integer estoqueAtual = Optional.ofNullable(produto.getQtdEstoque()).orElse(0);
+        Integer estoqueMinimo = Optional.ofNullable(produto.getEstoqueMinimo()).orElse(0);
+        Integer prazoReposicao = Optional.ofNullable(produto.getPrazoReposicaoDias()).orElse(0);
+
+        BigDecimal consumoMedioDiario = calcularConsumoMedioDiario(produto);
+        Integer diasRestantes = calcularDiasRestantes(consumoMedioDiario, estoqueAtual);
+        LocalDate dataRuptura = diasRestantes != null ? LocalDate.now(clock).plusDays(diasRestantes) : null;
+
+        InventoryAlertSeverity severity = determinarSeveridade(estoqueAtual, estoqueMinimo, prazoReposicao, diasRestantes);
+        if (severity == null) {
+            return Optional.empty();
+        }
+
+        int quantidadeSugerida = calcularQuantidadeSugerida(estoqueAtual, estoqueMinimo, prazoReposicao, consumoMedioDiario);
+        String mensagem = construirMensagem(estoqueAtual, estoqueMinimo, prazoReposicao, diasRestantes, severity);
+
+        InventoryAlert alerta = InventoryAlert.builder()
+                .produto(produto)
+                .severity(severity)
+                .diasRestantes(diasRestantes)
+                .consumoMedioDiario(consumoMedioDiario)
+                .estoqueAtual(estoqueAtual)
+                .estoqueMinimo(estoqueMinimo)
+                .prazoReposicaoDias(prazoReposicao)
+                .quantidadeSugerida(quantidadeSugerida)
+                .dataEstimadaRuptura(dataRuptura)
+                .mensagem(mensagem)
+                .build();
+        alerta.setTenantId(produto.getOrganizationId());
+        return Optional.of(alerta);
+    }
+
+    private BigDecimal calcularConsumoMedioDiario(Produto produto) {
+        if (produto.getId() == null || produto.getOrganizationId() == null) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+        LocalDate hoje = LocalDate.now(clock);
+        LocalDateTime inicioJanela = hoje.minusDays(CONSUMPTION_LOOKBACK_DAYS - 1L).atStartOfDay();
+        List<InventoryHistory> historicos = historyRepository
+                .findByProdutoIdAndOrganizationIdAndActionAndCreatedAtAfterOrderByCreatedAtAsc(
+                        produto.getId(),
+                        produto.getOrganizationId(),
+                        InventoryAction.DECREMENT,
+                        inicioJanela);
+        if (historicos.isEmpty()) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        Map<LocalDate, Integer> consumoPorDia = new HashMap<>();
+        for (InventoryHistory historico : historicos) {
+            if (historico.getCreatedAt() == null) {
+                continue;
+            }
+            LocalDate data = historico.getCreatedAt().toLocalDate();
+            consumoPorDia.merge(data, historico.getQuantidade(), Integer::sum);
+        }
+        if (consumoPorDia.isEmpty()) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        BigDecimal totalConsumido = BigDecimal.valueOf(consumoPorDia.values().stream()
+                .mapToInt(Integer::intValue)
+                .sum());
+        LocalDate primeiraData = consumoPorDia.keySet().stream()
+                .min(LocalDate::compareTo)
+                .orElse(hoje);
+        long diasConsiderados = Math.max(1,
+                Math.min(CONSUMPTION_LOOKBACK_DAYS, ChronoUnit.DAYS.between(primeiraData, hoje) + 1));
+        return totalConsumido.divide(BigDecimal.valueOf(diasConsiderados), 2, RoundingMode.HALF_UP);
+    }
+
+    private Integer calcularDiasRestantes(BigDecimal consumoMedioDiario, Integer estoqueAtual) {
+        if (consumoMedioDiario == null || consumoMedioDiario.compareTo(BigDecimal.ZERO) <= 0) {
+            return null;
+        }
+        if (estoqueAtual == null) {
+            return null;
+        }
+        return BigDecimal.valueOf(estoqueAtual)
+                .divide(consumoMedioDiario, 0, RoundingMode.DOWN)
+                .intValue();
+    }
+
+    private InventoryAlertSeverity determinarSeveridade(Integer estoqueAtual, Integer estoqueMinimo,
+                                                        Integer prazoReposicao, Integer diasRestantes) {
+        if (estoqueAtual == null) {
+            return null;
+        }
+        if (estoqueAtual <= estoqueMinimo) {
+            return InventoryAlertSeverity.CRITICAL;
+        }
+        if (diasRestantes == null) {
+            return null;
+        }
+        if (prazoReposicao != null && prazoReposicao > 0 && diasRestantes <= prazoReposicao) {
+            return InventoryAlertSeverity.CRITICAL;
+        }
+        int limiteAtencao = prazoReposicao != null && prazoReposicao > 0 ? prazoReposicao + 2 : 3;
+        if (diasRestantes <= limiteAtencao) {
+            return InventoryAlertSeverity.WARNING;
+        }
+        return null;
+    }
+
+    private int calcularQuantidadeSugerida(Integer estoqueAtual, Integer estoqueMinimo, Integer prazoReposicao,
+                                           BigDecimal consumoMedioDiario) {
+        int atual = Optional.ofNullable(estoqueAtual).orElse(0);
+        int minimo = Optional.ofNullable(estoqueMinimo).orElse(0);
+        int prazo = Optional.ofNullable(prazoReposicao).orElse(0);
+
+        int consumoDurantePrazo = 0;
+        if (consumoMedioDiario != null && consumoMedioDiario.compareTo(BigDecimal.ZERO) > 0 && prazo > 0) {
+            consumoDurantePrazo = consumoMedioDiario
+                    .multiply(BigDecimal.valueOf(prazo))
+                    .setScale(0, RoundingMode.CEILING)
+                    .intValue();
+        }
+        int alvo = Math.max(minimo, consumoDurantePrazo) + minimo;
+        return Math.max(0, alvo - atual);
+    }
+
+    private String construirMensagem(Integer estoqueAtual, Integer estoqueMinimo, Integer prazoReposicao,
+                                     Integer diasRestantes, InventoryAlertSeverity severity) {
+        if (estoqueAtual != null && estoqueAtual <= estoqueMinimo) {
+            return "Estoque abaixo do mínimo definido.";
+        }
+        if (diasRestantes == null) {
+            return "Consumo insuficiente para projeção de ruptura.";
+        }
+        if (severity == InventoryAlertSeverity.CRITICAL && prazoReposicao != null && prazoReposicao > 0) {
+            return String.format("Estoque projetado para acabar em %d dias (prazo de reposição: %d).",
+                    diasRestantes, prazoReposicao);
+        }
+        return String.format("Estoque projetado para acabar em %d dias.", diasRestantes);
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Services/PlanoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/PlanoService.java
@@ -123,6 +123,7 @@ public class PlanoService {
                 .recomendacoesHabilitadas(plano.getRecomendacoesHabilitadas())
                 .pagamentosHabilitados(plano.getPagamentosHabilitados())
                 .suportePrioritario(plano.getSuportePrioritario())
+                .monitoramentoEstoqueHabilitado(plano.getMonitoramentoEstoqueHabilitado())
                 .usuariosUtilizados(Math.toIntExact(usuariosAtivos))
                 .usuariosRestantes(calcularRestante(plano.getMaxUsuarios(), usuariosAtivos))
                 .produtosUtilizados(Math.toIntExact(produtosAtivos))
@@ -134,6 +135,16 @@ public class PlanoService {
                 .servicosUtilizados(Math.toIntExact(servicosAtivos))
                 .servicosRestantes(calcularRestante(plano.getMaxServicos(), servicosAtivos))
                 .build();
+    }
+
+    public boolean isMonitoramentoEstoqueHabilitado(Integer organizationId) {
+        if (organizationId == null) {
+            return false;
+        }
+        return organizationRepository.findById(organizationId)
+                .map(Organization::getPlanoAtivoId)
+                .map(Plano::getMonitoramentoEstoqueHabilitado)
+                .orElse(false);
     }
 
     private Integer calcularRestante(Integer maximo, long utilizado) {

--- a/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
@@ -72,6 +72,7 @@ public class ProdutoService {
         Produto produto = produtoMapper.toEntity(request);
         produto.setId(null);
         produto.setTenantId(organizationId);
+        aplicarValoresPadrao(produto);
         Produto salvo = produtoRepository.save(produto);
         return produtoMapper.toResponse(salvo);
     }
@@ -83,6 +84,7 @@ public class ProdutoService {
         Produto produto = produtoMapper.toEntity(request);
         produto.setId(produtoSalvo.getId());
         produto.setTenantId(produtoSalvo.getOrganizationId());
+        aplicarValoresPadrao(produto);
         Produto atualizado = produtoRepository.save(produto);
         return produtoMapper.toResponse(atualizado);
     }
@@ -147,6 +149,15 @@ public class ProdutoService {
         Integer limite = plano.getMaxProdutos();
         if (limite != null && limite > 0 && produtosAtivos + novosProdutos > limite) {
             throw new IllegalStateException("Limite de produtos do plano atingido");
+        }
+    }
+
+    private void aplicarValoresPadrao(Produto produto) {
+        if (produto.getEstoqueMinimo() == null) {
+            produto.setEstoqueMinimo(0);
+        }
+        if (produto.getPrazoReposicaoDias() == null) {
+            produto.setPrazoReposicaoDias(0);
         }
     }
 }

--- a/src/main/java/com/AIT/Optimanage/Support/PlatformDataInitializer.java
+++ b/src/main/java/com/AIT/Optimanage/Support/PlatformDataInitializer.java
@@ -52,6 +52,7 @@ public class PlatformDataInitializer implements ApplicationRunner {
                 .recomendacoesHabilitadas(true)
                 .pagamentosHabilitados(true)
                 .suportePrioritario(true)
+                .monitoramentoEstoqueHabilitado(true)
                 .build();
         plan.setId(1);
         planoRepository.save(plan);

--- a/src/main/resources/db/migration/V3__inventory_monitoring.sql
+++ b/src/main/resources/db/migration/V3__inventory_monitoring.sql
@@ -1,0 +1,29 @@
+ALTER TABLE produto
+    ADD COLUMN estoque_minimo INT NOT NULL DEFAULT 0,
+    ADD COLUMN prazo_reposicao_dias INT NOT NULL DEFAULT 0;
+
+ALTER TABLE inventory_history
+    ADD COLUMN created_by INT,
+    ADD COLUMN created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ADD COLUMN updated_by INT,
+    ADD COLUMN updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE TABLE inventory_alert (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    organization_id INT NOT NULL,
+    produto_id INT NOT NULL,
+    severity VARCHAR(16) NOT NULL,
+    dias_restantes INT,
+    consumo_medio_diario DECIMAL(12, 2) NOT NULL,
+    estoque_atual INT NOT NULL,
+    estoque_minimo INT NOT NULL,
+    prazo_reposicao_dias INT NOT NULL,
+    quantidade_sugerida INT NOT NULL,
+    data_estimada_ruptura DATE,
+    mensagem VARCHAR(255),
+    created_by INT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_by INT,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_inventory_alert_produto FOREIGN KEY (produto_id) REFERENCES produto(id)
+);

--- a/src/main/resources/db/migration/V4__inventory_monitoring_permission.sql
+++ b/src/main/resources/db/migration/V4__inventory_monitoring_permission.sql
@@ -1,0 +1,2 @@
+ALTER TABLE plano
+    ADD COLUMN monitoramento_estoque_habilitado BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/java/com/AIT/Optimanage/Services/InventoryMonitoringServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/InventoryMonitoringServiceTest.java
@@ -1,0 +1,137 @@
+package com.AIT.Optimanage.Services;
+
+import com.AIT.Optimanage.Models.Inventory.InventoryAction;
+import com.AIT.Optimanage.Models.Inventory.InventoryAlert;
+import com.AIT.Optimanage.Models.Inventory.InventoryAlertSeverity;
+import com.AIT.Optimanage.Models.Inventory.InventoryHistory;
+import com.AIT.Optimanage.Models.Produto;
+import com.AIT.Optimanage.Repositories.InventoryAlertRepository;
+import com.AIT.Optimanage.Repositories.InventoryHistoryRepository;
+import com.AIT.Optimanage.Repositories.ProdutoRepository;
+import com.AIT.Optimanage.Services.PlanoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InventoryMonitoringServiceTest {
+
+    @Mock
+    private ProdutoRepository produtoRepository;
+    @Mock
+    private InventoryHistoryRepository historyRepository;
+    @Mock
+    private InventoryAlertRepository alertRepository;
+    @Mock
+    private PlanoService planoService;
+
+    private Clock clock;
+
+    private InventoryMonitoringService service;
+
+    @BeforeEach
+    void setUp() {
+        clock = Clock.fixed(LocalDate.of(2024, 1, 30).atStartOfDay(ZoneId.systemDefault()).toInstant(),
+                ZoneId.systemDefault());
+        service = new InventoryMonitoringService(produtoRepository, historyRepository, alertRepository, planoService, clock);
+    }
+
+    @Test
+    void deveGerarAlertaCriticoQuandoEstoqueAbaixoDoMinimo() {
+        Produto produto = Produto.builder()
+                .id(1)
+                .qtdEstoque(5)
+                .estoqueMinimo(10)
+                .prazoReposicaoDias(3)
+                .ativo(true)
+                .build();
+        produto.setTenantId(99);
+
+        InventoryHistory h1 = InventoryHistory.builder()
+                .quantidade(4)
+                .build();
+        h1.setCreatedAt(LocalDateTime.of(2024, 1, 28, 10, 0));
+        InventoryHistory h2 = InventoryHistory.builder()
+                .quantidade(3)
+                .build();
+        h2.setCreatedAt(LocalDateTime.of(2024, 1, 29, 10, 0));
+
+        when(planoService.isMonitoramentoEstoqueHabilitado(99)).thenReturn(true);
+        when(produtoRepository.findAllByOrganizationIdAndAtivoTrue(99)).thenReturn(List.of(produto));
+        when(historyRepository.findByProdutoIdAndOrganizationIdAndActionAndCreatedAtAfterOrderByCreatedAtAsc(
+                eq(1), eq(99), eq(InventoryAction.DECREMENT), any(LocalDateTime.class)))
+                .thenReturn(List.of(h1, h2));
+        when(alertRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        List<InventoryAlert> alertas = service.recalcularAlertasOrganizacao(99);
+
+        assertThat(alertas).hasSize(1);
+        InventoryAlert alerta = alertas.get(0);
+        assertThat(alerta.getSeverity()).isEqualTo(InventoryAlertSeverity.CRITICAL);
+        assertThat(alerta.getQuantidadeSugerida()).isGreaterThan(0);
+        assertThat(alerta.getConsumoMedioDiario()).isGreaterThan(BigDecimal.ZERO);
+
+        verify(alertRepository).deleteByOrganizationId(99);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<InventoryAlert>> captor = ArgumentCaptor.forClass(List.class);
+        verify(alertRepository).saveAll(captor.capture());
+        assertThat(captor.getValue()).hasSize(1);
+        assertThat(captor.getValue().get(0).getProduto()).isEqualTo(produto);
+    }
+
+    @Test
+    void naoDeveGerarAlertasQuandoEstoqueSaudavel() {
+        Produto produto = Produto.builder()
+                .id(2)
+                .qtdEstoque(50)
+                .estoqueMinimo(10)
+                .prazoReposicaoDias(5)
+                .ativo(true)
+                .build();
+        produto.setTenantId(55);
+
+        InventoryHistory consumo = InventoryHistory.builder()
+                .quantidade(2)
+                .build();
+        consumo.setCreatedAt(LocalDateTime.of(2024, 1, 25, 9, 0));
+
+        when(planoService.isMonitoramentoEstoqueHabilitado(55)).thenReturn(true);
+        when(produtoRepository.findAllByOrganizationIdAndAtivoTrue(55)).thenReturn(List.of(produto));
+        when(historyRepository.findByProdutoIdAndOrganizationIdAndActionAndCreatedAtAfterOrderByCreatedAtAsc(
+                eq(2), eq(55), eq(InventoryAction.DECREMENT), any(LocalDateTime.class)))
+                .thenReturn(List.of(consumo));
+
+        List<InventoryAlert> alertas = service.recalcularAlertasOrganizacao(55);
+
+        assertThat(alertas).isEmpty();
+        verify(alertRepository).deleteByOrganizationId(55);
+        verify(alertRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void deveLimparAlertasQuandoPlanoNaoPermiteMonitoramento() {
+        when(planoService.isMonitoramentoEstoqueHabilitado(77)).thenReturn(false);
+
+        List<InventoryAlert> alertas = service.recalcularAlertasOrganizacao(77);
+
+        assertThat(alertas).isEmpty();
+        verify(alertRepository).deleteByOrganizationId(77);
+        verifyNoInteractions(produtoRepository);
+        verifyNoInteractions(historyRepository);
+        verify(alertRepository, never()).saveAll(anyList());
+    }
+}


### PR DESCRIPTION
## Summary
- add the monitoramentoEstoqueHabilitado capability flag to plans, DTOs and database schema
- gate inventory monitoring analytics and alert recalculation behind the new plan permission and update documentation/tests accordingly

## Testing
- `./mvnw test` *(fails: unable to download parent POM from Maven Central because the repository is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1430ed34c83248b4aa0dbcb2577d4