### PR TITLE
Evita ajuste de estoque para compras em orçamento

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -255,6 +255,7 @@ public class CompraService {
         return compraMapper.toResponse(salvo);
     }
 
+    @Transactional
     public CompraResponseDTO confirmarCompra(Integer idCompra) {
         Compra compra = getCompra(idCompra);
         StatusCompra statusAnterior = compra.getStatus();
@@ -263,10 +264,11 @@ public class CompraService {
         } else {
             atualizarStatus(compra, StatusCompra.AGUARDANDO_EXECUCAO);
         }
-        if (statusAnterior == StatusCompra.ORCAMENTO) {
-            publicarCompraCriada(compra, compra.getCompraProdutos());
-        }
+        boolean devePublicarEvento = statusAnterior == StatusCompra.ORCAMENTO;
         Compra salvo = compraRepository.save(compra);
+        if (devePublicarEvento) {
+            publicarCompraCriada(salvo, salvo.getCompraProdutos());
+        }
         return compraMapper.toResponse(salvo);
     }
 

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -202,6 +202,7 @@ public class CompraService {
         }
 
         Compra compra = getCompra(idCompra);
+        StatusCompra statusAnterior = compra.getStatus();
 
         compra.setDataEfetuacao(compraDTO.getDataEfetuacao());
         compra.setDataAgendada(compraDTO.getDataAgendada());
@@ -210,7 +211,9 @@ public class CompraService {
         compra.setCondicaoPagamento(compraDTO.getCondicaoPagamento());
         compra.setObservacoes(compraDTO.getObservacoes());
 
-        reverterEstoqueCompra(compra, "Ajuste de edição da compra #" + compra.getId());
+        if (statusAnterior != StatusCompra.ORCAMENTO) {
+            reverterEstoqueCompra(compra, "Ajuste de edição da compra #" + compra.getId());
+        }
 
         compraProdutoRepository.deleteAll(compra.getCompraProdutos());
         compraServicoRepository.deleteAll(compra.getCompraServicos());
@@ -242,9 +245,11 @@ public class CompraService {
         compraProdutoRepository.saveAll(compraProdutos);
         compraServicoRepository.saveAll(compraServicos);
 
-        compraProdutos.forEach(cp ->
-                inventoryService.incrementar(cp.getProduto().getId(), cp.getQuantidade(), InventorySource.COMPRA,
-                        compra.getId(), "Atualização da compra #" + compra.getId()));
+        if (compra.getStatus() != StatusCompra.ORCAMENTO) {
+            compraProdutos.forEach(cp ->
+                    inventoryService.incrementar(cp.getProduto().getId(), cp.getQuantidade(), InventorySource.COMPRA,
+                            compra.getId(), "Atualização da compra #" + compra.getId()));
+        }
 
         Compra salvo = compraRepository.save(compra);
         return compraMapper.toResponse(salvo);
@@ -252,10 +257,14 @@ public class CompraService {
 
     public CompraResponseDTO confirmarCompra(Integer idCompra) {
         Compra compra = getCompra(idCompra);
-        if (compra.getStatus() == StatusCompra.ORCAMENTO && compra.getCompraServicos().isEmpty()) {
+        StatusCompra statusAnterior = compra.getStatus();
+        if (statusAnterior == StatusCompra.ORCAMENTO && compra.getCompraServicos().isEmpty()) {
             atualizarStatus(compra, StatusCompra.AGUARDANDO_PAG);
         } else {
             atualizarStatus(compra, StatusCompra.AGUARDANDO_EXECUCAO);
+        }
+        if (statusAnterior == StatusCompra.ORCAMENTO) {
+            publicarCompraCriada(compra, compra.getCompraProdutos());
         }
         Compra salvo = compraRepository.save(compra);
         return compraMapper.toResponse(salvo);
@@ -462,7 +471,7 @@ public class CompraService {
             return false;
         }
 
-        if (statusAnterior == StatusCompra.CONCRETIZADO) {
+        if (statusAnterior == StatusCompra.CONCRETIZADO || statusAnterior == StatusCompra.ORCAMENTO) {
             return false;
         }
 
@@ -489,7 +498,7 @@ public class CompraService {
     }
 
     private void publicarCompraCriada(Compra compra, List<CompraProduto> itens) {
-        if (itens == null || itens.isEmpty()) {
+        if (compra.getStatus() == StatusCompra.ORCAMENTO || itens == null || itens.isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- impede que compras criadas ou editadas com status ORCAMENTO ajustem o estoque
- garante que o estoque seja atualizado apenas quando a compra sai de ORCAMENTO
- evita reversões de estoque desnecessárias ao cancelar ou editar orçamentos

## Testing
- ./mvnw test *(falha por falta de acesso à internet para baixar dependências)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f683b8308324858d52f1debca289