### PR TITLE
Add goal progress metrics to analytics summary

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/ResumoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/ResumoDTO.java
@@ -13,5 +13,8 @@ public class ResumoDTO {
     private BigDecimal totalVendas;
     private BigDecimal totalCompras;
     private BigDecimal lucro;
+    private BigDecimal metaMensal;
+    private BigDecimal metaAnual;
+    private BigDecimal progressoMensal;
+    private BigDecimal progressoAnual;
 }
-

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -106,6 +106,13 @@ public interface VendaRepository extends JpaRepository<Venda, Integer>, JpaSpeci
     BigDecimal sumValorFinalByOrganizationAndStatus(@Param("organizationId") Integer organizationId,
                                                     @Param("status") StatusVenda status);
 
+    @Query("SELECT COALESCE(SUM(v.valorFinal), 0) FROM Venda v " +
+            "WHERE v.organizationId = :organizationId " +
+            "AND v.dataEfetuacao BETWEEN :inicio AND :fim")
+    BigDecimal sumValorFinalByOrganizationBetweenDates(@Param("organizationId") Integer organizationId,
+                                                       @Param("inicio") LocalDate inicio,
+                                                       @Param("fim") LocalDate fim);
+
     @Query("SELECT COUNT(v) FROM Venda v " +
             "WHERE v.organizationId = :organizationId " +
             "AND v.cliente.id = :clienteId " +


### PR DESCRIPTION
## Summary
- extend the analytics summary DTO to expose sales goals and progress indicators
- fetch organization goals in AnalyticsService, aggregate monthly/annual sales, and compute progress
- add repository support and unit tests covering goal present/absent scenarios

## Testing
- `./mvnw -Dtest=AnalyticsServiceTest test`


------
https://chatgpt.com/codex/tasks/task_e_68dae71337388324bdf4b7e4fe2f8eb0