### PR TITLE
Add churn score metric to clients

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteResponse.java
@@ -31,4 +31,5 @@ public class ClienteResponse {
     private String site;
     private String informacoesAdicionais;
     private BigDecimal lifetimeValue;
+    private BigDecimal churnScore;
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
@@ -46,6 +46,9 @@ public class Cliente extends AuditableEntity implements OwnableEntity {
     @Column(name = "lifetime_value", nullable = false, precision = 12, scale = 2)
     @Builder.Default
     private BigDecimal lifetimeValue = BigDecimal.ZERO;
+    @Column(name = "churn_score", nullable = false, precision = 5, scale = 4)
+    @Builder.Default
+    private BigDecimal churnScore = BigDecimal.ZERO;
     @Column(length = 64)
     private String nome;
     @Column(length = 55)

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -79,6 +79,14 @@ public interface VendaRepository extends JpaRepository<Venda, Integer> {
                                                @Param("clienteId") Integer clienteId,
                                                @Param("status") StatusVenda status);
 
+    @Query("SELECT COUNT(v) FROM Venda v " +
+            "WHERE v.organizationId = :organizationId " +
+            "AND v.cliente.id = :clienteId " +
+            "AND v.status = :status")
+    long countByClienteAndStatus(@Param("organizationId") Integer organizationId,
+                                 @Param("clienteId") Integer clienteId,
+                                 @Param("status") StatusVenda status);
+
     @Query("""
             SELECT v FROM Venda v
             WHERE v.organizationId = :organizationId

--- a/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Venda/VendaService.java
@@ -200,7 +200,7 @@ public class VendaService {
 
         publicarVendaRegistrada(novaVenda, vendaProdutos, loggedUser);
 
-        atualizarLifetimeValueCliente(novaVenda);
+        atualizarMetricasCliente(novaVenda);
 
         contadorService.IncrementarContador(Tabela.VENDA);
         return vendaMapper.toResponse(novaVenda);
@@ -276,7 +276,7 @@ public class VendaService {
         }
 
         Venda salvo = vendaRepository.save(venda);
-        atualizarLifetimeValueCliente(salvo);
+        atualizarMetricasCliente(salvo);
 
         if (descontoGeralAnterior.compareTo(descontoGeralAtualizado) != 0) {
             auditTrailService.recordDiscountRuleChange(salvo.getId(),
@@ -295,7 +295,7 @@ public class VendaService {
             throw new IllegalArgumentException("Esta venda já foi confirmada.");
         }
         Venda salvo = vendaRepository.save(venda);
-        atualizarLifetimeValueCliente(salvo);
+        atualizarMetricasCliente(salvo);
         publicarVendaRegistrada(salvo, salvo.getVendaProdutos(), loggedUser);
         return vendaMapper.toResponse(salvo);
     }
@@ -310,7 +310,7 @@ public class VendaService {
 
         atualizarVendaPosPagamento(loggedUser, venda);
         Venda salvo = vendaRepository.save(venda);
-        atualizarLifetimeValueCliente(salvo);
+        atualizarMetricasCliente(salvo);
         return vendaMapper.toResponse(salvo);
     }
 
@@ -343,7 +343,7 @@ public class VendaService {
         pagamentoVendaService.lancarPagamento(venda, pagamentoDTO);
         atualizarVendaPosPagamento(loggedUser, venda);
         Venda salvo = vendaRepository.save(venda);
-        atualizarLifetimeValueCliente(salvo);
+        atualizarMetricasCliente(salvo);
         return vendaMapper.toResponse(salvo);
     }
 
@@ -372,7 +372,7 @@ public class VendaService {
 
         atualizarVendaPosPagamento(loggedUser, venda);
         Venda salvo = vendaRepository.save(venda);
-        atualizarLifetimeValueCliente(salvo);
+        atualizarMetricasCliente(salvo);
         return vendaMapper.toResponse(salvo);
     }
 
@@ -398,7 +398,7 @@ public class VendaService {
         }
         atualizarStatus(venda, StatusVenda.CANCELADA);
         Venda salvo = vendaRepository.save(venda);
-        atualizarLifetimeValueCliente(salvo);
+        atualizarMetricasCliente(salvo);
         return vendaMapper.toResponse(salvo);
     }
 
@@ -442,7 +442,7 @@ public class VendaService {
             }
         }
         Venda salvo = vendaRepository.save(venda);
-        atualizarLifetimeValueCliente(salvo);
+        atualizarMetricasCliente(salvo);
         return vendaMapper.toResponse(salvo);
     }
 
@@ -470,7 +470,7 @@ public class VendaService {
         venda.setDuracaoEstimada(duracao);
         venda.setStatus(StatusVenda.AGENDADA);
         Venda salvo = vendaRepository.save(venda);
-        atualizarLifetimeValueCliente(salvo);
+        atualizarMetricasCliente(salvo);
         return vendaMapper.toResponse(salvo);
     }
 
@@ -491,7 +491,7 @@ public class VendaService {
             throw new IllegalArgumentException("Não é possível finalizar um agendamento que não está agendado.");
         }
         Venda salvo = vendaRepository.save(venda);
-        atualizarLifetimeValueCliente(salvo);
+        atualizarMetricasCliente(salvo);
         return vendaMapper.toResponse(salvo);
     }
 
@@ -506,7 +506,7 @@ public class VendaService {
             venda.setStatus(StatusVenda.CONCRETIZADA);
         }
         Venda salvo = vendaRepository.save(venda);
-        atualizarLifetimeValueCliente(salvo);
+        atualizarMetricasCliente(salvo);
         return vendaMapper.toResponse(salvo);
     }
 
@@ -528,6 +528,7 @@ public class VendaService {
         Venda salvo = vendaRepository.save(venda);
         auditTrailService.recordSaleCancellation(salvo.getId(),
                 String.format("Venda cancelada por usuário %d", Optional.ofNullable(loggedUser).map(User::getId).orElse(null)));
+        atualizarMetricasCliente(salvo);
         return vendaMapper.toResponse(salvo);
     }
 
@@ -659,9 +660,9 @@ public class VendaService {
                         venda.getId(), descricao));
     }
 
-    private void atualizarLifetimeValueCliente(Venda venda) {
+    private void atualizarMetricasCliente(Venda venda) {
         Optional.ofNullable(venda)
                 .map(Venda::getCliente)
-                .ifPresent(clienteService::atualizarLifetimeValue);
+                .ifPresent(clienteService::atualizarMetricasCliente);
     }
 }


### PR DESCRIPTION
## Summary
- add churn score field to Cliente and expose it through the response DTO
- recalculate customer metrics (lifetime value and churn score) whenever sales are updated, including cancellations
- provide repository support for counting sales by status to drive churn score updates

## Testing
- ./mvnw -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68d6a17a3f4c83248df45d2d99ea9d19