### PR TITLE
Fix purchase cancellation and adjust cache keys

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
@@ -33,7 +33,7 @@ public class ClienteService {
     private final ClienteMapper clienteMapper;
     private final PlanoService planoService;
 
-    @Cacheable(value = "clientes", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId() + '-' + #pesquisa.hashCode()")
+    @Cacheable(value = "clientes", key = "T(com.AIT.Optimanage.Support.CacheKeyResolver).userScopedKey(#pesquisa)")
     @Transactional(readOnly = true)
     public Page<ClienteResponse> listarClientes(ClienteSearch pesquisa) {
         User loggedUser = CurrentUser.get();

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -56,12 +56,10 @@ import org.springframework.transaction.annotation.Transactional;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 
-import com.AIT.Optimanage.Repositories.Compra.CompraFilters;
-import com.AIT.Optimanage.Repositories.FilterBuilder;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -91,7 +89,7 @@ public class CompraService {
     private final InventoryService inventoryService;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Cacheable(value = "compras", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId() + '-' + #pesquisa.hashCode()")
+    @Cacheable(value = "compras", key = "T(com.AIT.Optimanage.Support.CacheKeyResolver).userScopedKey(#pesquisa)")
     @Transactional(readOnly = true)
     public Page<CompraResponseDTO> listarCompras(CompraSearch pesquisa) {
         User loggedUser = CurrentUser.get();
@@ -322,17 +320,21 @@ public class CompraService {
         Plano plano = obterPlanoAtual();
         garantirPagamentosHabilitados(plano);
         Compra compra = getCompra(idCompra);
+        if (compra.getStatus() == StatusCompra.CANCELADO) {
+            throw new IllegalArgumentException("Não é possível estornar uma compra cancelada.");
+        }
         boolean deveReverterEstoque = compra.getStatus() == StatusCompra.CONCRETIZADO
                 || compra.getStatus() == StatusCompra.PAGO;
         if (deveReverterEstoque) {
             reverterEstoqueCompra(compra, "Estorno integral da compra #" + compra.getId());
-            atualizarStatus(compra, StatusCompra.AGUARDANDO_PAG);
         }
-        compra.setValorPendente(compra.getValorFinal());
+        BigDecimal valorFinal = Optional.ofNullable(compra.getValorFinal()).orElse(BigDecimal.ZERO);
+        compra.setValorPendente(valorFinal);
         Optional.ofNullable(compra.getPagamentos()).orElseGet(List::of).forEach(pagamento
                 -> { if (pagamento.getStatusPagamento() == StatusPagamento.PAGO)
                         { pagamentoCompraService.estornarPagamento(pagamento); }
                     });
+        compra.setStatus(StatusCompra.AGUARDANDO_PAG);
         Compra salvo = compraRepository.save(compra);
         return compraMapper.toResponse(salvo);
     }
@@ -430,6 +432,18 @@ public class CompraService {
         if (deveReverterEstoqueAoCancelar(compra, statusAnterior)) {
             reverterEstoqueCompra(compra, "Cancelamento da compra #" + compra.getId());
         }
+
+        Optional.ofNullable(compra.getPagamentos()).orElseGet(List::of).stream()
+                .filter(Objects::nonNull)
+                .forEach(pagamento -> {
+                    if (pagamento.getStatusPagamento() == StatusPagamento.PAGO) {
+                        pagamentoCompraService.estornarPagamento(pagamento);
+                    } else if (pagamento.getStatusPagamento() == StatusPagamento.PENDENTE) {
+                        pagamentoCompraService.cancelarPagamento(pagamento);
+                    }
+                });
+
+        compra.setValorPendente(BigDecimal.ZERO);
 
         compra.setStatus(StatusCompra.CANCELADO);
         Compra salvo = compraRepository.save(compra);

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/PagamentoCompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/PagamentoCompraService.java
@@ -110,4 +110,10 @@ public class PagamentoCompraService {
         compraPagamento.setStatusPagamento(StatusPagamento.ESTORNADO);
         pagamentoCompraRepository.save(compraPagamento);
     }
+
+    public void cancelarPagamento(CompraPagamento pagamento) {
+        CompraPagamento compraPagamento = listarUmPagamento(pagamento.getId());
+        compraPagamento.setStatusPagamento(StatusPagamento.ESTORNADO);
+        pagamentoCompraRepository.save(compraPagamento);
+    }
 }

--- a/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Fornecedor/FornecedorService.java
@@ -33,7 +33,7 @@ public class FornecedorService {
     private final FornecedorMapper fornecedorMapper;
     private final PlanoService planoService;
 
-    @Cacheable(value = "fornecedores", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId() + '-' + #pesquisa.hashCode()")
+    @Cacheable(value = "fornecedores", key = "T(com.AIT.Optimanage.Support.CacheKeyResolver).userScopedKey(#pesquisa)")
     @Transactional(readOnly = true)
     public Page<FornecedorResponse> listarFornecedores(FornecedorSearch pesquisa) {
         User loggedUser = CurrentUser.get();

--- a/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
@@ -30,7 +30,7 @@ public class ProdutoService {
     private final ProdutoMapper produtoMapper;
     private final PlanoService planoService;
 
-    @Cacheable(value = "produtos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId() + '-' + #pesquisa.hashCode()")
+    @Cacheable(value = "produtos", key = "T(com.AIT.Optimanage.Support.CacheKeyResolver).userScopedKey(#pesquisa)")
     public Page<ProdutoResponse> listarProdutos(Search pesquisa) {
         Integer organizationId = CurrentUser.getOrganizationId();
         if (organizationId == null) {

--- a/src/main/java/com/AIT/Optimanage/Services/ServicoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ServicoService.java
@@ -30,7 +30,7 @@ public class ServicoService {
     private final ServicoMapper servicoMapper;
     private final PlanoService planoService;
 
-    @Cacheable(value = "servicos", key = "T(com.AIT.Optimanage.Security.CurrentUser).get().getId() + '-' + #pesquisa.hashCode()")
+    @Cacheable(value = "servicos", key = "T(com.AIT.Optimanage.Support.CacheKeyResolver).userScopedKey(#pesquisa)")
     public Page<ServicoResponse> listarServicos(Search pesquisa) {
         User loggedUser = CurrentUser.get();
         Integer organizationId = CurrentUser.getOrganizationId();

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -95,7 +95,7 @@ public class VendaService {
     private final InventoryService inventoryService;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Cacheable(value = "vendas", key = "#loggedUser.id + '-' + #pesquisa.hashCode()")
+    @Cacheable(value = "vendas", key = "T(com.AIT.Optimanage.Support.CacheKeyResolver).userScopedKey(#loggedUser, #pesquisa)")
     @Transactional(readOnly = true)
     public Page<VendaResponseDTO> listarVendas(User loggedUser, VendaSearch pesquisa) {
         Integer organizationId = loggedUser != null ? loggedUser.getTenantId() : CurrentUser.getOrganizationId();

--- a/src/main/java/com/AIT/Optimanage/Support/CacheKeyResolver.java
+++ b/src/main/java/com/AIT/Optimanage/Support/CacheKeyResolver.java
@@ -1,0 +1,50 @@
+package com.AIT.Optimanage.Support;
+
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Security.CurrentUser;
+
+import java.util.Objects;
+import java.util.Optional;
+public final class CacheKeyResolver {
+
+    private CacheKeyResolver() {
+    }
+
+    public static String userScopedKey(Object... segments) {
+        Integer userId = Optional.ofNullable(CurrentUser.get())
+                .map(User::getId)
+                .orElse(null);
+        return compose("user", userId, segments);
+    }
+
+    public static String userScopedKey(Object fallbackUser, Object... segments) {
+        Integer userId = Optional.ofNullable(CurrentUser.get())
+                .map(User::getId)
+                .orElseGet(() -> extractUserId(fallbackUser));
+        return compose("user", userId, segments);
+    }
+
+    public static String organizationScopedKey(Object... segments) {
+        Integer organizationId = CurrentUser.getOrganizationId();
+        return compose("org", organizationId, segments);
+    }
+
+    private static String compose(String scope, Object scopeId, Object... segments) {
+        String base = scope + ':' + Objects.toString(scopeId, "none");
+        if (segments == null || segments.length == 0) {
+            return base;
+        }
+        int hash = Objects.hash((Object[]) segments);
+        return base + ':' + Integer.toHexString(hash);
+    }
+
+    private static Integer extractUserId(Object candidate) {
+        if (candidate instanceof User user) {
+            return user.getId();
+        }
+        if (candidate instanceof Number number) {
+            return number.intValue();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add a cache key resolver so cached listings use safe user scoped keys
- adjust purchase cancellation and full refund flows to zero pending balances and estornar all payments
- block refunds for cancelled purchases and reuse payment cancellation helper

## Testing
- `./mvnw test` *(fails: non-resolvable parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d43d4040b48324b1c9cddadc38a299