### PR TITLE
Add aggregated financial summaries per organization

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
@@ -41,15 +41,17 @@ public class AnalyticsService {
         if (organizationId == null) {
             throw new EntityNotFoundException("Organização não encontrada");
         }
-        BigDecimal totalVendas = vendaRepository.findAll().stream()
-                .filter(v -> organizationId.equals(v.getOrganizationId()))
-                .map(Venda::getValorFinal)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal totalVendas = BigDecimal.ZERO;
+        BigDecimal vendasResult = vendaRepository.sumValorFinalByOrganization(organizationId);
+        if (vendasResult != null) {
+            totalVendas = vendasResult;
+        }
 
-        BigDecimal totalCompras = compraRepository.findAll().stream()
-                .filter(c -> organizationId.equals(c.getOrganizationId()))
-                .map(Compra::getValorFinal)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal totalCompras = BigDecimal.ZERO;
+        BigDecimal comprasResult = compraRepository.sumValorFinalByOrganization(organizationId);
+        if (comprasResult != null) {
+            totalCompras = comprasResult;
+        }
 
         BigDecimal lucro = totalVendas.subtract(totalCompras);
         return new ResumoDTO(totalVendas, totalCompras, lucro);

--- a/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
@@ -1,11 +1,13 @@
 package com.AIT.Optimanage.Repositories.Compra;
 
 import com.AIT.Optimanage.Models.Compra.Compra;
+import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -25,4 +27,11 @@ public interface CompraRepository extends JpaRepository<Compra, Integer>, JpaSpe
                                         @Param("userId") Integer userId,
                                         @Param("inicio") LocalDate inicio,
                                         @Param("fim") LocalDate fim);
+
+    @Query("SELECT SUM(c.valorFinal) FROM Compra c WHERE c.organizationId = :organizationId")
+    BigDecimal sumValorFinalByOrganization(@Param("organizationId") Integer organizationId);
+
+    @Query("SELECT SUM(c.valorFinal) FROM Compra c WHERE c.organizationId = :organizationId AND c.status = :status")
+    BigDecimal sumValorFinalByOrganizationAndStatus(@Param("organizationId") Integer organizationId,
+                                                    @Param("status") StatusCompra status);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -91,6 +91,13 @@ public interface VendaRepository extends JpaRepository<Venda, Integer>, JpaSpeci
                                                @Param("clienteId") Integer clienteId,
                                                @Param("status") StatusVenda status);
 
+    @Query("SELECT SUM(v.valorFinal) FROM Venda v WHERE v.organizationId = :organizationId")
+    BigDecimal sumValorFinalByOrganization(@Param("organizationId") Integer organizationId);
+
+    @Query("SELECT SUM(v.valorFinal) FROM Venda v WHERE v.organizationId = :organizationId AND v.status = :status")
+    BigDecimal sumValorFinalByOrganizationAndStatus(@Param("organizationId") Integer organizationId,
+                                                    @Param("status") StatusVenda status);
+
     @Query("SELECT COUNT(v) FROM Venda v " +
             "WHERE v.organizationId = :organizationId " +
             "AND v.cliente.id = :clienteId " +

--- a/src/test/java/com/AIT/Optimanage/Analytics/AnalyticsServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Analytics/AnalyticsServiceTest.java
@@ -1,0 +1,123 @@
+package com.AIT.Optimanage.Analytics;
+
+import com.AIT.Optimanage.Analytics.DTOs.ResumoDTO;
+import com.AIT.Optimanage.Models.User.Role;
+import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Repositories.Compra.CompraRepository;
+import com.AIT.Optimanage.Repositories.Venda.VendaRepository;
+import com.AIT.Optimanage.Security.CurrentUser;
+import com.AIT.Optimanage.Services.InventoryMonitoringService;
+import com.AIT.Optimanage.Services.PlanoService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyticsServiceTest {
+
+    @Mock
+    private VendaRepository vendaRepository;
+    @Mock
+    private CompraRepository compraRepository;
+    @Mock
+    private InventoryMonitoringService inventoryMonitoringService;
+    @Mock
+    private PlanoService planoService;
+
+    private AnalyticsService analyticsService;
+
+    @BeforeEach
+    void setUp() {
+        analyticsService = new AnalyticsService(vendaRepository, compraRepository, inventoryMonitoringService, planoService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        CurrentUser.clear();
+    }
+
+    @Test
+    void shouldCalculateResumoUsingRepositoryAggregates() {
+        int organizationId = 1;
+        CurrentUser.set(buildUser(organizationId));
+
+        when(vendaRepository.sumValorFinalByOrganization(organizationId)).thenReturn(BigDecimal.valueOf(150));
+        when(compraRepository.sumValorFinalByOrganization(organizationId)).thenReturn(BigDecimal.valueOf(90));
+
+        ResumoDTO resumo = analyticsService.obterResumo();
+
+        assertNotNull(resumo);
+        assertBigDecimalEquals(BigDecimal.valueOf(150), resumo.getTotalVendas());
+        assertBigDecimalEquals(BigDecimal.valueOf(90), resumo.getTotalCompras());
+        assertBigDecimalEquals(BigDecimal.valueOf(60), resumo.getLucro());
+    }
+
+    @Test
+    void shouldTreatNullAggregatesAsZero() {
+        int organizationId = 5;
+        CurrentUser.set(buildUser(organizationId));
+
+        when(vendaRepository.sumValorFinalByOrganization(organizationId)).thenReturn(null);
+        when(compraRepository.sumValorFinalByOrganization(organizationId)).thenReturn(null);
+
+        ResumoDTO resumo = analyticsService.obterResumo();
+
+        assertNotNull(resumo);
+        assertBigDecimalEquals(BigDecimal.ZERO, resumo.getTotalVendas());
+        assertBigDecimalEquals(BigDecimal.ZERO, resumo.getTotalCompras());
+        assertBigDecimalEquals(BigDecimal.ZERO, resumo.getLucro());
+    }
+
+    @Test
+    void shouldIsolateResumoByOrganization() {
+        int firstOrganization = 10;
+        int secondOrganization = 20;
+
+        when(vendaRepository.sumValorFinalByOrganization(firstOrganization)).thenReturn(BigDecimal.valueOf(75));
+        when(compraRepository.sumValorFinalByOrganization(firstOrganization)).thenReturn(BigDecimal.valueOf(25));
+        when(vendaRepository.sumValorFinalByOrganization(secondOrganization)).thenReturn(BigDecimal.valueOf(120));
+        when(compraRepository.sumValorFinalByOrganization(secondOrganization)).thenReturn(BigDecimal.valueOf(30));
+
+        CurrentUser.set(buildUser(firstOrganization));
+        ResumoDTO firstResumo = analyticsService.obterResumo();
+        assertBigDecimalEquals(BigDecimal.valueOf(75), firstResumo.getTotalVendas());
+        assertBigDecimalEquals(BigDecimal.valueOf(25), firstResumo.getTotalCompras());
+        assertBigDecimalEquals(BigDecimal.valueOf(50), firstResumo.getLucro());
+        verify(vendaRepository).sumValorFinalByOrganization(firstOrganization);
+        verify(compraRepository).sumValorFinalByOrganization(firstOrganization);
+
+        CurrentUser.set(buildUser(secondOrganization));
+        ResumoDTO secondResumo = analyticsService.obterResumo();
+        assertBigDecimalEquals(BigDecimal.valueOf(120), secondResumo.getTotalVendas());
+        assertBigDecimalEquals(BigDecimal.valueOf(30), secondResumo.getTotalCompras());
+        assertBigDecimalEquals(BigDecimal.valueOf(90), secondResumo.getLucro());
+        verify(vendaRepository).sumValorFinalByOrganization(secondOrganization);
+        verify(compraRepository).sumValorFinalByOrganization(secondOrganization);
+    }
+
+    private User buildUser(int organizationId) {
+        User user = User.builder()
+                .nome("Test")
+                .sobrenome("User")
+                .email("test@example.com")
+                .senha("secret")
+                .role(Role.ADMIN)
+                .build();
+        user.setTenantId(organizationId);
+        return user;
+    }
+
+    private void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual), () -> "Expected " + expected + " but was " + actual);
+    }
+}


### PR DESCRIPTION
## Summary
- add aggregate queries in venda and compra repositories to summarize valorFinal per organization and per status
- update the analytics summary to use repository aggregates and guard against null totals when computing lucro
- add unit tests for AnalyticsService to validate tenant isolation and null handling of aggregated totals

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68dabfb517f88324be29482a6b2c10d9