### PR TITLE
Add platform engagement analytics endpoint

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
@@ -1,6 +1,7 @@
 package com.AIT.Optimanage.Analytics;
 
 import com.AIT.Optimanage.Analytics.DTOs.InventoryAlertDTO;
+import com.AIT.Optimanage.Analytics.DTOs.PlatformEngajamentoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformResumoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PrevisaoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.ResumoDTO;
@@ -39,6 +40,11 @@ public class AnalyticsController extends V1BaseController {
     public ResponseEntity<PlatformResumoDTO> resumoPlataforma() {
         analyticsService.requirePlatformOrganization();
         return ok(analyticsService.obterResumoPlataforma());
+    }
+
+    @GetMapping("/plataforma/engajamento")
+    public ResponseEntity<PlatformEngajamentoDTO> engajamentoPlataforma() {
+        return ok(analyticsService.obterEngajamentoPlataforma());
     }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
@@ -46,7 +46,8 @@ public class AnalyticsController extends V1BaseController {
     @GetMapping("/plataforma/engajamento")
     public ResponseEntity<PlatformEngajamentoDTO> engajamentoPlataforma() {
         return ok(analyticsService.obterEngajamentoPlataforma());
-  
+    }
+
     @GetMapping("/plataforma/adocao-recursos")
     public ResponseEntity<PlatformFeatureAdoptionDTO> adocaoRecursosPlataforma() {
         return ok(analyticsService.obterAdocaoRecursosPlataforma());

--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
@@ -208,8 +208,7 @@ public class AnalyticsService {
         long organizacoesAtivas60Dias = vendaRepository.countDistinctOrganizationsByPeriodo(corte60Dias, hoje);
 
         long organizacoesInativas60Dias = organizationRepository
-                .findOrganizationsWithoutSalesSince(corte60Dias, PlatformConstants.PLATFORM_ORGANIZATION_ID)
-                .size();
+                .countOrganizationsWithoutSalesSince(corte60Dias, PlatformConstants.PLATFORM_ORGANIZATION_ID);
 
         Map<Integer, LocalDate> primeirasVendas = vendaRepository.findPrimeiraVendaPorOrganizacao(null, hoje)
                 .stream()

--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformEngajamentoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformEngajamentoDTO.java
@@ -1,0 +1,21 @@
+package com.AIT.Optimanage.Analytics.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlatformEngajamentoDTO {
+    private long organizacoesAtivas30Dias;
+    private long organizacoesAtivas60Dias;
+    private long organizacoesInativas60Dias;
+    private BigDecimal tempoMedioPrimeiraVendaDias;
+    private BigDecimal taxaRetencao30Dias;
+    private BigDecimal taxaRetencao60Dias;
+}

--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
@@ -7,11 +7,24 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Repository
 public interface OrganizationRepository extends JpaRepository<Organization, Integer> {
 
     @Modifying(clearAutomatically = true)
     @Query("update Organization o set o.organizationId = :organizationId where o.id = :organizationId")
     void updateOrganizationTenant(@Param("organizationId") Integer organizationId);
+
+    @Query("""
+            SELECT o
+            FROM Organization o
+            LEFT JOIN Venda v ON v.organizationId = o.id AND v.dataEfetuacao >= :cutoff
+            WHERE (:excludedOrganizationId IS NULL OR o.id <> :excludedOrganizationId)
+              AND v.id IS NULL
+            """)
+    List<Organization> findOrganizationsWithoutSalesSince(@Param("cutoff") LocalDate cutoff,
+                                                          @Param("excludedOrganizationId") Integer excludedOrganizationId);
 }
 

--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
@@ -20,9 +20,13 @@ public interface OrganizationRepository extends JpaRepository<Organization, Inte
     @Query("""
             SELECT o
             FROM Organization o
-            LEFT JOIN Venda v ON v.organizationId = o.id AND v.dataEfetuacao >= :cutoff
             WHERE (:excludedOrganizationId IS NULL OR o.id <> :excludedOrganizationId)
-              AND v.id IS NULL
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM Venda v
+                    WHERE v.organizationId = o.id
+                      AND v.dataEfetuacao >= :cutoff
+              )
             """)
     List<Organization> findOrganizationsWithoutSalesSince(@Param("cutoff") LocalDate cutoff,
                                                           @Param("excludedOrganizationId") Integer excludedOrganizationId);

--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Repository
 public interface OrganizationRepository extends JpaRepository<Organization, Integer> {
@@ -18,7 +17,7 @@ public interface OrganizationRepository extends JpaRepository<Organization, Inte
     void updateOrganizationTenant(@Param("organizationId") Integer organizationId);
 
     @Query("""
-            SELECT o
+            SELECT COUNT(o)
             FROM Organization o
             WHERE (:excludedOrganizationId IS NULL OR o.id <> :excludedOrganizationId)
               AND NOT EXISTS (
@@ -28,7 +27,7 @@ public interface OrganizationRepository extends JpaRepository<Organization, Inte
                       AND v.dataEfetuacao >= :cutoff
               )
             """)
-    List<Organization> findOrganizationsWithoutSalesSince(@Param("cutoff") LocalDate cutoff,
-                                                          @Param("excludedOrganizationId") Integer excludedOrganizationId);
+    long countOrganizationsWithoutSalesSince(@Param("cutoff") LocalDate cutoff,
+                                             @Param("excludedOrganizationId") Integer excludedOrganizationId);
 }
 

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -141,6 +141,15 @@ public interface VendaRepository extends JpaRepository<Venda, Integer>, JpaSpeci
             """)
     long countByOrganizationOrGlobal(@Param("organizationId") Integer organizationId);
 
+    @Query("""
+            SELECT COUNT(DISTINCT v.organizationId)
+            FROM Venda v
+            WHERE (:inicio IS NULL OR v.dataEfetuacao >= :inicio)
+              AND (:fim IS NULL OR v.dataEfetuacao <= :fim)
+            """)
+    long countDistinctOrganizationsByPeriodo(@Param("inicio") LocalDate inicio,
+                                             @Param("fim") LocalDate fim);
+
     @Query("SELECT COUNT(v) FROM Venda v " +
             "WHERE v.organizationId = :organizationId " +
             "AND v.cliente.id = :clienteId " +
@@ -161,4 +170,14 @@ public interface VendaRepository extends JpaRepository<Venda, Integer>, JpaSpeci
                                        @Param("userId") Integer userId,
                                        @Param("inicio") LocalDate inicio,
                                        @Param("fim") LocalDate fim);
+
+    @Query("""
+            SELECT v.organizationId, MIN(v.dataEfetuacao)
+            FROM Venda v
+            WHERE (:inicio IS NULL OR v.dataEfetuacao >= :inicio)
+              AND (:fim IS NULL OR v.dataEfetuacao <= :fim)
+            GROUP BY v.organizationId
+            """)
+    List<Object[]> findPrimeiraVendaPorOrganizacao(@Param("inicio") LocalDate inicio,
+                                                   @Param("fim") LocalDate fim);
 }


### PR DESCRIPTION
## Summary
- add sales repository queries to count active organizations and retrieve first sale dates per tenant
- extend organization repository with a left join query to detect inactive organizations
- expose a platform engagement analytics DTO, service aggregation, and REST endpoint

## Testing
- ./mvnw -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68dd34de04b483249da3e65c09e658d0