### PR TITLE
feat: add platform health score analytics endpoint

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/AnalyticsController.java
@@ -3,6 +3,7 @@ package com.AIT.Optimanage.Analytics;
 import com.AIT.Optimanage.Analytics.DTOs.InventoryAlertDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformEngajamentoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformFeatureAdoptionDTO;
+import com.AIT.Optimanage.Analytics.DTOs.PlatformHealthScoreDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformOrganizationsResumoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PlatformResumoDTO;
 import com.AIT.Optimanage.Analytics.DTOs.PrevisaoDTO;
@@ -41,6 +42,11 @@ public class AnalyticsController extends V1BaseController {
     @GetMapping({"/plataforma/organizacoes/visao-geral", "/plataforma/organizacoes/resumo"})
     public ResponseEntity<PlatformOrganizationsResumoDTO> resumoOrganizacoesPlataforma() {
         return ok(analyticsService.obterResumoPlataforma());
+    }
+
+    @GetMapping("/plataforma/organizacoes/health-score")
+    public ResponseEntity<PlatformHealthScoreDTO> healthScoreOrganizacoesPlataforma() {
+        return ok(analyticsService.obterHealthScorePlataforma());
     }
 
     @GetMapping({"/plataforma/resumo", "/plataforma/resumo-financeiro"})

--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformHealthScoreDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformHealthScoreDTO.java
@@ -1,0 +1,27 @@
+package com.AIT.Optimanage.Analytics.DTOs;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+
+@Value
+@Builder
+public class PlatformHealthScoreDTO {
+
+    long totalOrganizations;
+    long clientesSemVendasRecentes;
+    BigDecimal volumeComprasUltimos30Dias;
+
+    HealthSegment ativoEmVendas;
+    HealthSegment ativoEmCompras;
+    HealthSegment emRisco;
+    HealthSegment churn;
+
+    @Value
+    @Builder
+    public static class HealthSegment {
+        long organizations;
+        BigDecimal percentage;
+    }
+}

--- a/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Compra/CompraRepository.java
@@ -83,4 +83,14 @@ public interface CompraRepository extends JpaRepository<Compra, Integer>, JpaSpe
     long countDistinctOrganizationsWithPurchasesBetween(@Param("inicio") LocalDate inicio,
                                                          @Param("fim") LocalDate fim,
                                                          @Param("excludedOrganizationId") Integer excludedOrganizationId);
+
+    @Query("""
+            SELECT COALESCE(SUM(c.valorFinal), 0)
+            FROM Compra c
+            WHERE c.dataEfetuacao BETWEEN :inicio AND :fim
+              AND (:excludedOrganizationId IS NULL OR c.organizationId <> :excludedOrganizationId)
+            """)
+    BigDecimal sumValorFinalGlobalBetweenDates(@Param("inicio") LocalDate inicio,
+                                               @Param("fim") LocalDate fim,
+                                               @Param("excludedOrganizationId") Integer excludedOrganizationId);
 }


### PR DESCRIPTION
## Summary
- add a DTO and repository query to aggregate health score metrics for platform organizations
- implement a platform-only health score calculation combining sales, purchase activity, and churn risk
- expose the health score through a new analytics endpoint for retention segmentation

## Testing
- ./mvnw -q test

------
https://chatgpt.com/codex/tasks/task_e_68dd70ce1c108324ba23df3ebf07c73f