### PR TITLE
Ajusta custo de serviços em compras

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -507,15 +507,16 @@ public class CompraService {
         return servicosDTO.stream()
                 .map(servicoDTO -> {
                     Servico servico = servicoService.buscarServicoAtivo(servicoDTO.getServicoId());
-                    BigDecimal valorFinalServico = servico.getValorVenda()
-                            .multiply(BigDecimal.valueOf(servicoDTO.getQuantidade()));
+                    BigDecimal valorUnitario = Optional.ofNullable(servico.getCusto())
+                            .orElse(servico.getValorVenda());
+                    BigDecimal valorTotal = valorUnitario.multiply(BigDecimal.valueOf(servicoDTO.getQuantidade()));
 
                     return CompraServico.builder()
                             .compra(compra)
                             .servico(servico)
-                            .valorUnitario(servico.getValorVenda())
+                            .valorUnitario(valorUnitario)
                             .quantidade(servicoDTO.getQuantidade())
-                            .valorTotal(valorFinalServico)
+                            .valorTotal(valorTotal)
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/src/test/java/com/AIT/Optimanage/Services/Compra/CompraServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/Compra/CompraServiceTest.java
@@ -184,6 +184,7 @@ class CompraServiceTest {
         produtoAtualizado.setId(5);
 
         Servico servicoAtualizado = Servico.builder()
+                .custo(BigDecimal.valueOf(45))
                 .valorVenda(BigDecimal.valueOf(50))
                 .build();
         servicoAtualizado.setId(3);
@@ -212,12 +213,15 @@ class CompraServiceTest {
         CompraProduto compraProdutoAtualizado = compra.getCompraProdutos().get(0);
         assertEquals(custoNegociado, compraProdutoAtualizado.getValorUnitario());
         assertEquals(custoNegociado.multiply(BigDecimal.valueOf(2)), compraProdutoAtualizado.getValorTotal());
-        assertEquals(BigDecimal.valueOf(200), compra.getValorFinal());
-        assertEquals(BigDecimal.valueOf(120), compra.getValorPendente());
+        assertEquals(BigDecimal.valueOf(195), compra.getValorFinal());
+        assertEquals(BigDecimal.valueOf(115), compra.getValorPendente());
         assertEquals(compraDTO.getDataEfetuacao(), compra.getDataEfetuacao());
         assertEquals("Atualizado", compra.getObservacoes());
         assertEquals(1, compra.getCompraProdutos().size());
         assertEquals(1, compra.getCompraServicos().size());
+        assertEquals(servicoAtualizado.getCusto(), compra.getCompraServicos().get(0).getValorUnitario());
+        assertEquals(servicoAtualizado.getCusto().multiply(BigDecimal.valueOf(1)),
+                compra.getCompraServicos().get(0).getValorTotal());
         verify(compraProdutoRepository).saveAll(anyList());
         verify(compraServicoRepository).saveAll(anyList());
         verify(inventoryService).reduzir(produtoAntigo.getId(), 1, InventorySource.COMPRA, compra.getId(),


### PR DESCRIPTION
## Summary
- atualiza a criação de itens de serviço na compra para priorizar o custo cadastrado ao definir valor unitário e total
- ajusta o teste de edição de compra para validar o uso do custo do serviço e os novos totais calculados

## Testing
- `./mvnw -q -Dtest=CompraServiceTest test` *(falhou: Network is unreachable ao resolver parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f6ca50608324bf2edc4f4f4957eb