### PR TITLE
Add platform organization summary analytics

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
@@ -3,7 +3,7 @@ package com.AIT.Optimanage.Analytics;
 import com.AIT.Optimanage.Analytics.DTOs.InventoryAlertDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformEngajamentoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformFeatureAdoptionDTO;
-import com.AIT.Optimanage.Analytics.DTOs.PlatformOrganizationsOverviewDTO;
+import com.AIT.Optimanage.Analytics.DTOs.PlatformOrganizationsResumoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformResumoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PrevisaoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.ResumoDTO;
@@ -39,8 +39,13 @@ public class AnalyticsController extends V1BaseController {
     }
 
     @GetMapping("/plataforma/resumo")
-    public ResponseEntity<PlatformResumoDTO> resumoPlataforma() {
+    public ResponseEntity<PlatformOrganizationsResumoDTO> resumoPlataforma() {
         return ok(analyticsService.obterResumoPlataforma());
+    }
+
+    @GetMapping("/plataforma/resumo-financeiro")
+    public ResponseEntity<PlatformResumoDTO> resumoFinanceiroPlataforma() {
+        return ok(analyticsService.obterResumoFinanceiroPlataforma());
     }
 
     @GetMapping("/plataforma/engajamento")
@@ -53,9 +58,5 @@ public class AnalyticsController extends V1BaseController {
         return ok(analyticsService.obterAdocaoRecursosPlataforma());
     }
 
-    @GetMapping("/plataforma/organizacoes/visao-geral")
-    public ResponseEntity<PlatformOrganizationsOverviewDTO> overviewOrganizacoesPlataforma() {
-        return ok(analyticsService.obterResumoOrganizacoesPlataforma());
-    }
 }
 

--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformOrganizationsResumoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformOrganizationsResumoDTO.java
@@ -12,9 +12,9 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class PlatformOrganizationsOverviewDTO {
+public class PlatformOrganizationsResumoDTO {
     private List<TimeSeriesPoint> criadas;
-    private List<TimeSeriesPoint> assinadas;
+    private List<TimeSeriesPoint> ativadas;
     private long totalAtivas;
     private long totalInativas;
 

--- a/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
@@ -72,4 +72,15 @@ public interface CompraRepository extends JpaRepository<Compra, Integer>, JpaSpe
             """)
     List<Integer> findDistinctOrganizationIdsWithPurchasesBetween(@Param("inicio") LocalDate inicio,
                                                                    @Param("fim") LocalDate fim);
+
+    @Query("""
+            SELECT COUNT(DISTINCT c.organizationId)
+            FROM Compra c
+            WHERE c.dataEfetuacao IS NOT NULL
+              AND c.dataEfetuacao BETWEEN :inicio AND :fim
+              AND (:excludedOrganizationId IS NULL OR c.organizationId <> :excludedOrganizationId)
+            """)
+    long countDistinctOrganizationsWithPurchasesBetween(@Param("inicio") LocalDate inicio,
+                                                         @Param("fim") LocalDate fim,
+                                                         @Param("excludedOrganizationId") Integer excludedOrganizationId);
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Venda/VendaRepository.java
@@ -201,4 +201,15 @@ public interface VendaRepository extends JpaRepository<Venda, Integer>, JpaSpeci
             """)
     List<Integer> findDistinctOrganizationIdsWithSalesBetween(@Param("inicio") LocalDate inicio,
                                                                @Param("fim") LocalDate fim);
+
+    @Query("""
+            SELECT COUNT(DISTINCT v.organizationId)
+            FROM Venda v
+            WHERE v.dataEfetuacao IS NOT NULL
+              AND v.dataEfetuacao BETWEEN :inicio AND :fim
+              AND (:excludedOrganizationId IS NULL OR v.organizationId <> :excludedOrganizationId)
+            """)
+    long countDistinctOrganizationsWithSalesBetween(@Param("inicio") LocalDate inicio,
+                                                    @Param("fim") LocalDate fim,
+                                                    @Param("excludedOrganizationId") Integer excludedOrganizationId);
 }


### PR DESCRIPTION
## Summary
- add platform-only organization summary analytics DTO and service flow
- expose dedicated platform endpoints and aggregated repository queries for recent activity counts
- cover platform summary access rules with updated unit tests

## Testing
- ./mvnw -q -DskipITs test

------
https://chatgpt.com/codex/tasks/task_e_68dd665680948324994d6483183e235e