### PR TITLE
Refine platform feature adoption aggregation

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsService.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 
 @Service
@@ -250,27 +251,13 @@ public class AnalyticsService {
                 .mapToLong(PlanFeatureAdoptionProjection::getTotalOrganizations)
                 .sum();
 
-        long agendaEnabled = aggregations.stream()
-                .mapToLong(PlanFeatureAdoptionProjection::getAgendaEnabledCount)
-                .sum();
-        long recomendacoesEnabled = aggregations.stream()
-                .mapToLong(PlanFeatureAdoptionProjection::getRecomendacoesEnabledCount)
-                .sum();
-        long pagamentosEnabled = aggregations.stream()
-                .mapToLong(PlanFeatureAdoptionProjection::getPagamentosEnabledCount)
-                .sum();
-        long suportePrioritarioEnabled = aggregations.stream()
-                .mapToLong(PlanFeatureAdoptionProjection::getSuportePrioritarioEnabledCount)
-                .sum();
-        long monitoramentoEstoqueEnabled = aggregations.stream()
-                .mapToLong(PlanFeatureAdoptionProjection::getMonitoramentoEstoqueEnabledCount)
-                .sum();
-        long metricasProdutoEnabled = aggregations.stream()
-                .mapToLong(PlanFeatureAdoptionProjection::getMetricasProdutoEnabledCount)
-                .sum();
-        long integracaoMarketplaceEnabled = aggregations.stream()
-                .mapToLong(PlanFeatureAdoptionProjection::getIntegracaoMarketplaceEnabledCount)
-                .sum();
+        long agendaEnabled = sumFeature(aggregations, PlanFeatureAdoptionProjection::getAgendaEnabledCount);
+        long recomendacoesEnabled = sumFeature(aggregations, PlanFeatureAdoptionProjection::getRecomendacoesEnabledCount);
+        long pagamentosEnabled = sumFeature(aggregations, PlanFeatureAdoptionProjection::getPagamentosEnabledCount);
+        long suportePrioritarioEnabled = sumFeature(aggregations, PlanFeatureAdoptionProjection::getSuportePrioritarioEnabledCount);
+        long monitoramentoEstoqueEnabled = sumFeature(aggregations, PlanFeatureAdoptionProjection::getMonitoramentoEstoqueEnabledCount);
+        long metricasProdutoEnabled = sumFeature(aggregations, PlanFeatureAdoptionProjection::getMetricasProdutoEnabledCount);
+        long integracaoMarketplaceEnabled = sumFeature(aggregations, PlanFeatureAdoptionProjection::getIntegracaoMarketplaceEnabledCount);
 
         return PlatformFeatureAdoptionDTO.builder()
                 .totalOrganizations(totalOrganizations)
@@ -324,6 +311,13 @@ public class AnalyticsService {
                 .organizations(enabledOrganizations)
                 .adoptionPercentage(adoptionPercentage)
                 .build();
+    }
+
+    private long sumFeature(List<PlanFeatureAdoptionProjection> aggregations,
+                            ToLongFunction<PlanFeatureAdoptionProjection> extractor) {
+        return aggregations.stream()
+                .mapToLong(extractor)
+                .sum();
     }
 
     private Organization getCurrentOrganizationOrThrow() {

--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
@@ -34,13 +34,13 @@ public interface OrganizationRepository extends JpaRepository<Organization, Inte
            SELECT p.id AS planId,
                    p.nome AS planName,
                    COUNT(o) AS totalOrganizations,
-                   SUM(CASE WHEN p.agendaHabilitada = true THEN 1 ELSE 0 END) AS agendaEnabledCount,
-                   SUM(CASE WHEN p.recomendacoesHabilitadas = true THEN 1 ELSE 0 END) AS recomendacoesEnabledCount,
-                   SUM(CASE WHEN p.pagamentosHabilitados = true THEN 1 ELSE 0 END) AS pagamentosEnabledCount,
-                   SUM(CASE WHEN p.suportePrioritario = true THEN 1 ELSE 0 END) AS suportePrioritarioEnabledCount,
-                   SUM(CASE WHEN p.monitoramentoEstoqueHabilitado = true THEN 1 ELSE 0 END) AS monitoramentoEstoqueEnabledCount,
-                   SUM(CASE WHEN p.metricasProdutoHabilitadas = true THEN 1 ELSE 0 END) AS metricasProdutoEnabledCount,
-                   SUM(CASE WHEN p.integracaoMarketplaceHabilitada = true THEN 1 ELSE 0 END) AS integracaoMarketplaceEnabledCount
+                   COALESCE(SUM(CASE WHEN p.agendaHabilitada = true THEN 1 ELSE 0 END), 0) AS agendaEnabledCount,
+                   COALESCE(SUM(CASE WHEN p.recomendacoesHabilitadas = true THEN 1 ELSE 0 END), 0) AS recomendacoesEnabledCount,
+                   COALESCE(SUM(CASE WHEN p.pagamentosHabilitados = true THEN 1 ELSE 0 END), 0) AS pagamentosEnabledCount,
+                   COALESCE(SUM(CASE WHEN p.suportePrioritario = true THEN 1 ELSE 0 END), 0) AS suportePrioritarioEnabledCount,
+                   COALESCE(SUM(CASE WHEN p.monitoramentoEstoqueHabilitado = true THEN 1 ELSE 0 END), 0) AS monitoramentoEstoqueEnabledCount,
+                   COALESCE(SUM(CASE WHEN p.metricasProdutoHabilitadas = true THEN 1 ELSE 0 END), 0) AS metricasProdutoEnabledCount,
+                   COALESCE(SUM(CASE WHEN p.integracaoMarketplaceHabilitada = true THEN 1 ELSE 0 END), 0) AS integracaoMarketplaceEnabledCount
             FROM Organization o
             JOIN o.planoAtivoId p
             WHERE (:excludedOrganizationId IS NULL OR o.id <> :excludedOrganizationId)


### PR DESCRIPTION
## Summary
- ensure feature adoption aggregation queries default to zero counts per plan
- reuse a helper in AnalyticsService when summing feature adoption totals

## Testing
- `./mvnw -q -DskipTests package` *(fails: interrupted due to long-running build)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5a25b6f4832498d9707d4979fbec