### PR TITLE
Add scheduled product turnover metrics

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoQuotaResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoQuotaResponse.java
@@ -26,6 +26,7 @@ public class PlanoQuotaResponse {
     private Boolean pagamentosHabilitados;
     private Boolean suportePrioritario;
     private Boolean monitoramentoEstoqueHabilitado;
+    private Boolean metricasProdutoHabilitadas;
     private Integer usuariosUtilizados;
     private Integer usuariosRestantes;
     private Integer produtosUtilizados;

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoRequest.java
@@ -61,5 +61,8 @@ public class PlanoRequest {
 
     @NotNull
     private Boolean monitoramentoEstoqueHabilitado;
+
+    @NotNull
+    private Boolean metricasProdutoHabilitadas;
 }
 

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/PlanoResponse.java
@@ -28,6 +28,7 @@ public class PlanoResponse {
     private Boolean pagamentosHabilitados;
     private Boolean suportePrioritario;
     private Boolean monitoramentoEstoqueHabilitado;
+    private Boolean metricasProdutoHabilitadas;
     private Integer createdBy;
     private Integer updatedBy;
     private LocalDateTime createdAt;

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/ProdutoResponse.java
@@ -28,4 +28,5 @@ public class ProdutoResponse {
     private Boolean ativo;
     private Integer estoqueMinimo;
     private Integer prazoReposicaoDias;
+    private BigDecimal rotatividade;
 }

--- a/src/main/java/com/AIT/Optimanage/Mappers/ProdutoMapper.java
+++ b/src/main/java/com/AIT/Optimanage/Mappers/ProdutoMapper.java
@@ -13,6 +13,7 @@ import org.mapstruct.ReportingPolicy;
 public interface ProdutoMapper {
 
     @Mapping(target = "fornecedor", source = "fornecedorId", qualifiedByName = "idToFornecedor")
+    @Mapping(target = "rotatividade", ignore = true)
     Produto toEntity(ProdutoRequest request);
 
     @Mapping(target = "fornecedorId", source = "fornecedor.id")

--- a/src/main/java/com/AIT/Optimanage/Models/Plano.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Plano.java
@@ -59,4 +59,8 @@ public class Plano extends AuditableEntity {
     @Column(nullable = false)
     private Boolean monitoramentoEstoqueHabilitado = false;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean metricasProdutoHabilitadas = false;
+
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Produto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Produto.java
@@ -55,6 +55,10 @@ public class Produto extends AuditableEntity implements OwnableEntity {
     @Column(nullable = false)
     private Boolean ativo = true;
 
+    @Builder.Default
+    @Column(nullable = false, precision = 10, scale = 4)
+    private BigDecimal rotatividade = BigDecimal.ZERO;
+
     @OneToMany(mappedBy = "produto", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Compatibilidade> compatibilidades;
 

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -3,6 +3,7 @@ package com.AIT.Optimanage.Repositories.Venda;
 import com.AIT.Optimanage.Models.Enums.FormaPagamento;
 import com.AIT.Optimanage.Models.Venda.Related.StatusVenda;
 import com.AIT.Optimanage.Models.Venda.Venda;
+import com.AIT.Optimanage.Repositories.Venda.projection.ProdutoQuantidadeProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -70,6 +71,16 @@ public interface VendaRepository extends JpaRepository<Venda, Integer> {
             "JOIN FETCH vp.produto p " +
             "WHERE v.organizationId = :organizationId")
     List<Venda> findAllWithProdutosByOrganization(@Param("organizationId") Integer organizationId);
+
+    @Query("SELECT vp.produto.id AS produtoId, SUM(vp.quantidade) AS totalQuantidade " +
+            "FROM Venda v JOIN v.vendaProdutos vp " +
+            "WHERE v.organizationId = :organizationId " +
+            "AND v.status = com.AIT.Optimanage.Models.Venda.Related.StatusVenda.CONCRETIZADA " +
+            "AND v.dataEfetuacao BETWEEN :inicio AND :fim " +
+            "GROUP BY vp.produto.id")
+    List<ProdutoQuantidadeProjection> sumQuantidadeVendidaPorProduto(@Param("organizationId") Integer organizationId,
+                                                                     @Param("inicio") LocalDate inicio,
+                                                                     @Param("fim") LocalDate fim);
 
     @Query("SELECT COALESCE(SUM(v.valorFinal), 0) FROM Venda v " +
             "WHERE v.organizationId = :organizationId " +

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/projection/ProdutoQuantidadeProjection.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/projection/ProdutoQuantidadeProjection.java
@@ -1,0 +1,7 @@
+package com.AIT.Optimanage.Repositories.Venda.projection;
+
+public interface ProdutoQuantidadeProjection {
+    Integer getProdutoId();
+
+    Long getTotalQuantidade();
+}

--- a/src/main/java/com/AIT/Optimanage/Services/PlanoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/PlanoService.java
@@ -87,6 +87,8 @@ public class PlanoService {
         existente.setSuportePrioritario(request.getSuportePrioritario());
         registrarAlteracaoQuota(quotaChanges, "monitoramentoEstoqueHabilitado", existente.getMonitoramentoEstoqueHabilitado(), request.getMonitoramentoEstoqueHabilitado());
         existente.setMonitoramentoEstoqueHabilitado(request.getMonitoramentoEstoqueHabilitado());
+        registrarAlteracaoQuota(quotaChanges, "metricasProdutoHabilitadas", existente.getMetricasProdutoHabilitadas(), request.getMetricasProdutoHabilitadas());
+        existente.setMetricasProdutoHabilitadas(request.getMetricasProdutoHabilitadas());
 
         if (!Objects.equals(existente.getNome(), request.getNome())) {
             existente.setNome(request.getNome());
@@ -167,6 +169,7 @@ public class PlanoService {
                 .pagamentosHabilitados(plano.getPagamentosHabilitados())
                 .suportePrioritario(plano.getSuportePrioritario())
                 .monitoramentoEstoqueHabilitado(plano.getMonitoramentoEstoqueHabilitado())
+                .metricasProdutoHabilitadas(plano.getMetricasProdutoHabilitadas())
                 .usuariosUtilizados(Math.toIntExact(usuariosAtivos))
                 .usuariosRestantes(calcularRestante(plano.getMaxUsuarios(), usuariosAtivos))
                 .produtosUtilizados(Math.toIntExact(produtosAtivos))
@@ -188,6 +191,17 @@ public class PlanoService {
                 .map(Organization::getPlanoAtivoId)
                 .flatMap(planoRepository::findById)
                 .map(Plano::getMonitoramentoEstoqueHabilitado)
+                .orElse(false);
+    }
+
+    public boolean isMetricasProdutoHabilitadas(Integer organizationId) {
+        if (organizationId == null) {
+            return false;
+        }
+        return organizationRepository.findById(organizationId)
+                .map(Organization::getPlanoAtivoId)
+                .flatMap(planoRepository::findById)
+                .map(Plano::getMetricasProdutoHabilitadas)
                 .orElse(false);
     }
 

--- a/src/main/java/com/AIT/Optimanage/Services/ProdutoMetricsService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ProdutoMetricsService.java
@@ -1,0 +1,98 @@
+package com.AIT.Optimanage.Services;
+
+import com.AIT.Optimanage.Models.Produto;
+import com.AIT.Optimanage.Repositories.ProdutoRepository;
+import com.AIT.Optimanage.Repositories.Venda.VendaRepository;
+import com.AIT.Optimanage.Repositories.Venda.projection.ProdutoQuantidadeProjection;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProdutoMetricsService {
+
+    private static final int LOOKBACK_DAYS = 90;
+
+    private final ProdutoRepository produtoRepository;
+    private final VendaRepository vendaRepository;
+    private final PlanoService planoService;
+    private final Clock clock;
+
+    @Scheduled(cron = "${product.metrics.cron:0 0 5 * * SAT,SUN}")
+    @Transactional
+    public void atualizarMetricasAgendado() {
+        List<Produto> todosProdutos = produtoRepository.findAll();
+        Map<Integer, List<Produto>> produtosPorOrganizacao = todosProdutos.stream()
+                .filter(produto -> produto.getOrganizationId() != null)
+                .filter(produto -> Boolean.TRUE.equals(produto.getAtivo()))
+                .collect(Collectors.groupingBy(Produto::getOrganizationId));
+
+        produtosPorOrganizacao.forEach((organizationId, produtos) -> {
+            try {
+                if (!planoService.isMetricasProdutoHabilitadas(organizationId)) {
+                    return;
+                }
+                recalcularRotatividade(organizationId, produtos);
+            } catch (Exception ex) {
+                log.error("Falha ao atualizar rotatividade dos produtos para a organização {}", organizationId, ex);
+            }
+        });
+    }
+
+    @Transactional
+    public void recalcularRotatividade(Integer organizationId, List<Produto> produtos) {
+        if (organizationId == null || produtos == null || produtos.isEmpty()) {
+            return;
+        }
+        if (!planoService.isMetricasProdutoHabilitadas(organizationId)) {
+            return;
+        }
+
+        LocalDate fim = LocalDate.now(clock);
+        LocalDate inicio = fim.minusDays(LOOKBACK_DAYS - 1L);
+
+        Map<Integer, Long> quantidadeVendidaPorProduto = vendaRepository
+                .sumQuantidadeVendidaPorProduto(organizationId, inicio, fim)
+                .stream()
+                .collect(Collectors.toMap(ProdutoQuantidadeProjection::getProdutoId,
+                        ProdutoQuantidadeProjection::getTotalQuantidade));
+
+        produtos.stream()
+                .filter(produto -> produto.getId() != null)
+                .forEach(produto -> {
+                    long quantidadeVendida = quantidadeVendidaPorProduto.getOrDefault(produto.getId(), 0L);
+                    BigDecimal rotatividade = calcularRotatividade(produto, quantidadeVendida);
+                    produto.setRotatividade(rotatividade);
+                });
+
+        produtoRepository.saveAll(produtos);
+    }
+
+    private BigDecimal calcularRotatividade(Produto produto, long quantidadeVendida) {
+        if (quantidadeVendida <= 0) {
+            return BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP);
+        }
+        int estoqueAtual = Optional.ofNullable(produto.getQtdEstoque()).orElse(0);
+        BigDecimal vendidos = BigDecimal.valueOf(quantidadeVendida);
+        BigDecimal estoqueMedio = vendidos
+                .add(BigDecimal.valueOf(estoqueAtual))
+                .divide(BigDecimal.valueOf(2), 4, RoundingMode.HALF_UP);
+        if (estoqueMedio.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP);
+        }
+        return vendidos.divide(estoqueMedio, 4, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/ProdutoService.java
@@ -20,6 +20,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
 import java.util.Optional;
 
 @Service
@@ -84,6 +86,7 @@ public class ProdutoService {
         Produto produto = produtoMapper.toEntity(request);
         produto.setId(produtoSalvo.getId());
         produto.setTenantId(produtoSalvo.getOrganizationId());
+        produto.setRotatividade(produtoSalvo.getRotatividade());
         aplicarValoresPadrao(produto);
         Produto atualizado = produtoRepository.save(produto);
         return produtoMapper.toResponse(atualizado);
@@ -158,6 +161,9 @@ public class ProdutoService {
         }
         if (produto.getPrazoReposicaoDias() == null) {
             produto.setPrazoReposicaoDias(0);
+        }
+        if (produto.getRotatividade() == null) {
+            produto.setRotatividade(BigDecimal.ZERO);
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,8 @@ schedule.token-cleanup.cron=0 0 0 * * *
 
 schedule.key-rotation.cron=0 0 0 * * *
 
+product.metrics.cron=0 0 5 * * SAT,SUN
+
 # Global API prefix for all endpoints
 server.servlet.context-path=/api/v1
 


### PR DESCRIPTION
## Summary
- add a rotatividade field to Produto and expose it through API responses
- extend Plano to support enabling product metrics and propagate the new flag through service DTOs
- create a weekend scheduler that recalculates product turnover for organizations with the feature and add the supporting sales aggregation

## Testing
- `./mvnw -q -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68da6c8317dc8324b86dc90db514fec9