### PR TITLE
Handle null payment collections during full reversals

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -321,7 +321,7 @@ public class CompraService {
             atualizarStatus(compra, StatusCompra.AGUARDANDO_PAG);
         }
         compra.setValorPendente(compra.getValorFinal());
-        compra.getPagamentos().forEach(pagamento
+        Optional.ofNullable(compra.getPagamentos()).orElseGet(List::of).forEach(pagamento
                 -> { if (pagamento.getStatusPagamento() == StatusPagamento.PAGO)
                         { pagamentoCompraService.estornarPagamento(pagamento); }
                     });

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -355,7 +355,7 @@ public class VendaService {
         if (venda.getStatus() == StatusVenda.CANCELADA) {
             throw new IllegalArgumentException("Não é possível estornar uma venda cancelada.");
         }
-        venda.getPagamentos().forEach(pagamento -> {
+        Optional.ofNullable(venda.getPagamentos()).orElseGet(List::of).forEach(pagamento -> {
             if (pagamento.getStatusPagamento() == StatusPagamento.PAGO) {
                 pagamentoVendaService.estornarPagamento(loggedUser, pagamento);
             }


### PR DESCRIPTION
## Summary
- guard estornarVendaIntegral against vendas sem lista de pagamentos
- evitar NullPointerException em estorno integral de compras sem pagamentos cadastrados

## Testing
- ./mvnw test *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d413cfe1348324a89487913a9345f1