### PR TITLE
Include overdue installments in agenda events

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Repositories/Compra/PagamentoCompraRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Compra/PagamentoCompraRepository.java
@@ -17,6 +17,6 @@ public interface PagamentoCompraRepository extends JpaRepository<CompraPagamento
 
     List<CompraPagamento> findAllByCompraIdAndCompraOrganizationIdAndStatusPagamento(Integer idCompra, Integer organizationId, StatusPagamento statusPagamento);
 
-    List<CompraPagamento> findAllByCompraOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(Integer organizationId, StatusPagamento statusPagamento, LocalDate dataVencimento);
+    List<CompraPagamento> findAllByCompraOrganizationIdAndStatusPagamentoAndDataVencimentoGreaterThanEqual(Integer organizationId, StatusPagamento statusPagamento, LocalDate dataVencimento);
 
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/PagamentoVendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/PagamentoVendaRepository.java
@@ -20,5 +20,5 @@ public interface PagamentoVendaRepository extends JpaRepository<VendaPagamento, 
 
     Optional<VendaPagamento> findByIdAndVendaAndVendaOrganizationId(Integer idPagamento, Venda venda, Integer organizationId);
 
-    List<VendaPagamento> findAllByVendaOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(Integer organizationId, StatusPagamento statusPagamento, LocalDate dataVencimento);
+    List<VendaPagamento> findAllByVendaOrganizationIdAndStatusPagamentoAndDataVencimentoGreaterThanEqual(Integer organizationId, StatusPagamento statusPagamento, LocalDate dataVencimento);
 }

--- a/src/main/java/com/AIT/Optimanage/Services/AgendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/AgendaService.java
@@ -82,7 +82,7 @@ public class AgendaService {
         Integer userId = loggedUser.getId();
 
         List<CompraPagamento> compras = pagamentoCompraRepository
-                .findAllByCompraOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(organizationId, StatusPagamento.PENDENTE, now);
+                .findAllByCompraOrganizationIdAndStatusPagamentoAndDataVencimentoGreaterThanEqual(organizationId, StatusPagamento.PENDENTE, inicio);
         compras.stream()
                 .filter(p -> withinRange(p.getDataVencimento(), inicio, fim))
                 .map(pagamento -> criarEvento(TipoEvento.PAGAMENTO, TipoEvento.COMPRA, pagamento.getDataVencimento(), null, null,
@@ -90,7 +90,7 @@ public class AgendaService {
                 .forEach(eventos::add);
 
         List<VendaPagamento> vendas = pagamentoVendaRepository
-                .findAllByVendaOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(organizationId, StatusPagamento.PENDENTE, now);
+                .findAllByVendaOrganizationIdAndStatusPagamentoAndDataVencimentoGreaterThanEqual(organizationId, StatusPagamento.PENDENTE, inicio);
         vendas.stream()
                 .filter(p -> withinRange(p.getDataVencimento(), inicio, fim))
                 .map(pagamento -> criarEvento(TipoEvento.PAGAMENTO, TipoEvento.VENDA, pagamento.getDataVencimento(), null, null,

--- a/src/test/java/com/AIT/Optimanage/Services/AgendaServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/AgendaServiceTest.java
@@ -107,11 +107,11 @@ class AgendaServiceTest {
                 .build();
         contato.setId(33);
 
-        when(pagamentoCompraRepository.findAllByCompraOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(
-                eq(usuario.getTenantId()), eq(StatusPagamento.PENDENTE), any(LocalDate.class)))
+        when(pagamentoCompraRepository.findAllByCompraOrganizationIdAndStatusPagamentoAndDataVencimentoGreaterThanEqual(
+                eq(usuario.getTenantId()), eq(StatusPagamento.PENDENTE), eq(inicio)))
                 .thenReturn(List.of(pagamentoCompra));
-        when(pagamentoVendaRepository.findAllByVendaOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(
-                eq(usuario.getTenantId()), eq(StatusPagamento.PENDENTE), any(LocalDate.class)))
+        when(pagamentoVendaRepository.findAllByVendaOrganizationIdAndStatusPagamentoAndDataVencimentoGreaterThanEqual(
+                eq(usuario.getTenantId()), eq(StatusPagamento.PENDENTE), eq(inicio)))
                 .thenReturn(List.of(pagamentoVenda));
         when(compraRepository.findAgendadasNoPeriodo(usuario.getTenantId(), usuario.getId(), inicio, fim))
                 .thenReturn(List.of(compra));
@@ -185,11 +185,11 @@ class AgendaServiceTest {
                 .build();
         contatoFora.setId(5);
 
-        when(pagamentoCompraRepository.findAllByCompraOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(
-                eq(usuario.getTenantId()), eq(StatusPagamento.PENDENTE), any(LocalDate.class)))
+        when(pagamentoCompraRepository.findAllByCompraOrganizationIdAndStatusPagamentoAndDataVencimentoGreaterThanEqual(
+                eq(usuario.getTenantId()), eq(StatusPagamento.PENDENTE), eq(inicio)))
                 .thenReturn(List.of(pagamentoDentro, pagamentoFora));
-        when(pagamentoVendaRepository.findAllByVendaOrganizationIdAndStatusPagamentoAndDataVencimentoAfter(
-                eq(usuario.getTenantId()), eq(StatusPagamento.PENDENTE), any(LocalDate.class)))
+        when(pagamentoVendaRepository.findAllByVendaOrganizationIdAndStatusPagamentoAndDataVencimentoGreaterThanEqual(
+                eq(usuario.getTenantId()), eq(StatusPagamento.PENDENTE), eq(inicio)))
                 .thenReturn(List.of());
         when(compraRepository.findAgendadasNoPeriodo(usuario.getTenantId(), usuario.getId(), inicio, fim))
                 .thenReturn(List.of(compraDentro, compraFora));


### PR DESCRIPTION
## Summary
- make agenda payment queries start from the user-provided initial date when present
- include installments due today or earlier by using inclusive repository filters
- align agenda service tests with the new inclusive filtering behavior

## Testing
- ./mvnw test *(fails: unable to download parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f6122aa48324b8d114c7c80a7c69