### PR TITLE
Add platform organization analytics overview endpoint

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
@@ -3,6 +3,7 @@ package com.AIT.Optimanage.Analytics;
 import com.AIT.Optimanage.Analytics.DTOs.InventoryAlertDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformEngajamentoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformFeatureAdoptionDTO;
+import com.AIT.Optimanage.Analytics.DTOs.PlatformOrganizationsOverviewDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformResumoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PrevisaoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.ResumoDTO;
@@ -39,7 +40,6 @@ public class AnalyticsController extends V1BaseController {
 
     @GetMapping("/plataforma/resumo")
     public ResponseEntity<PlatformResumoDTO> resumoPlataforma() {
-        analyticsService.requirePlatformOrganization();
         return ok(analyticsService.obterResumoPlataforma());
     }
 
@@ -51,6 +51,11 @@ public class AnalyticsController extends V1BaseController {
     @GetMapping("/plataforma/adocao-recursos")
     public ResponseEntity<PlatformFeatureAdoptionDTO> adocaoRecursosPlataforma() {
         return ok(analyticsService.obterAdocaoRecursosPlataforma());
+    }
+
+    @GetMapping("/plataforma/organizacoes/visao-geral")
+    public ResponseEntity<PlatformOrganizationsOverviewDTO> overviewOrganizacoesPlataforma() {
+        return ok(analyticsService.obterResumoOrganizacoesPlataforma());
     }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformOrganizationsOverviewDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformOrganizationsOverviewDTO.java
@@ -1,0 +1,29 @@
+package com.AIT.Optimanage.Analytics.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlatformOrganizationsOverviewDTO {
+    private List<TimeSeriesPoint> criadas;
+    private List<TimeSeriesPoint> assinadas;
+    private long totalAtivas;
+    private long totalInativas;
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class TimeSeriesPoint {
+        private LocalDate data;
+        private long quantidade;
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
@@ -51,4 +51,25 @@ public interface CompraRepository extends JpaRepository<Compra, Integer>, JpaSpe
     List<Compra> findByFornecedorIdAndOrganizationIdAndStatusIn(@Param("fornecedorId") Integer fornecedorId,
                                                                 @Param("organizationId") Integer organizationId,
                                                                 @Param("statuses") List<StatusCompra> statuses);
+
+    @Query("""
+            SELECT c.dataEfetuacao AS dia,
+                   COUNT(DISTINCT c.organizationId) AS quantidade
+            FROM Compra c
+            WHERE c.dataEfetuacao IS NOT NULL
+              AND c.dataEfetuacao BETWEEN :inicio AND :fim
+            GROUP BY c.dataEfetuacao
+            ORDER BY c.dataEfetuacao
+            """)
+    List<Object[]> countDistinctOrganizationsWithPurchasesByDate(@Param("inicio") LocalDate inicio,
+                                                                  @Param("fim") LocalDate fim);
+
+    @Query("""
+            SELECT DISTINCT c.organizationId
+            FROM Compra c
+            WHERE c.dataEfetuacao IS NOT NULL
+              AND c.dataEfetuacao BETWEEN :inicio AND :fim
+            """)
+    List<Integer> findDistinctOrganizationIdsWithPurchasesBetween(@Param("inicio") LocalDate inicio,
+                                                                   @Param("fim") LocalDate fim);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -47,5 +48,40 @@ public interface OrganizationRepository extends JpaRepository<Organization, Inte
             GROUP BY p.id, p.nome
             """)
     List<PlanFeatureAdoptionProjection> aggregateFeatureAdoptionByPlan(@Param("excludedOrganizationId") Integer excludedOrganizationId);
+
+    @Query("""
+            SELECT function('DATE', o.createdAt) AS dia,
+                   COUNT(o) AS quantidade
+            FROM Organization o
+            WHERE o.createdAt IS NOT NULL
+              AND o.createdAt BETWEEN :inicio AND :fim
+              AND (:excludedOrganizationId IS NULL OR o.id <> :excludedOrganizationId)
+            GROUP BY function('DATE', o.createdAt)
+            ORDER BY dia
+            """)
+    List<Object[]> countOrganizationsCreatedByDateRange(@Param("inicio") LocalDateTime inicio,
+                                                         @Param("fim") LocalDateTime fim,
+                                                         @Param("excludedOrganizationId") Integer excludedOrganizationId);
+
+    @Query("""
+            SELECT o.dataAssinatura AS dia,
+                   COUNT(o) AS quantidade
+            FROM Organization o
+            WHERE o.dataAssinatura IS NOT NULL
+              AND o.dataAssinatura BETWEEN :inicio AND :fim
+              AND (:excludedOrganizationId IS NULL OR o.id <> :excludedOrganizationId)
+            GROUP BY o.dataAssinatura
+            ORDER BY o.dataAssinatura
+            """)
+    List<Object[]> countOrganizationsSignedByDateRange(@Param("inicio") LocalDate inicio,
+                                                        @Param("fim") LocalDate fim,
+                                                        @Param("excludedOrganizationId") Integer excludedOrganizationId);
+
+    @Query("""
+            SELECT COUNT(o)
+            FROM Organization o
+            WHERE (:excludedOrganizationId IS NULL OR o.id <> :excludedOrganizationId)
+            """)
+    long countAllExcluding(@Param("excludedOrganizationId") Integer excludedOrganizationId);
 }
 

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -180,4 +180,25 @@ public interface VendaRepository extends JpaRepository<Venda, Integer>, JpaSpeci
             """)
     List<Object[]> findPrimeiraVendaPorOrganizacao(@Param("inicio") LocalDate inicio,
                                                    @Param("fim") LocalDate fim);
+
+    @Query("""
+            SELECT v.dataEfetuacao AS dia,
+                   COUNT(DISTINCT v.organizationId) AS quantidade
+            FROM Venda v
+            WHERE v.dataEfetuacao IS NOT NULL
+              AND v.dataEfetuacao BETWEEN :inicio AND :fim
+            GROUP BY v.dataEfetuacao
+            ORDER BY v.dataEfetuacao
+            """)
+    List<Object[]> countDistinctOrganizationsWithSalesByDate(@Param("inicio") LocalDate inicio,
+                                                              @Param("fim") LocalDate fim);
+
+    @Query("""
+            SELECT DISTINCT v.organizationId
+            FROM Venda v
+            WHERE v.dataEfetuacao IS NOT NULL
+              AND v.dataEfetuacao BETWEEN :inicio AND :fim
+            """)
+    List<Integer> findDistinctOrganizationIdsWithSalesBetween(@Param("inicio") LocalDate inicio,
+                                                               @Param("fim") LocalDate fim);
 }


### PR DESCRIPTION
## Summary
- extend platform analytics service with organization overview aggregation and platform-only gatekeeping
- add repository aggregations and DTO to surface platform organization creation, activation, and activity insights
- expose new platform analytics endpoint and cover service flow with unit tests

## Testing
- `./mvnw -q test`


------
https://chatgpt.com/codex/tasks/task_e_68dd5a0cf24c8324aeb4318dc6ba7375