### PR TITLE
Add organization trial support and analytics

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformOnboardingMetricsDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Analytics/DTOs/PlatformOnboardingMetricsDTO.java
@@ -16,4 +16,9 @@ public class PlatformOnboardingMetricsDTO {
     BigDecimal percentualAssinatura30Dias;
     BigDecimal taxaConversaoTotal;
     BigDecimal taxaConversaoUltimos30Dias;
+    long totalTrials;
+    long trialsAtivos;
+    long trialsExpirados;
+    BigDecimal taxaConversaoTrials;
+    BigDecimal taxaConversaoTrialsNoPrazo;
 }

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/OrganizationRequest.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/OrganizationRequest.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
+import com.AIT.Optimanage.Models.Organization.TrialType;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -38,6 +40,12 @@ public class OrganizationRequest {
 
     @NotNull
     private Integer planoId;
+
+    private LocalDate trialInicio;
+
+    private LocalDate trialFim;
+
+    private TrialType trialTipo;
 
     @Valid
     @NotNull

--- a/src/main/java/com/AIT/Optimanage/Controllers/dto/OrganizationResponse.java
+++ b/src/main/java/com/AIT/Optimanage/Controllers/dto/OrganizationResponse.java
@@ -5,6 +5,10 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
+import com.AIT.Optimanage.Models.Organization.TrialType;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -16,4 +20,7 @@ public class OrganizationResponse {
     private String razaoSocial;
     private String nomeFantasia;
     private Integer ownerUserId;
+    private LocalDate trialInicio;
+    private LocalDate trialFim;
+    private TrialType trialTipo;
 }

--- a/src/main/java/com/AIT/Optimanage/Models/Organization/Organization.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Organization/Organization.java
@@ -4,6 +4,7 @@ import com.AIT.Optimanage.Models.AuditableEntity;
 import com.AIT.Optimanage.Models.OwnableEntity;
 import com.AIT.Optimanage.Models.Plano;
 import com.AIT.Optimanage.Models.User.User;
+import com.AIT.Optimanage.Models.Organization.TrialType;
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -72,5 +73,12 @@ public class Organization extends AuditableEntity implements OwnableEntity {
 
     @Column(precision = 2)
     private Float metaAnual;
+
+    private LocalDate trialInicio;
+
+    private LocalDate trialFim;
+
+    @Enumerated(EnumType.STRING)
+    private TrialType trialTipo;
 }
 

--- a/src/main/java/com/AIT/Optimanage/Models/Organization/TrialType.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Organization/TrialType.java
@@ -1,0 +1,6 @@
+package com.AIT.Optimanage.Models.Organization;
+
+public enum TrialType {
+    PLAN_DEFAULT,
+    CUSTOM
+}

--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationOnboardingProjection.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationOnboardingProjection.java
@@ -3,7 +3,12 @@ package com.AIT.Optimanage.Repositories.Organization;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import com.AIT.Optimanage.Models.Organization.TrialType;
+
 public interface OrganizationOnboardingProjection {
     LocalDateTime getCreatedAt();
     LocalDate getDataAssinatura();
+    LocalDate getTrialInicio();
+    LocalDate getTrialFim();
+    TrialType getTrialTipo();
 }

--- a/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
+++ b/src/main/java/com/AIT/Optimanage/Repositories/Organization/OrganizationRepository.java
@@ -142,7 +142,10 @@ public interface OrganizationRepository extends JpaRepository<Organization, Inte
 
     @Query("""
             SELECT o.createdAt AS createdAt,
-                   o.dataAssinatura AS dataAssinatura
+                   o.dataAssinatura AS dataAssinatura,
+                   o.trialInicio AS trialInicio,
+                   o.trialFim AS trialFim,
+                   o.trialTipo AS trialTipo
             FROM Organization o
             WHERE (:excludedOrganizationId IS NULL OR o.id <> :excludedOrganizationId)
               AND (:createdSince IS NULL OR o.createdAt >= :createdSince)

--- a/src/main/resources/db/migration/V10__add_trial_fields_to_organization.sql
+++ b/src/main/resources/db/migration/V10__add_trial_fields_to_organization.sql
@@ -1,0 +1,4 @@
+ALTER TABLE organization
+    ADD COLUMN trial_inicio DATE NULL,
+    ADD COLUMN trial_fim DATE NULL,
+    ADD COLUMN trial_tipo VARCHAR(32) NULL;


### PR DESCRIPTION
## Summary
- add Flyway migration and entity/DTO mappings for organization trial start, end, and type
- automatically populate trial windows during organization creation and expose them in responses
- extend platform onboarding analytics to track trial conversion/expiration and add targeted tests

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e013f54ac88324acad162a8e6325a8