### PR TITLE
Exclude platform organization from feature adoption aggregation

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
@@ -243,7 +243,8 @@ public class AnalyticsService {
     public PlatformFeatureAdoptionDTO obterAdocaoRecursosPlataforma() {
         requirePlatformOrganization();
 
-        List<PlanFeatureAdoptionProjection> aggregations = organizationRepository.aggregateFeatureAdoptionByPlan();
+        List<PlanFeatureAdoptionProjection> aggregations = organizationRepository
+                .aggregateFeatureAdoptionByPlan(PlatformConstants.PLATFORM_ORGANIZATION_ID);
 
         long totalOrganizations = aggregations.stream()
                 .mapToLong(PlanFeatureAdoptionProjection::getTotalOrganizations)

--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
@@ -43,8 +43,9 @@ public interface OrganizationRepository extends JpaRepository<Organization, Inte
                    SUM(CASE WHEN p.integracaoMarketplaceHabilitada = true THEN 1 ELSE 0 END) AS integracaoMarketplaceEnabledCount
             FROM Organization o
             JOIN o.planoAtivoId p
+            WHERE (:excludedOrganizationId IS NULL OR o.id <> :excludedOrganizationId)
             GROUP BY p.id, p.nome
             """)
-    List<PlanFeatureAdoptionProjection> aggregateFeatureAdoptionByPlan();
+    List<PlanFeatureAdoptionProjection> aggregateFeatureAdoptionByPlan(@Param("excludedOrganizationId") Integer excludedOrganizationId);
 }
 


### PR DESCRIPTION
## Summary
- exclude the platform tenant from feature-adoption plan aggregations in the organization repository
- update the analytics service to rely on the filtered aggregation when building the platform feature adoption view

## Testing
- ./mvnw -q -DskipTests=false test *(fails: Domain "TEXT" not found; existing integration schema issue)*

------
https://chatgpt.com/codex/tasks/task_e_68dd52bf42008324af8e407824de3f71