### PR TITLE
Add average ticket metric to client

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ClienteResponse.java
@@ -32,4 +32,5 @@ public class ClienteResponse {
     private String informacoesAdicionais;
     private BigDecimal lifetimeValue;
     private BigDecimal churnScore;
+    private BigDecimal averageTicket;
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
@@ -49,6 +49,9 @@ public class Cliente extends AuditableEntity implements OwnableEntity {
     @Column(name = "churn_score", nullable = false, precision = 5, scale = 4)
     @Builder.Default
     private BigDecimal churnScore = BigDecimal.ZERO;
+    @Column(name = "average_ticket", nullable = false, precision = 12, scale = 2)
+    @Builder.Default
+    private BigDecimal averageTicket = BigDecimal.ZERO;
     @Column(length = 64)
     private String nome;
     @Column(length = 55)

--- a/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Cliente/ClienteService.java
@@ -102,6 +102,7 @@ public class ClienteService {
         cliente.setDataCadastro(LocalDate.now());
         cliente.setLifetimeValue(BigDecimal.ZERO);
         cliente.setChurnScore(BigDecimal.ZERO);
+        cliente.setAverageTicket(BigDecimal.ZERO);
         validarCliente(cliente);
         Cliente salvo = clienteRepository.save(cliente);
         return clienteMapper.toResponse(salvo);
@@ -123,6 +124,7 @@ public class ClienteService {
         cliente.setTenantId(clienteSalvo.getOrganizationId());
         cliente.setLifetimeValue(clienteSalvo.getLifetimeValue());
         cliente.setChurnScore(clienteSalvo.getChurnScore());
+        cliente.setAverageTicket(clienteSalvo.getAverageTicket());
         validarCliente(cliente);
         Cliente atualizado = clienteRepository.save(cliente);
         return clienteMapper.toResponse(atualizado);
@@ -238,6 +240,12 @@ public class ClienteService {
 
         cliente.setLifetimeValue(lifetimeValue);
         cliente.setChurnScore(churnScore);
+        BigDecimal averageTicket = BigDecimal.ZERO;
+        if (vendasConcretizadas > 0) {
+            averageTicket = lifetimeValue
+                    .divide(BigDecimal.valueOf(vendasConcretizadas), 2, RoundingMode.HALF_UP);
+        }
+        cliente.setAverageTicket(averageTicket);
         clienteRepository.save(cliente);
     }
 

--- a/src/main/resources/db/migration/V8__add_average_ticket_to_cliente.sql
+++ b/src/main/resources/db/migration/V8__add_average_ticket_to_cliente.sql
@@ -1,0 +1,9 @@
+ALTER TABLE cliente
+    ADD COLUMN average_ticket DECIMAL(12, 2) NOT NULL DEFAULT 0;
+
+UPDATE cliente
+SET average_ticket = 0
+WHERE average_ticket IS NULL;
+
+ALTER TABLE cliente
+    ALTER COLUMN average_ticket DROP DEFAULT;


### PR DESCRIPTION
## Summary
- add the averageTicket metric to the Cliente entity and expose it in responses
- ensure client creation, editing, and metric recalculation manage the average ticket value based on concretized sales
- provide a database migration to persist the new average ticket column

## Testing
- ./mvnw -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68d6cdcded448324a41ffeb236ebd91d