### PR TITLE
Optimize inventory monitoring history loading

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Repositories/InventoryHistoryRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/InventoryHistoryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 
 @Repository
@@ -16,4 +17,10 @@ public interface InventoryHistoryRepository extends JpaRepository<InventoryHisto
             Integer organizationId,
             InventoryAction action,
             LocalDateTime createdAt);
+
+    List<InventoryHistory> findByOrganizationIdAndActionAndCreatedAtAfterAndProduto_IdInOrderByProduto_IdAscCreatedAtAsc(
+            Integer organizationId,
+            InventoryAction action,
+            LocalDateTime createdAt,
+            Collection<Integer> produtoIds);
 }


### PR DESCRIPTION
## Summary
- batch load recent inventory history records for all products in an organization
- reuse the loaded history when evaluating products to avoid per-item queries

## Testing
- ./mvnw -q test *(fails: missing spring-boot-starter-parent because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4200a1a188324a12bff311421f774