### PR TITLE
Add platform feature adoption analytics endpoint

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
@@ -1,6 +1,7 @@
 package com.AIT.Optimanage.Analytics;
 
 import com.AIT.Optimanage.Analytics.DTOs.InventoryAlertDTO;
+import com.AIT.Optimanage.Analytics.DTOs.PlatformFeatureAdoptionDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformResumoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PrevisaoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.ResumoDTO;
@@ -39,6 +40,11 @@ public class AnalyticsController extends V1BaseController {
     public ResponseEntity<PlatformResumoDTO> resumoPlataforma() {
         analyticsService.requirePlatformOrganization();
         return ok(analyticsService.obterResumoPlataforma());
+    }
+
+    @GetMapping("/plataforma/adocao-recursos")
+    public ResponseEntity<PlatformFeatureAdoptionDTO> adocaoRecursosPlataforma() {
+        return ok(analyticsService.obterAdocaoRecursosPlataforma());
     }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
@@ -1,6 +1,7 @@
 package com.AIT.Optimanage.Analytics;
 
 import com.AIT.Optimanage.Analytics.DTOs.InventoryAlertDTO;
+import com.AIT.Optimanage.Analytics.DTOs.PlatformFeatureAdoptionDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformResumoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PrevisaoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.ResumoDTO;
@@ -10,6 +11,7 @@ import com.AIT.Optimanage.Models.User.User;
 import com.AIT.Optimanage.Models.Venda.Venda;
 import com.AIT.Optimanage.Repositories.Compra.CompraRepository;
 import com.AIT.Optimanage.Repositories.Organization.OrganizationRepository;
+import com.AIT.Optimanage.Repositories.Organization.PlanFeatureAdoptionProjection;
 import com.AIT.Optimanage.Repositories.Venda.VendaRepository;
 import com.AIT.Optimanage.Security.CurrentUser;
 import com.AIT.Optimanage.Services.InventoryMonitoringService;
@@ -193,6 +195,49 @@ public class AnalyticsService {
         return new PlatformResumoDTO(totalVendas, totalCompras, lucro, ticketMedio, crescimentoMensal);
     }
 
+    public PlatformFeatureAdoptionDTO obterAdocaoRecursosPlataforma() {
+        requirePlatformOrganization();
+
+        List<PlanFeatureAdoptionProjection> aggregations = organizationRepository.aggregateFeatureAdoptionByPlan();
+
+        long totalOrganizations = aggregations.stream()
+                .mapToLong(PlanFeatureAdoptionProjection::getTotalOrganizations)
+                .sum();
+
+        long agendaEnabled = aggregations.stream()
+                .mapToLong(PlanFeatureAdoptionProjection::getAgendaEnabledCount)
+                .sum();
+        long recomendacoesEnabled = aggregations.stream()
+                .mapToLong(PlanFeatureAdoptionProjection::getRecomendacoesEnabledCount)
+                .sum();
+        long pagamentosEnabled = aggregations.stream()
+                .mapToLong(PlanFeatureAdoptionProjection::getPagamentosEnabledCount)
+                .sum();
+        long suportePrioritarioEnabled = aggregations.stream()
+                .mapToLong(PlanFeatureAdoptionProjection::getSuportePrioritarioEnabledCount)
+                .sum();
+        long monitoramentoEstoqueEnabled = aggregations.stream()
+                .mapToLong(PlanFeatureAdoptionProjection::getMonitoramentoEstoqueEnabledCount)
+                .sum();
+        long metricasProdutoEnabled = aggregations.stream()
+                .mapToLong(PlanFeatureAdoptionProjection::getMetricasProdutoEnabledCount)
+                .sum();
+        long integracaoMarketplaceEnabled = aggregations.stream()
+                .mapToLong(PlanFeatureAdoptionProjection::getIntegracaoMarketplaceEnabledCount)
+                .sum();
+
+        return PlatformFeatureAdoptionDTO.builder()
+                .totalOrganizations(totalOrganizations)
+                .agenda(buildFeatureAdoptionMetrics(agendaEnabled, totalOrganizations))
+                .recomendacoes(buildFeatureAdoptionMetrics(recomendacoesEnabled, totalOrganizations))
+                .pagamentos(buildFeatureAdoptionMetrics(pagamentosEnabled, totalOrganizations))
+                .suportePrioritario(buildFeatureAdoptionMetrics(suportePrioritarioEnabled, totalOrganizations))
+                .monitoramentoEstoque(buildFeatureAdoptionMetrics(monitoramentoEstoqueEnabled, totalOrganizations))
+                .metricasProduto(buildFeatureAdoptionMetrics(metricasProdutoEnabled, totalOrganizations))
+                .integracaoMarketplace(buildFeatureAdoptionMetrics(integracaoMarketplaceEnabled, totalOrganizations))
+                .build();
+    }
+
     private InventoryAlertDTO toDto(InventoryAlert alert) {
         return InventoryAlertDTO.builder()
                 .produtoId(alert.getProduto().getId())
@@ -216,6 +261,23 @@ public class AnalyticsService {
         BigDecimal valorTotal = total != null ? total : BigDecimal.ZERO;
         return valorTotal.multiply(BigDecimal.valueOf(100))
                 .divide(meta, 2, RoundingMode.HALF_UP);
+    }
+
+    private PlatformFeatureAdoptionDTO.FeatureAdoptionMetrics buildFeatureAdoptionMetrics(long enabledOrganizations,
+                                                                                        long totalOrganizations) {
+        BigDecimal adoptionPercentage;
+        if (totalOrganizations == 0) {
+            adoptionPercentage = BigDecimal.ZERO;
+        } else {
+            adoptionPercentage = BigDecimal.valueOf(enabledOrganizations)
+                    .multiply(BigDecimal.valueOf(100))
+                    .divide(BigDecimal.valueOf(totalOrganizations), 2, RoundingMode.HALF_UP);
+        }
+
+        return PlatformFeatureAdoptionDTO.FeatureAdoptionMetrics.builder()
+                .organizations(enabledOrganizations)
+                .adoptionPercentage(adoptionPercentage)
+                .build();
     }
 
     private Organization getCurrentOrganizationOrThrow() {

--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformFeatureAdoptionDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformFeatureAdoptionDTO.java
@@ -1,0 +1,34 @@
+package com.AIT.Optimanage.Analytics.DTOs;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+
+@Value
+@Builder
+public class PlatformFeatureAdoptionDTO {
+
+    long totalOrganizations;
+
+    FeatureAdoptionMetrics agenda;
+
+    FeatureAdoptionMetrics recomendacoes;
+
+    FeatureAdoptionMetrics pagamentos;
+
+    FeatureAdoptionMetrics suportePrioritario;
+
+    FeatureAdoptionMetrics monitoramentoEstoque;
+
+    FeatureAdoptionMetrics metricasProduto;
+
+    FeatureAdoptionMetrics integracaoMarketplace;
+
+    @Value
+    @Builder
+    public static class FeatureAdoptionMetrics {
+        long organizations;
+        BigDecimal adoptionPercentage;
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
@@ -7,11 +7,30 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface OrganizationRepository extends JpaRepository<Organization, Integer> {
 
     @Modifying(clearAutomatically = true)
     @Query("update Organization o set o.organizationId = :organizationId where o.id = :organizationId")
     void updateOrganizationTenant(@Param("organizationId") Integer organizationId);
+
+    @Query("""
+            SELECT p.id AS planId,
+                   p.nome AS planName,
+                   COUNT(o) AS totalOrganizations,
+                   SUM(CASE WHEN p.agendaHabilitada = true THEN 1 ELSE 0 END) AS agendaEnabledCount,
+                   SUM(CASE WHEN p.recomendacoesHabilitadas = true THEN 1 ELSE 0 END) AS recomendacoesEnabledCount,
+                   SUM(CASE WHEN p.pagamentosHabilitados = true THEN 1 ELSE 0 END) AS pagamentosEnabledCount,
+                   SUM(CASE WHEN p.suportePrioritario = true THEN 1 ELSE 0 END) AS suportePrioritarioEnabledCount,
+                   SUM(CASE WHEN p.monitoramentoEstoqueHabilitado = true THEN 1 ELSE 0 END) AS monitoramentoEstoqueEnabledCount,
+                   SUM(CASE WHEN p.metricasProdutoHabilitadas = true THEN 1 ELSE 0 END) AS metricasProdutoEnabledCount,
+                   SUM(CASE WHEN p.integracaoMarketplaceHabilitada = true THEN 1 ELSE 0 END) AS integracaoMarketplaceEnabledCount
+            FROM Organization o
+            JOIN o.planoAtivoId p
+            GROUP BY p.id, p.nome
+            """)
+    List<PlanFeatureAdoptionProjection> aggregateFeatureAdoptionByPlan();
 }
 

--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/PlanFeatureAdoptionProjection.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/PlanFeatureAdoptionProjection.java
@@ -1,0 +1,24 @@
+package com.AIT.Optimanage.Repositories.Organization;
+
+public interface PlanFeatureAdoptionProjection {
+
+    Integer getPlanId();
+
+    String getPlanName();
+
+    Long getTotalOrganizations();
+
+    Long getAgendaEnabledCount();
+
+    Long getRecomendacoesEnabledCount();
+
+    Long getPagamentosEnabledCount();
+
+    Long getSuportePrioritarioEnabledCount();
+
+    Long getMonitoramentoEstoqueEnabledCount();
+
+    Long getMetricasProdutoEnabledCount();
+
+    Long getIntegracaoMarketplaceEnabledCount();
+}

--- a/src/test/java/com/AIT/Optimanage/Analytics/AnalyticsServiceTest.java
+++ b/src/test/java/com/AIT/Optimanage/Analytics/AnalyticsServiceTest.java
@@ -148,6 +148,8 @@ class AnalyticsServiceTest {
         int organizationId = 30;
         CurrentUser.set(buildUser(organizationId));
 
+        when(organizationRepository.findById(organizationId)).thenReturn(java.util.Optional.of(buildOrganization(organizationId, null, null)));
+
         List<Venda> duplicatedSales = List.of(
                 venda(organizationId, LocalDate.of(2024, 1, 1), new BigDecimal("100")),
                 venda(organizationId, LocalDate.of(2024, 1, 1), new BigDecimal("50")),
@@ -178,6 +180,8 @@ class AnalyticsServiceTest {
     void shouldReactToIrregularIntervalsInForecast() {
         int organizationId = 40;
         CurrentUser.set(buildUser(organizationId));
+
+        when(organizationRepository.findById(organizationId)).thenReturn(java.util.Optional.of(buildOrganization(organizationId, null, null)));
 
         List<Venda> irregularSpacing = List.of(
                 venda(organizationId, LocalDate.of(2024, 1, 1), new BigDecimal("150")),


### PR DESCRIPTION
## Summary
- add repository projection and aggregation query to gather feature adoption by plan
- compute platform-wide feature adoption metrics and DTO within analytics service
- expose new platform adoption endpoint and update analytics tests

## Testing
- ./mvnw -q test

------
https://chatgpt.com/codex/tasks/task_e_68dd34f0e8e48324894f3d9c0136d4be