### PR TITLE
Add audit trail entries for plan subscription changes

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Services/AuditTrailService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/AuditTrailService.java
@@ -1,6 +1,8 @@
 package com.AIT.Optimanage.Services;
 
 import com.AIT.Optimanage.Models.Audit.AuditTrail;
+import com.AIT.Optimanage.Models.Organization.Organization;
+import com.AIT.Optimanage.Models.Plano;
 import com.AIT.Optimanage.Repositories.Audit.AuditTrailRepository;
 import com.AIT.Optimanage.Security.CurrentUser;
 import com.AIT.Optimanage.Support.TenantContext;
@@ -23,6 +25,42 @@ public class AuditTrailService {
 
     public void recordSaleCancellation(Integer vendaId, String details) {
         record("VENDA", vendaId, "CANCELAMENTO_VENDA", details);
+    }
+
+    public void recordPlanSubscription(
+            Organization organization,
+            Plano previousPlan,
+            Plano newPlan,
+            boolean previousTrial,
+            boolean newTrial
+    ) {
+        if (organization == null) {
+            return;
+        }
+
+        String previousPlanInfo = previousPlan == null
+                ? "Nenhum"
+                : String.format("%s (ID: %d, trial=%s)",
+                previousPlan.getNome(),
+                previousPlan.getId(),
+                previousTrial);
+
+        String newPlanInfo = newPlan == null
+                ? "Nenhum"
+                : String.format("%s (ID: %d, trial=%s)",
+                newPlan.getNome(),
+                newPlan.getId(),
+                newTrial);
+
+        String details = String.format(
+                "Organização: %s (ID: %d); Plano anterior: %s; Plano atual: %s",
+                organization.getNomeFantasia(),
+                organization.getId(),
+                previousPlanInfo,
+                newPlanInfo
+        );
+
+        record("ORGANIZACAO", organization.getId(), "ALTERACAO_ASSINATURA_PLANO", details);
     }
 
     public void record(String entityType, Integer entityId, String action, String details) {

--- a/src/test/java/com/AIT/Optimanage/Services/PlanoServiceCacheTest.java
+++ b/src/test/java/com/AIT/Optimanage/Services/PlanoServiceCacheTest.java
@@ -151,7 +151,7 @@ class PlanoServiceCacheTest {
         assertThat(second).contains(novo);
         verify(organizationRepository, times(3)).findById(1);
         verify(organizationRepository, times(1)).save(info);
-        verify(planoRepository, times(1)).findById(10);
+        verify(planoRepository, times(2)).findById(10);
         verify(planoRepository, times(2)).findById(20);
     }
 }


### PR DESCRIPTION
## Summary
- add a new `AuditTrailService.recordPlanSubscription` helper to capture plan changes with trial indicators
- invoke the audit trail when creating an organization or updating its active plan
- extend unit tests to cover the new logging behaviour and cache expectations

## Testing
- ./mvnw -Dtest=OrganizationServiceTest,UsuarioServiceTest,PlanoServiceCacheTest test

------
https://chatgpt.com/codex/tasks/task_e_68e00bbec99483248d81db2666ccafeb