### PR TITLE
Ensure Lombok builders preserve entity defaults

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Cliente/Cliente.java
@@ -41,6 +41,7 @@ public class Cliente extends AuditableEntity implements OwnableEntity {
     @Column(nullable = false, length = 64)
     private String origem;
 
+    @Builder.Default
     @Column(nullable = false)
     private Boolean ativo = true;
     @Column(name = "lifetime_value", nullable = false, precision = 12, scale = 2)

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/Compra.java
@@ -50,6 +50,7 @@ public class Compra extends AuditableEntity implements OwnableEntity {
     @DecimalMin(value = "0.0")
     @Column(nullable = false, precision = 10, scale = 2)
     private BigDecimal valorPendente;
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private StatusCompra status = StatusCompra.ORCAMENTO;

--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraDTO.java
@@ -21,15 +21,19 @@ import java.util.List;
 public class CompraDTO {
     @NotNull
     private Integer fornecedorId;
+    @Builder.Default
     @NotNull
     private LocalDate dataEfetuacao = LocalDate.now();
+    @Builder.Default
     private LocalDate dataAgendada = null;
     private LocalTime horaAgendada;
+    @Builder.Default
     private Duration duracaoEstimada = Duration.ofHours(1);
     private LocalDate dataCobranca;
     @DecimalMin(value = "0.0")
     private BigDecimal valorFinal;
     private String condicaoPagamento;
+    @Builder.Default
     @NotNull
     private StatusCompra status = StatusCompra.ORCAMENTO;
     private String observacoes;

--- a/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Fornecedor/Fornecedor.java
@@ -42,6 +42,7 @@ public class Fornecedor extends AuditableEntity implements OwnableEntity {
     @Column(nullable = false, length = 64)
     private String origem;
 
+    @Builder.Default
     @Column(nullable = false)
     private Boolean ativo = true;
     @Column(length = 64)

--- a/src/main/java/com/AIT/Optimanage/Models/Produto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Produto.java
@@ -52,6 +52,7 @@ public class Produto extends AuditableEntity implements OwnableEntity {
     @Column(nullable = false)
     private Integer prazoReposicaoDias = 0;
     private Boolean terceirizado;
+    @Builder.Default
     @Column(nullable = false)
     private Boolean ativo = true;
 

--- a/src/main/java/com/AIT/Optimanage/Models/Servico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Servico.java
@@ -42,6 +42,7 @@ public class Servico extends AuditableEntity implements OwnableEntity {
     @Column(nullable = false)
     private Integer tempoExecucao;
     private Boolean terceirizado;
+    @Builder.Default
     @Column(nullable = false)
     private Boolean ativo = true;
 

--- a/src/main/java/com/AIT/Optimanage/Models/User/User.java
+++ b/src/main/java/com/AIT/Optimanage/Models/User/User.java
@@ -32,6 +32,7 @@ public class User extends AuditableEntity implements UserDetails {
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Column(nullable = false)
     private String senha;
+    @Builder.Default
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     @Column(nullable = false)
     private Boolean ativo = true;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/DTOs/VendaDTO.java
@@ -21,18 +21,24 @@ import java.util.List;
 public class VendaDTO {
     @NotNull
     private Integer clienteId;
+    @Builder.Default
     @NotNull
     private LocalDate dataEfetuacao = LocalDate.now();
+    @Builder.Default
     private LocalDate dataAgendada = null;
     private LocalTime horaAgendada;
+    @Builder.Default
     private Duration duracaoEstimada = Duration.ofHours(1);
     private LocalDate dataCobranca;
+    @Builder.Default
     @DecimalMin(value = "0.0")
     @DecimalMax(value = "100.0")
     private BigDecimal descontoGeral = BigDecimal.ZERO;
     private String condicaoPagamento;
+    @Builder.Default
     @Min(0)
     private Integer alteracoesPermitidas = 0;
+    @Builder.Default
     @NotNull
     private StatusVenda status = StatusVenda.PENDENTE;
     private String observacoes;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/Venda.java
@@ -56,12 +56,14 @@ public class Venda extends AuditableEntity implements OwnableEntity {
     @Column(nullable = false, precision = 10, scale = 2)
     private BigDecimal valorFinal;
     private String condicaoPagamento;
+    @Builder.Default
     @Min(0)
     @Column(nullable = false)
     private Integer alteracoesPermitidas = 0;
     @DecimalMin(value = "0.0")
     @Column(nullable = false, precision = 10, scale = 2)
     private BigDecimal valorPendente;
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private StatusVenda status = StatusVenda.PENDENTE;

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/VendaProduto.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/VendaProduto.java
@@ -41,6 +41,7 @@ public class VendaProduto extends AuditableEntity {
     @Column(nullable = false)
     private Integer quantidade;
 
+    @Builder.Default
     @Column(length = 3)
     private BigDecimal desconto = BigDecimal.ZERO;
 

--- a/src/main/java/com/AIT/Optimanage/Models/Venda/VendaServico.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Venda/VendaServico.java
@@ -41,6 +41,7 @@ public class VendaServico extends AuditableEntity {
     @Column(nullable = false, precision = 10, scale = 2)
     private BigDecimal valorUnitario;
 
+    @Builder.Default
     @Column(length = 3)
     private BigDecimal desconto = BigDecimal.ZERO;
 


### PR DESCRIPTION
## Summary
- add `@Builder.Default` to core entity fields so Lombok builders retain default business values
- align purchase and sale DTO defaults to prevent null statuses and scheduling data when using builders

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68e6573cbf38832481f654fb0ff49c6b