### PR TITLE
Evita baixa de estoque para orçamentos de venda

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -224,8 +224,12 @@ public class VendaService {
         venda.setObservacoes(vendaDTO.getObservacoes());
         venda.setDescontoGeral(descontoGeralAtualizado);
 
+        StatusVenda statusAnterior = venda.getStatus();
+
         // Devolve estoque dos produtos antigos e remove os registros
-        devolverProdutosParaEstoque(venda, "Reversão da venda #" + venda.getId());
+        if (statusAnterior != StatusVenda.ORCAMENTO) {
+            devolverProdutosParaEstoque(venda, "Reversão da venda #" + venda.getId());
+        }
         vendaProdutoRepository.deleteByVenda(venda);
         vendaServicoRepository.deleteByVenda(venda);
 
@@ -256,9 +260,11 @@ public class VendaService {
         vendaProdutoRepository.saveAll(vendaProdutos);
         vendaServicoRepository.saveAll(vendaServicos);
 
-        vendaProdutos.forEach(vp ->
-                inventoryService.reduzir(vp.getProduto().getId(), vp.getQuantidade(), InventorySource.VENDA,
-                        venda.getId(), "Atualização da venda #" + venda.getId()));
+        if (venda.getStatus() != StatusVenda.ORCAMENTO) {
+            vendaProdutos.forEach(vp ->
+                    inventoryService.reduzir(vp.getProduto().getId(), vp.getQuantidade(), InventorySource.VENDA,
+                            venda.getId(), "Atualização da venda #" + venda.getId()));
+        }
 
         Venda salvo = vendaRepository.save(venda);
         return vendaMapper.toResponse(salvo);
@@ -273,6 +279,7 @@ public class VendaService {
         } else {
             throw new IllegalArgumentException("Esta venda já foi confirmada.");
         }
+        publicarVendaRegistrada(venda, venda.getVendaProdutos(), loggedUser);
         Venda salvo = vendaRepository.save(venda);
         return vendaMapper.toResponse(salvo);
     }
@@ -518,7 +525,7 @@ public class VendaService {
     }
 
     private void publicarVendaRegistrada(Venda venda, List<VendaProduto> itens, User owner) {
-        if (itens == null || itens.isEmpty()) {
+        if (venda == null || venda.getStatus() == StatusVenda.ORCAMENTO || itens == null || itens.isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- impede a publicação de eventos de ajuste quando a venda está em status ORCAMENTO
- ajusta a lógica de atualização para não devolver ou reduzir estoque enquanto a venda permanecer como orçamento
- garante a baixa de estoque apenas ao confirmar a venda a partir de um orçamento

## Testing
- ./mvnw -q test *(falha: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d41859faac83248b2b2e637757e093