### PR TITLE
Fix payment config lookup for webhooks

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/PaymentsController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/PaymentsController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -28,8 +29,9 @@ public class PaymentsController extends V1BaseController {
     @PostMapping("/webhook")
     @Operation(summary = "Webhook de pagamento", description = "Confirma pagamentos assíncronos")
     @ApiResponse(responseCode = "204", description = "Processado com sucesso")
-    public ResponseEntity<Void> handleWebhook(@RequestBody @Valid PaymentConfirmationDTO confirmDTO) {
-        PaymentConfig config = paymentConfigService.getConfig(confirmDTO.getProvider());
+    public ResponseEntity<Void> handleWebhook(@RequestParam("organizationId") Integer organizationId,
+                                              @RequestBody @Valid PaymentConfirmationDTO confirmDTO) {
+        PaymentConfig config = paymentConfigService.getConfig(organizationId, confirmDTO.getProvider());
         paymentService.confirmPayment(confirmDTO.getPaymentIntentId(), config);
         return noContent();
     }

--- a/src/main/java/com/AIT/Optimanage/Payments/PagamentoWebhookController.java
+++ b/src/main/java/com/AIT/Optimanage/Payments/PagamentoWebhookController.java
@@ -20,9 +20,10 @@ public class PagamentoWebhookController {
 
     @PostMapping("/webhook")
     public ResponseEntity<PagamentoDTO> handleWebhook(@RequestParam PaymentProvider provider,
+                                                      @RequestParam("organizationId") Integer organizationId,
                                                       @RequestBody String payload,
                                                       @RequestHeader Map<String, String> headers) {
-        PaymentConfig config = paymentConfigService.getConfig(provider);
+        PaymentConfig config = paymentConfigService.getConfig(organizationId, provider);
         PagamentoDTO dto = paymentService.handleWebhook(provider, payload, headers, config);
         return ResponseEntity.ok(dto);
     }

--- a/src/main/java/com/AIT/Optimanage/Services/Payment/PaymentConfigService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Payment/PaymentConfigService.java
@@ -3,7 +3,6 @@ package com.AIT.Optimanage.Services.Payment;
 import com.AIT.Optimanage.Models.Payment.PaymentConfig;
 import com.AIT.Optimanage.Models.Payment.PaymentProvider;
 import com.AIT.Optimanage.Repositories.Payment.PaymentConfigRepository;
-import com.AIT.Optimanage.Security.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,8 +20,4 @@ public class PaymentConfigService {
                 .orElseThrow(() -> new MissingPaymentConfigurationException(provider, organizationId));
     }
 
-    public PaymentConfig getConfig(PaymentProvider provider) {
-        Integer organizationId = CurrentUser.getOrganizationId();
-        return getConfig(organizationId, provider);
-    }
 }


### PR DESCRIPTION
## Summary
- require explicit organization context when resolving payment configurations for webhook handlers
- remove the CurrentUser-dependent lookup that broke unauthenticated webhook calls

## Testing
- `mvn test` *(fails: unable to download Spring Boot parent due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d42e841af88324842363d63fa20ace