### PR TITLE
Add platform analytics summary endpoint and platform access guard

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
@@ -1,6 +1,7 @@
 package com.AIT.Optimanage.Analytics;
 
 import com.AIT.Optimanage.Analytics.DTOs.InventoryAlertDTO;
+import com.AIT.Optimanage.Analytics.DTOs.PlatformResumoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PrevisaoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.ResumoDTO;
 import com.AIT.Optimanage.Controllers.BaseController.V1BaseController;
@@ -32,6 +33,12 @@ public class AnalyticsController extends V1BaseController {
     @GetMapping("/estoque-critico")
     public ResponseEntity<List<InventoryAlertDTO>> estoqueCritico() {
         return ok(analyticsService.listarAlertasEstoque());
+    }
+
+    @GetMapping("/plataforma/resumo")
+    public ResponseEntity<PlatformResumoDTO> resumoPlataforma() {
+        analyticsService.requirePlatformOrganization();
+        return ok(analyticsService.obterResumoPlataforma());
     }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformResumoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformResumoDTO.java
@@ -1,0 +1,18 @@
+package com.AIT.Optimanage.Analytics.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlatformResumoDTO {
+    private BigDecimal volumeTotalVendas;
+    private BigDecimal volumeTotalCompras;
+    private BigDecimal lucroAgregado;
+    private BigDecimal ticketMedio;
+    private BigDecimal crescimentoMensal;
+}

--- a/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
@@ -36,6 +36,13 @@ public interface CompraRepository extends JpaRepository<Compra, Integer>, JpaSpe
                                                     @Param("status") StatusCompra status);
 
     @Query("""
+            SELECT COALESCE(SUM(c.valorFinal), 0)
+            FROM Compra c
+            WHERE (:organizationId IS NULL OR c.organizationId = :organizationId)
+            """)
+    BigDecimal sumValorFinalGlobal(@Param("organizationId") Integer organizationId);
+
+    @Query("""
             SELECT c FROM Compra c
             WHERE c.fornecedor.id = :fornecedorId
               AND c.organizationId = :organizationId

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -106,12 +106,40 @@ public interface VendaRepository extends JpaRepository<Venda, Integer>, JpaSpeci
     BigDecimal sumValorFinalByOrganizationAndStatus(@Param("organizationId") Integer organizationId,
                                                     @Param("status") StatusVenda status);
 
+    @Query("""
+            SELECT COALESCE(SUM(v.valorFinal), 0)
+            FROM Venda v
+            WHERE (:organizationId IS NULL OR v.organizationId = :organizationId)
+            """)
+    BigDecimal sumValorFinalGlobal(@Param("organizationId") Integer organizationId);
+
     @Query("SELECT COALESCE(SUM(v.valorFinal), 0) FROM Venda v " +
             "WHERE v.organizationId = :organizationId " +
             "AND v.dataEfetuacao BETWEEN :inicio AND :fim")
     BigDecimal sumValorFinalByOrganizationBetweenDates(@Param("organizationId") Integer organizationId,
                                                        @Param("inicio") LocalDate inicio,
                                                        @Param("fim") LocalDate fim);
+
+    @Query("""
+            SELECT YEAR(v.dataEfetuacao) AS ano,
+                   MONTH(v.dataEfetuacao) AS mes,
+                   COALESCE(SUM(v.valorFinal), 0) AS total
+            FROM Venda v
+            WHERE (:organizationId IS NULL OR v.organizationId = :organizationId)
+              AND v.dataEfetuacao BETWEEN :inicio AND :fim
+            GROUP BY YEAR(v.dataEfetuacao), MONTH(v.dataEfetuacao)
+            ORDER BY ano, mes
+            """)
+    List<Object[]> sumValorFinalByMonthGlobal(@Param("organizationId") Integer organizationId,
+                                              @Param("inicio") LocalDate inicio,
+                                              @Param("fim") LocalDate fim);
+
+    @Query("""
+            SELECT COUNT(v)
+            FROM Venda v
+            WHERE (:organizationId IS NULL OR v.organizationId = :organizationId)
+            """)
+    long countByOrganizationOrGlobal(@Param("organizationId") Integer organizationId);
 
     @Query("SELECT COUNT(v) FROM Venda v " +
             "WHERE v.organizationId = :organizationId " +


### PR DESCRIPTION
## Summary
- enforce platform organization validation through a shared helper in the analytics service
- add platform-wide aggregation DTO and repository queries to compute global metrics
- expose GET /api/v1/analytics/plataforma/resumo to return the new platform summary

## Testing
- ./mvnw -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dd2ccb69e483248160f00c98f8c566