### PR TITLE
Enhance recommendation scoring with client metrics

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Config/RecommendationProperties.java
+++ b/src/main/java/com/AIT/Optimanage/Config/RecommendationProperties.java
@@ -1,0 +1,17 @@
+package com.AIT.Optimanage.Config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.recommendation")
+public class RecommendationProperties {
+
+    private int historyWindowDays = 180;
+    private double churnWeight = 0.5;
+    private double rotatividadeWeight = 0.25;
+}

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -73,6 +73,14 @@ public interface VendaRepository extends JpaRepository<Venda, Integer>, JpaSpeci
             "WHERE v.organizationId = :organizationId")
     List<Venda> findAllWithProdutosByOrganization(@Param("organizationId") Integer organizationId);
 
+    @Query("SELECT DISTINCT v FROM Venda v " +
+            "JOIN FETCH v.vendaProdutos vp " +
+            "JOIN FETCH vp.produto p " +
+            "WHERE v.organizationId = :organizationId " +
+            "AND (:cutoff IS NULL OR v.dataEfetuacao >= :cutoff)")
+    List<Venda> findRecentWithProdutosByOrganization(@Param("organizationId") Integer organizationId,
+                                                      @Param("cutoff") LocalDate cutoff);
+
     @Query("SELECT vp.produto.id AS produtoId, SUM(vp.quantidade) AS totalQuantidade " +
             "FROM Venda v JOIN v.vendaProdutos vp " +
             "WHERE v.organizationId = :organizationId " +

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,10 @@ app.jwt.keys.rotation=${JWT_ROTATION_KEY}
 app.jwt.expiration=${JWT_EXPIRATION}
 app.jwt.refresh-expiration=${JWT_REFRESH_EXPIRATION}
 
+app.recommendation.history-window-days=365
+app.recommendation.churn-weight=0.5
+app.recommendation.rotatividade-weight=0.3
+
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.open-in-view=false


### PR DESCRIPTION
## Summary
- add RecommendationProperties to externalize scoring parameters for history window, churn and rotatividade weights
- update recommendation logic to factor cliente churn/average ticket, product rotatividade, and use a recent sales query
- extend repository query to fetch recent vendas with produtos filtered by cutoff date and add targeted recommendation tests

## Testing
- mvn -Dtest=RecommendationServiceTest test

------
https://chatgpt.com/codex/tasks/task_e_68dabfa5a604832489182d0bb771cbd3