### PR TITLE
Allow pending/completed sales without billing date

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Validation/VendaValidator.java
+++ b/src/main/java/com/AIT/Optimanage/Validation/VendaValidator.java
@@ -17,13 +17,6 @@ public class VendaValidator {
         if (vendaDTO.getDataAgendada() == null && vendaDTO.getStatus() == StatusVenda.AGENDADA) {
             throw new IllegalArgumentException("Data agendada não informada para venda agendada");
         }
-        if (vendaDTO.getDataCobranca() == null) {
-            if (vendaDTO.getStatus() == StatusVenda.AGUARDANDO_PAG) {
-                throw new IllegalArgumentException("Data de cobrança não informada para venda aguardando pagamento");
-            } else if (vendaDTO.getStatus() == StatusVenda.CONCRETIZADA) {
-                throw new IllegalArgumentException("Data de cobrança não informada para venda concretizada");
-            }
-        }
         boolean permiteOrcamento = loggedUser != null
                 && loggedUser.getOrganization() != null
                 && Boolean.TRUE.equals(loggedUser.getOrganization().getPermiteOrcamento());

--- a/src/test/java/com/AIT/Optimanage/Validation/VendaValidatorTest.java
+++ b/src/test/java/com/AIT/Optimanage/Validation/VendaValidatorTest.java
@@ -77,4 +77,32 @@ class VendaValidatorTest {
 
         assertThrows(IllegalArgumentException.class, () -> validator.validarVenda(dto, new User()));
     }
+
+    @Test
+    void validarVendaNaoExigeDataCobrancaParaStatusAguardandoPagamento() {
+        VendaDTO dto = VendaDTO.builder()
+                .clienteId(1)
+                .dataEfetuacao(LocalDate.now())
+                .status(StatusVenda.AGUARDANDO_PAG)
+                .descontoGeral(BigDecimal.ZERO)
+                .produtos(List.of(new VendaProdutoDTO(1, 1, BigDecimal.ZERO)))
+                .servicos(List.of(new VendaServicoDTO(1, 1, BigDecimal.ZERO)))
+                .build();
+
+        assertDoesNotThrow(() -> validator.validarVenda(dto, new User()));
+    }
+
+    @Test
+    void validarVendaNaoExigeDataCobrancaParaStatusConcretizada() {
+        VendaDTO dto = VendaDTO.builder()
+                .clienteId(1)
+                .dataEfetuacao(LocalDate.now())
+                .status(StatusVenda.CONCRETIZADA)
+                .descontoGeral(BigDecimal.ZERO)
+                .produtos(List.of(new VendaProdutoDTO(1, 1, BigDecimal.ZERO)))
+                .servicos(List.of(new VendaServicoDTO(1, 1, BigDecimal.ZERO)))
+                .build();
+
+        assertDoesNotThrow(() -> validator.validarVenda(dto, new User()));
+    }
 }


### PR DESCRIPTION
## Summary
- allow the venda validator to accept pending and completed sales without a billing date, matching the payment flow rules
- add regression coverage to ensure those statuses no longer require `dataCobranca`

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e6573cbf38832481f654fb0ff49c6b