### PR TITLE
Fix payment validations, refunds, and external payment request

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -298,9 +298,13 @@ public class CompraService {
             } else if (pagamento.getStatusPagamento() == StatusPagamento.PAGO &&
                     pagamento.getDataPagamento() != null && pagamento.getDataPagamento().isAfter(LocalDate.now())) {
                 throw new IllegalArgumentException("Um pagamento realizado não pode ser no futuro");
-            } else if (pagamento.getStatusPagamento() == StatusPagamento.PENDENTE &&
-                    pagamento.getDataVencimento().isBefore(LocalDate.now())) {
-                throw new IllegalArgumentException("Um pagamento pendente não pode ter vencimento no passado");
+            } else if (pagamento.getStatusPagamento() == StatusPagamento.PENDENTE) {
+                if (pagamento.getDataVencimento() == null) {
+                    throw new IllegalArgumentException("Pagamentos pendentes devem informar uma data de vencimento");
+                }
+                if (pagamento.getDataVencimento().isBefore(LocalDate.now())) {
+                    throw new IllegalArgumentException("Um pagamento pendente não pode ter vencimento no passado");
+                }
             }
             pagamentoCompraService.lancarPagamento(compra, pagamento);
         }

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -305,14 +305,13 @@ public class VendaService {
         PaymentProvider provider = request != null && request.getProvider() != null
                 ? request.getProvider()
                 : PaymentProvider.STRIPE;
-        PaymentRequestDTO req = request != null ? request : PaymentRequestDTO.builder()
-                .amount(venda.getValorPendente())
+        PaymentRequestDTO req = PaymentRequestDTO.builder()
+                .amount(Optional.ofNullable(venda.getValorPendente()).orElse(BigDecimal.ZERO))
                 .currency("brl")
                 .description("Venda " + idVenda)
                 .provider(provider)
                 .build();
         PaymentConfig config = paymentConfigService.getConfig(loggedUser.getOrganizationId(), provider);
-        req.setProvider(provider);
         return paymentService.createPayment(req, config);
     }
 
@@ -342,9 +341,13 @@ public class VendaService {
             } else if (pagamento.getStatusPagamento() == StatusPagamento.PAGO &&
                     pagamento.getDataPagamento() != null && pagamento.getDataPagamento().isAfter(LocalDate.now())) {
                 throw new IllegalArgumentException("A data de pagamento não pode ser no futuro.");
-            } else if (pagamento.getStatusPagamento() == StatusPagamento.PENDENTE &&
-                    pagamento.getDataVencimento().isBefore(LocalDate.now())) {
-                throw new IllegalArgumentException("Um pagamento pendente não pode ter vencimento no passado.");
+            } else if (pagamento.getStatusPagamento() == StatusPagamento.PENDENTE) {
+                if (pagamento.getDataVencimento() == null) {
+                    throw new IllegalArgumentException("Pagamentos pendentes devem informar uma data de vencimento.");
+                }
+                if (pagamento.getDataVencimento().isBefore(LocalDate.now())) {
+                    throw new IllegalArgumentException("Um pagamento pendente não pode ter vencimento no passado.");
+                }
             }
             pagamentoVendaService.lancarPagamento(venda, pagamento);
         }
@@ -367,6 +370,7 @@ public class VendaService {
                 pagamentoVendaService.estornarPagamento(loggedUser, pagamento);
             }
         });
+        devolverProdutosParaEstoque(venda, "Estorno integral da venda #" + venda.getId());
         venda.setValorPendente(Optional.ofNullable(venda.getValorFinal()).orElse(BigDecimal.ZERO));
         if (venda.getStatus() == StatusVenda.CONCRETIZADA) {
             venda.setStatus(StatusVenda.AGUARDANDO_PAG);

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -371,12 +371,13 @@ public class VendaService {
             }
         });
         devolverProdutosParaEstoque(venda, "Estorno integral da venda #" + venda.getId());
-        venda.setValorPendente(Optional.ofNullable(venda.getValorFinal()).orElse(BigDecimal.ZERO));
+        venda.setValorPendente(BigDecimal.ZERO);
         if (venda.getStatus() == StatusVenda.CONCRETIZADA) {
             venda.setStatus(StatusVenda.AGUARDANDO_PAG);
         } else {
             atualizarStatus(venda, StatusVenda.AGUARDANDO_PAG);
         }
+        atualizarStatus(venda, StatusVenda.CANCELADA);
         Venda salvo = vendaRepository.save(venda);
         return vendaMapper.toResponse(salvo);
     }


### PR DESCRIPTION
## Summary
- require pending purchase and sale payments to provide a due date before validating the deadline
- return sold products to inventory when a sale is fully refunded
- derive external payment requests from the server-side sale balance instead of trusting client-provided values

## Testing
- ./mvnw test *(fails: missing parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d41fdd2718832498e5e7eaee46f88a