### PR TITLE
Normalize purchase scheduling on creation

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -60,6 +60,7 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -72,6 +73,7 @@ public class CompraService {
 
     private static final StatusTransitionPolicy<StatusCompra, Compra> STATUS_TRANSITION_POLICY =
             StatusTransitionPolicies.compraPolicy();
+    private static final DateTimeFormatter HORA_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     private final CompraRepository compraRepository;
     private final FornecedorService fornecedorService;
@@ -141,6 +143,22 @@ public class CompraService {
             garantirAgendaHabilitada(plano);
         }
 
+        LocalDate dataAgendada = compraDTO.getDataAgendada();
+        LocalTime horaAgendada = compraDTO.getHoraAgendada();
+        Duration duracaoEstimada = compraDTO.getDuracaoEstimada();
+        if (dataAgendada != null || horaAgendada != null) {
+            dataAgendada = agendaValidator.validarDataAgendamento(
+                    Optional.ofNullable(dataAgendada).map(LocalDate::toString).orElse(null));
+            String horaFormatada = Optional.ofNullable(horaAgendada)
+                    .map(time -> time.format(HORA_FORMATTER))
+                    .orElse(null);
+            horaAgendada = agendaValidator.validarHoraAgendada(horaFormatada);
+            Integer duracaoMinutos = Optional.ofNullable(duracaoEstimada)
+                    .map(duration -> Math.toIntExact(duration.toMinutes()))
+                    .orElse(null);
+            duracaoEstimada = agendaValidator.validarDuracao(duracaoMinutos);
+        }
+
         Integer organizationId = CurrentUser.getOrganizationId();
         if (organizationId == null) {
             throw new EntityNotFoundException("Organização não encontrada");
@@ -151,9 +169,9 @@ public class CompraService {
                 .fornecedor(fornecedor)
                 .sequencialUsuario(contador.getContagemAtual())
                 .dataEfetuacao(compraDTO.getDataEfetuacao())
-                .dataAgendada(compraDTO.getDataAgendada())
-                .horaAgendada(compraDTO.getHoraAgendada())
-                .duracaoEstimada(compraDTO.getDuracaoEstimada())
+                .dataAgendada(dataAgendada)
+                .horaAgendada(horaAgendada)
+                .duracaoEstimada(duracaoEstimada)
                 .valorFinal(BigDecimal.ZERO)
                 .condicaoPagamento(compraDTO.getCondicaoPagamento())
                 .valorPendente(BigDecimal.ZERO)
@@ -161,6 +179,7 @@ public class CompraService {
                 .observacoes(compraDTO.getObservacoes())
                 .build();
 
+        novaCompra.setTenantId(organizationId);
         List<CompraProduto> compraProdutos = criarListaProdutos(compraDTO.getProdutos(), novaCompra);
         List<CompraServico> compraServicos = criarListaServicos(compraDTO.getServicos(), novaCompra);
         novaCompra.setCompraProdutos(compraProdutos);
@@ -178,8 +197,13 @@ public class CompraService {
         novaCompra.setValorFinal(valorTotal);
         novaCompra.setValorPendente(valorTotal.subtract(valorPago));
 
-        
-        novaCompra.setTenantId(organizationId);
+        if (novaCompra.getDataAgendada() != null) {
+            Integer userId = Optional.ofNullable(novaCompra.getCreatedBy())
+                    .orElseGet(() -> Optional.ofNullable(CurrentUser.get()).map(User::getId).orElse(null));
+            agendaValidator.validarConflitosAgendamentoCompra(novaCompra, userId, novaCompra.getDataAgendada(),
+                    novaCompra.getHoraAgendada(), novaCompra.getDuracaoEstimada());
+        }
+
         compraRepository.save(novaCompra);
         compraProdutoRepository.saveAll(compraProdutos);
         compraServicoRepository.saveAll(compraServicos);

--- a/src/test/java/com/AIT/Optimanage/Services/Compra/CompraServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/Compra/CompraServiceTest.java
@@ -11,11 +11,14 @@ import com.AIT.Optimanage.Models.Compra.DTOs.CompraServicoDTO;
 import com.AIT.Optimanage.Models.Compra.Related.StatusCompra;
 import com.AIT.Optimanage.Models.Enums.FormaPagamento;
 import com.AIT.Optimanage.Models.Enums.StatusPagamento;
+import com.AIT.Optimanage.Models.Fornecedor.Fornecedor;
 import com.AIT.Optimanage.Models.Inventory.InventorySource;
 import com.AIT.Optimanage.Models.Plano;
 import com.AIT.Optimanage.Models.Produto;
 import com.AIT.Optimanage.Models.Servico;
+import com.AIT.Optimanage.Models.User.Contador;
 import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Models.User.Tabela;
 import com.AIT.Optimanage.Repositories.Compra.CompraProdutoRepository;
 import com.AIT.Optimanage.Repositories.Compra.CompraRepository;
 import com.AIT.Optimanage.Repositories.Compra.CompraServicoRepository;
@@ -39,6 +42,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -48,9 +52,12 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,6 +79,7 @@ class CompraServiceTest {
     @Mock private CompraValidator compraValidator;
     @Mock private PlanoService planoService;
     @Mock private AgendaValidator agendaValidator;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private CompraService compraService;
@@ -94,8 +102,14 @@ class CompraServiceTest {
                 .thenAnswer(invocation -> LocalDate.parse(invocation.getArgument(0)));
         lenient().when(agendaValidator.validarHoraAgendada(anyString()))
                 .thenAnswer(invocation -> LocalTime.parse(invocation.getArgument(0)));
-        lenient().when(agendaValidator.validarDuracao(anyInt()))
-                .thenAnswer(invocation -> Duration.ofMinutes(((Integer) invocation.getArgument(0)).longValue()));
+        lenient().when(agendaValidator.validarDuracao(any()))
+                .thenAnswer(invocation -> {
+                    Integer minutos = invocation.getArgument(0);
+                    if (minutos == null) {
+                        return Duration.ofHours(1);
+                    }
+                    return Duration.ofMinutes(minutos.longValue());
+                });
         doNothing().when(agendaValidator)
                 .validarConflitosAgendamentoCompra(any(), any(), any(), any(), any());
     }
@@ -379,6 +393,60 @@ class CompraServiceTest {
         verify(inventoryService).incrementar(produtoAtualizado.getId(), 3, InventorySource.COMPRA, compra.getId(),
                 "Atualização da compra #" + compra.getId());
         assertEquals(expectedResponse, response);
+    }
+
+    @Test
+    void criarCompraComConflitoDeAgendaParaMesmoUsuarioELancaExcecao() {
+        Fornecedor fornecedor = new Fornecedor();
+        fornecedor.setId(5);
+
+        Contador contador = new Contador();
+        contador.setContagemAtual(1);
+
+        Produto produto = Produto.builder()
+                .custo(BigDecimal.valueOf(25))
+                .valorVenda(BigDecimal.valueOf(30))
+                .build();
+        produto.setId(9);
+
+        Servico servico = Servico.builder()
+                .custo(BigDecimal.valueOf(40))
+                .valorVenda(BigDecimal.valueOf(50))
+                .build();
+        servico.setId(4);
+
+        when(fornecedorService.listarUmFornecedor(fornecedor.getId())).thenReturn(fornecedor);
+        when(contadorService.BuscarContador(Tabela.COMPRA)).thenReturn(contador);
+        when(produtoService.buscarProdutoAtivo(produto.getId())).thenReturn(produto);
+        when(servicoService.buscarServicoAtivo(servico.getId())).thenReturn(servico);
+        when(compraRepository.save(any(Compra.class))).thenAnswer(invocation -> {
+            Compra compra = invocation.getArgument(0);
+            if (compra.getId() == null) {
+                compra.setId(1);
+            }
+            return compra;
+        });
+        when(compraMapper.toResponse(any(Compra.class))).thenReturn(new CompraResponseDTO());
+
+        CompraDTO compraDTO = CompraDTO.builder()
+                .fornecedorId(fornecedor.getId())
+                .dataEfetuacao(LocalDate.now())
+                .dataAgendada(LocalDate.now().plusDays(1))
+                .horaAgendada(LocalTime.of(10, 0))
+                .duracaoEstimada(Duration.ofMinutes(60))
+                .status(StatusCompra.AGUARDANDO_EXECUCAO)
+                .produtos(Collections.singletonList(new CompraProdutoDTO(produto.getId(), 1, produto.getCusto())))
+                .servicos(Collections.singletonList(new CompraServicoDTO(servico.getId(), 1)))
+                .build();
+
+        compraService.criarCompra(compraDTO);
+
+        doThrow(new IllegalArgumentException("Já existe um agendamento para este usuário no período informado."))
+                .when(agendaValidator)
+                .validarConflitosAgendamentoCompra(any(Compra.class), any(), any(), any(), any());
+
+        assertThrows(IllegalArgumentException.class, () -> compraService.criarCompra(compraDTO));
+        verify(compraRepository, times(1)).save(any(Compra.class));
     }
 }
 


### PR DESCRIPTION
## Summary
- normalize scheduled date, time, and duration in `criarCompra` using the agenda validator and ensure conflicts are checked before saving
- set the tenant on the new purchase prior to conflict validation to use organization context
- add a unit test that asserts an overlapping purchase for the same user throws a scheduling conflict

## Testing
- ./mvnw -Dtest=CompraServiceTest test

------
https://chatgpt.com/codex/tasks/task_e_68dae7d2dc548324a34f666dd61fae8e