### PR TITLE
Restringe ajustes de estoque ao tenant atual

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Repositories/ProdutoRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/ProdutoRepository.java
@@ -26,12 +26,14 @@ public interface ProdutoRepository extends JpaRepository<Produto, Integer> {
     List<Produto> findAllByOrganizationIdAndAtivoTrue(Integer organizationId);
 
     @Modifying
-    @Query("update Produto p set p.qtdEstoque = p.qtdEstoque - :quantidade where p.id = :id and p.qtdEstoque >= :quantidade")
-    int reduzirEstoque(Integer id, Integer quantidade);
+    @Query("update Produto p set p.qtdEstoque = p.qtdEstoque - :quantidade " +
+            "where p.id = :id and p.organizationId = :organizationId and p.qtdEstoque >= :quantidade")
+    int reduzirEstoque(Integer id, Integer quantidade, Integer organizationId);
 
     @Modifying
-    @Query("update Produto p set p.qtdEstoque = p.qtdEstoque + :quantidade where p.id = :id")
-    int incrementarEstoque(Integer id, Integer quantidade);
+    @Query("update Produto p set p.qtdEstoque = p.qtdEstoque + :quantidade " +
+            "where p.id = :id and p.organizationId = :organizationId")
+    int incrementarEstoque(Integer id, Integer quantidade, Integer organizationId);
 
     long countByOrganizationIdAndAtivoTrue(Integer organizationId);
 }

--- a/src/main/java/com/AIT/Optimanage/Services/InventoryService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/InventoryService.java
@@ -53,12 +53,15 @@ public class InventoryService {
         if (quantidade == null || quantidade <= 0) {
             throw new IllegalArgumentException("A quantidade deve ser maior que zero.");
         }
-        Produto produto = produtoRepository.findById(produtoId)
+        Integer organizationId = Optional.ofNullable(TenantContext.getTenantId())
+                .orElseThrow(() -> new IllegalStateException("Organização não definida no contexto."));
+
+        Produto produto = produtoRepository.findByIdAndOrganizationId(produtoId, organizationId)
                 .orElseThrow(() -> new EntityNotFoundException("Produto não encontrado: " + produtoId));
 
         int updatedRows = action == InventoryAction.INCREMENT
-                ? produtoRepository.incrementarEstoque(produtoId, quantidade)
-                : produtoRepository.reduzirEstoque(produtoId, quantidade);
+                ? produtoRepository.incrementarEstoque(produtoId, quantidade, organizationId)
+                : produtoRepository.reduzirEstoque(produtoId, quantidade, organizationId);
 
         if (updatedRows == 0) {
             String mensagem = action == InventoryAction.INCREMENT

--- a/src/test/java/com/AIT/Optimanage/Repositories/ProdutoRepositoryConcurrencyTest.java
+++ b/src/test/java/com/AIT/Optimanage/Repositories/ProdutoRepositoryConcurrencyTest.java
@@ -72,7 +72,7 @@ class ProdutoRepositoryConcurrencyTest {
                 try {
                     start.await();
                     transactionTemplate.execute(status -> {
-                        produtoRepository.incrementarEstoque(produto.getId(), 1);
+                        produtoRepository.incrementarEstoque(produto.getId(), 1, 1);
                         return null;
                     });
                 } catch (InterruptedException e) {
@@ -107,7 +107,7 @@ class ProdutoRepositoryConcurrencyTest {
                 try {
                     start.await();
                     Integer updated = transactionTemplate.execute(status ->
-                            produtoRepository.reduzirEstoque(produto.getId(), 1));
+                            produtoRepository.reduzirEstoque(produto.getId(), 1, 1));
                     if (updated == 1) {
                         success.incrementAndGet();
                     }


### PR DESCRIPTION
## Summary
- restringe atualizações de estoque para considerar o organization_id nos comandos UPDATE
- busca produtos pelo tenant ativo antes de registrar histórico de estoque
- atualiza testes de concorrência para refletir nova assinatura dos métodos de estoque

## Testing
- `./mvnw -q test` *(falhou: dependência do parent POM não pôde ser resolvida devido à ausência de acesso à internet)*

------
https://chatgpt.com/codex/tasks/task_e_68d41831de3083249d07a994781d2532