### PR TITLE
Fix enum and audit schema compatibility for tests

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Audit/AuditTrail.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Audit/AuditTrail.java
@@ -3,6 +3,7 @@ package com.AIT.Optimanage.Models.Audit;
 import com.AIT.Optimanage.Models.AuditableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,6 +30,7 @@ public class AuditTrail extends AuditableEntity {
     @Column(name = "action", nullable = false, length = 150)
     private String action;
 
-    @Column(name = "details", columnDefinition = "TEXT")
+    @Lob
+    @Column(name = "details")
     private String details;
 }

--- a/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/Contador.java
@@ -1,9 +1,17 @@
 package com.AIT.Optimanage.Models.User;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+
 import com.AIT.Optimanage.Models.Audit.OwnerEntityListener;
 import com.AIT.Optimanage.Models.OwnableEntity;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import com.AIT.Optimanage.Models.AuditableEntity;
 
 @Data
@@ -13,6 +21,7 @@ import com.AIT.Optimanage.Models.AuditableEntity;
 @Entity
 @EntityListeners(OwnerEntityListener.class)
 public class Contador extends AuditableEntity implements OwnableEntity {
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Tabela nomeTabela;
     @Column(nullable = false)


### PR DESCRIPTION
## Summary
- map Contador.nomeTabela to EnumType.STRING so the in-memory H2 schema matches production enum values
- persist audit trail details as a LOB instead of a MySQL-specific TEXT column so tests and production share the same mapping

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68e57a92f8848324bcbea06bd03a9f59