### PR TITLE
Add audit trail for plan quota changes and sales actions

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoResponse.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -26,5 +28,9 @@ public class PlanoResponse {
     private Boolean pagamentosHabilitados;
     private Boolean suportePrioritario;
     private Boolean monitoramentoEstoqueHabilitado;
+    private Integer createdBy;
+    private Integer updatedBy;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }
 

--- a/src/main/java/com/AIT/Optimanage/Models/Audit/AuditTrail.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Audit/AuditTrail.java
@@ -1,0 +1,34 @@
+package com.AIT.Optimanage.Models.Audit;
+
+import com.AIT.Optimanage.Models.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a domain action that must be tracked for compliance/auditability purposes.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "audit_trail")
+public class AuditTrail extends AuditableEntity {
+
+    @Column(name = "entity_type", nullable = false, length = 100)
+    private String entityType;
+
+    @Column(name = "entity_id", nullable = false)
+    private Integer entityId;
+
+    @Column(name = "action", nullable = false, length = 150)
+    private String action;
+
+    @Column(name = "details", columnDefinition = "TEXT")
+    private String details;
+}

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaResponseDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaResponseDTO.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -38,4 +39,8 @@ public class VendaResponseDTO {
     private List<VendaProdutoResponseDTO> produtos;
     private List<VendaServicoResponseDTO> servicos;
     private List<VendaPagamentoResponseDTO> pagamentos;
+    private Integer createdBy;
+    private Integer updatedBy;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Audit/AuditTrailRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Audit/AuditTrailRepository.java
@@ -1,0 +1,9 @@
+package com.AIT.Optimanage.Repositories.Audit;
+
+import com.AIT.Optimanage.Models.Audit.AuditTrail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AuditTrailRepository extends JpaRepository<AuditTrail, Integer> {
+}

--- a/src/main/java/com/AIT/Optimanage/Services/AuditTrailService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/AuditTrailService.java
@@ -1,0 +1,45 @@
+package com.AIT.Optimanage.Services;
+
+import com.AIT.Optimanage.Models.Audit.AuditTrail;
+import com.AIT.Optimanage.Repositories.Audit.AuditTrailRepository;
+import com.AIT.Optimanage.Security.CurrentUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuditTrailService {
+
+    private final AuditTrailRepository auditTrailRepository;
+
+    public void recordPlanQuotaChange(Integer planId, String details) {
+        record("PLANO", planId, "ALTERACAO_COTAS", details);
+    }
+
+    public void recordDiscountRuleChange(Integer entityId, String details) {
+        record("DESCONTO", entityId, "ALTERACAO_REGRAS_DESCONTO", details);
+    }
+
+    public void recordSaleCancellation(Integer vendaId, String details) {
+        record("VENDA", vendaId, "CANCELAMENTO_VENDA", details);
+    }
+
+    public void record(String entityType, Integer entityId, String action, String details) {
+        if (entityId == null) {
+            return;
+        }
+        AuditTrail entry = AuditTrail.builder()
+                .entityType(entityType)
+                .entityId(entityId)
+                .action(action)
+                .details(details)
+                .build();
+
+        Integer organizationId = CurrentUser.getOrganizationId();
+        if (organizationId != null) {
+            entry.setTenantId(organizationId);
+        }
+
+        auditTrailRepository.save(entry);
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Services/AuditTrailService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/AuditTrailService.java
@@ -3,6 +3,7 @@ package com.AIT.Optimanage.Services;
 import com.AIT.Optimanage.Models.Audit.AuditTrail;
 import com.AIT.Optimanage.Repositories.Audit.AuditTrailRepository;
 import com.AIT.Optimanage.Security.CurrentUser;
+import com.AIT.Optimanage.Support.TenantContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -35,9 +36,13 @@ public class AuditTrailService {
                 .details(details)
                 .build();
 
-        Integer organizationId = CurrentUser.getOrganizationId();
-        if (organizationId != null) {
-            entry.setTenantId(organizationId);
+        Integer tenantId = TenantContext.getTenantId();
+        if (tenantId == null) {
+            tenantId = CurrentUser.getOrganizationId();
+        }
+
+        if (tenantId != null) {
+            entry.setTenantId(tenantId);
         }
 
         auditTrailRepository.save(entry);

--- a/src/main/resources/db/migration/V5__create_audit_trail_table.sql
+++ b/src/main/resources/db/migration/V5__create_audit_trail_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE audit_trail (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    organization_id INT NOT NULL,
+    entity_type VARCHAR(100) NOT NULL,
+    entity_id INT NOT NULL,
+    action VARCHAR(150) NOT NULL,
+    details TEXT,
+    created_by INT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_by INT,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_audit_trail_org_entity ON audit_trail (organization_id, entity_type);
+CREATE INDEX idx_audit_trail_entity_id ON audit_trail (entity_id);


### PR DESCRIPTION
## Summary
- add an audit trail entity, repository and service to persist compliance events
- record plan quota modifications, discount rule updates and sale cancellations in the audit trail
- expose audit metadata on plan and sale responses to improve traceability

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d531c3dee08324890005b86802eacc