### PR TITLE
feat: enhance recommendations with service bundles

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Config/RecommendationProperties.java
+++ b/src/main/java/com/AIT/Optimanage/Config/RecommendationProperties.java
@@ -14,4 +14,7 @@ public class RecommendationProperties {
     private int historyWindowDays = 180;
     private double churnWeight = 0.5;
     private double rotatividadeWeight = 0.25;
+    private double produtoMargemWeight = 1.0;
+    private double servicoMargemWeight = 1.0;
+    private double bundleWeight = 1.2;
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/Venda/VendaController.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/Venda/VendaController.java
@@ -1,7 +1,7 @@
 package com.AIT.Optimanage.Controllers.Venda;
 
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
-import com.AIT.Optimanage.Controllers.dto.ProdutoResponse;
+import com.AIT.Optimanage.Controllers.dto.RecommendationSuggestionResponse;
 import com.AIT.Optimanage.Models.PagamentoDTO;
 import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Models.Enums.FormaPagamento;
@@ -200,11 +200,12 @@ public class VendaController extends V1BaseController {
     @Operation(summary = "Recomendar produtos",
             description = "Sugere itens com base no histórico de vendas, priorizando recorrência, margem e compatibilidade")
     @ApiResponse(responseCode = "200", description = "Sucesso")
-    public ResponseEntity<List<ProdutoResponse>> recomendarProdutos(@AuthenticationPrincipal User loggedUser,
-                                                                    @RequestParam(value = "clienteId", required = false) Integer clienteId,
-                                                                    @RequestParam(value = "contexto", required = false) String contexto,
-                                                                    @RequestParam(value = "estoquePositivo", required = false) Boolean estoquePositivo) {
-        return ok(recommendationService.recomendarProdutos(clienteId, contexto, estoquePositivo));
+    public ResponseEntity<List<RecommendationSuggestionResponse>> recomendarProdutos(@AuthenticationPrincipal User loggedUser,
+                                                                                     @RequestParam(value = "clienteId", required = false) Integer clienteId,
+                                                                                     @RequestParam(value = "contexto", required = false) String contexto,
+                                                                                     @RequestParam(value = "estoquePositivo", required = false) Boolean estoquePositivo,
+                                                                                     @RequestParam(value = "apenasBundles", required = false) Boolean apenasBundles) {
+        return ok(recommendationService.recomendarProdutos(clienteId, contexto, estoquePositivo, apenasBundles));
     }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/RecommendationSuggestionResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/RecommendationSuggestionResponse.java
@@ -1,0 +1,29 @@
+package com.AIT.Optimanage.Controllers.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecommendationSuggestionResponse {
+
+    private boolean bundle;
+    private double score;
+    private List<ProdutoResponse> produtos;
+    private List<ServicoResponse> servicos;
+
+    public List<ProdutoResponse> getProdutos() {
+        return produtos == null ? Collections.emptyList() : produtos;
+    }
+
+    public List<ServicoResponse> getServicos() {
+        return servicos == null ? Collections.emptyList() : servicos;
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -74,12 +74,14 @@ public interface VendaRepository extends JpaRepository<Venda, Integer>, JpaSpeci
     List<Venda> findAllWithProdutosByOrganization(@Param("organizationId") Integer organizationId);
 
     @Query("SELECT DISTINCT v FROM Venda v " +
-            "JOIN FETCH v.vendaProdutos vp " +
-            "JOIN FETCH vp.produto p " +
+            "LEFT JOIN FETCH v.vendaProdutos vp " +
+            "LEFT JOIN FETCH vp.produto p " +
+            "LEFT JOIN FETCH v.vendaServicos vs " +
+            "LEFT JOIN FETCH vs.servico s " +
             "WHERE v.organizationId = :organizationId " +
             "AND (:cutoff IS NULL OR v.dataEfetuacao >= :cutoff)")
-    List<Venda> findRecentWithProdutosByOrganization(@Param("organizationId") Integer organizationId,
-                                                      @Param("cutoff") LocalDate cutoff);
+    List<Venda> findRecentWithItensByOrganization(@Param("organizationId") Integer organizationId,
+                                                  @Param("cutoff") LocalDate cutoff);
 
     @Query("SELECT vp.produto.id AS produtoId, SUM(vp.quantidade) AS totalQuantidade " +
             "FROM Venda v JOIN v.vendaProdutos vp " +


### PR DESCRIPTION
## Summary
- extend venda repository queries and recommendation properties to support weighted product and service bundles
- update recommendation service and controller to return bundle-aware suggestion DTOs with configurable filters
- add tests covering service availability and bundle scoring scenarios

## Testing
- `mvn -DskipITs -Dtest=RecommendationServiceTest test`


------
https://chatgpt.com/codex/tasks/task_e_68dae76c8e7c83249a84e80912c1e51d