### PR TITLE
Allow optional billing date for sales

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
@@ -44,7 +44,7 @@ public class Venda extends AuditableEntity implements OwnableEntity {
     private LocalTime horaAgendada;
     @Column(name = "duracao_estimada")
     private Duration duracaoEstimada;
-    @Column(nullable = false)
+    @Column(nullable = true)
     private LocalDate dataCobranca;
     @DecimalMin(value = "0.0")
     @Column(nullable = false, precision = 10, scale = 2)

--- a/src/test/java/com/AIT/Optimanage/Models/Venda/VendaEntityTest.java
+++ b/src/test/java/com/AIT/Optimanage/Models/Venda/VendaEntityTest.java
@@ -1,0 +1,19 @@
+package com.AIT.Optimanage.Models.Venda;
+
+import jakarta.persistence.Column;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VendaEntityTest {
+
+    @Test
+    void dataCobrancaPermiteValoresNulos() throws NoSuchFieldException {
+        Field campoDataCobranca = Venda.class.getDeclaredField("dataCobranca");
+        Column column = campoDataCobranca.getAnnotation(Column.class);
+        assertTrue(column == null || column.nullable(),
+                "O campo dataCobranca deve aceitar valores nulos para permitir vendas pendentes");
+    }
+}


### PR DESCRIPTION
## Summary
- allow vendas to persist without a billing date when ainda pendentes by marking dataCobranca as nullable
- add a regression test ensuring the entity metadata keeps the billing date optional

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e57a92f8848324bcbea06bd03a9f59