### PR TITLE
Evita saldo pendente negativo apos pagamentos

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -553,8 +553,13 @@ public class CompraService {
     public void atualizarCompraPosPagamento(Compra compra) {
         List<CompraPagamento> pagamentos = pagamentoCompraService.listarPagamentosRealizadosCompra(compra.getId());
 
-        BigDecimal valorPago = pagamentos.stream().map(CompraPagamento::getValorPago).reduce(BigDecimal.ZERO, BigDecimal::add);
-        compra.setValorPendente(compra.getValorFinal().subtract(valorPago));
+        BigDecimal valorPago = pagamentos.stream().map(CompraPagamento::getValorPago)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal valorPendente = compra.getValorFinal().subtract(valorPago);
+        if (valorPendente.compareTo(BigDecimal.ZERO) < 0) {
+            valorPendente = BigDecimal.ZERO;
+        }
+        compra.setValorPendente(valorPendente);
 
         if (compra.getValorPendente().compareTo(BigDecimal.ZERO) == 0) {
             if (compra.getStatus() == StatusCompra.AGUARDANDO_PAG || compra.getStatus() == StatusCompra.PARCIALMENTE_PAGO) {

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -575,8 +575,13 @@ public class VendaService {
     private void atualizarVendaPosPagamento(User loggedUser, Venda venda) {
         List<VendaPagamento> pagamentos = pagamentoVendaService.listarPagamentosRealizadosVenda(loggedUser, venda.getId());
 
-        BigDecimal valorPago = pagamentos.stream().map(VendaPagamento::getValorPago).reduce(BigDecimal.ZERO, BigDecimal::add);
-        venda.setValorPendente(venda.getValorFinal().subtract(valorPago));
+        BigDecimal valorPago = pagamentos.stream().map(VendaPagamento::getValorPago)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal valorPendente = venda.getValorFinal().subtract(valorPago);
+        if (valorPendente.compareTo(BigDecimal.ZERO) < 0) {
+            valorPendente = BigDecimal.ZERO;
+        }
+        venda.setValorPendente(valorPendente);
         if (venda.getValorPendente().compareTo(BigDecimal.ZERO) <= 0) {
             if (venda.getStatus() == StatusVenda.AGUARDANDO_PAG || venda.getStatus() == StatusVenda.PENDENTE) {
                 atualizarStatus(venda, StatusVenda.PAGA);


### PR DESCRIPTION
## Summary
- impede que vendas registrem valor pendente negativo ao somar pagamentos
- evita que compras fiquem com saldo pendente negativo após pagamentos excedentes

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68d414035c848324b240f2c8c19d1fc8