### PR TITLE
Allow customizing service prices in purchase flows

### DIFF
--- a/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraServicoDTO.java
+++ b/src/main/java/com/AIT/Optimanage/Models/Compra/DTOs/CompraServicoDTO.java
@@ -1,10 +1,13 @@
 package com.AIT.Optimanage.Models.Compra.DTOs;
 
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
 
 @Data
 @NoArgsConstructor
@@ -16,4 +19,12 @@ public class CompraServicoDTO {
     @NotNull
     @Min(1)
     private Integer quantidade;
+
+    @DecimalMin(value = "0.0", inclusive = false, message = "O valor unitário deve ser maior que zero")
+    private BigDecimal valorUnitario;
+
+    public CompraServicoDTO(Integer servicoId, Integer quantidade) {
+        this.servicoId = servicoId;
+        this.quantidade = quantidade;
+    }
 }

--- a/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Compra/CompraService.java
@@ -596,9 +596,14 @@ public class CompraService {
         return servicosDTO.stream()
                 .map(servicoDTO -> {
                     Servico servico = servicoService.buscarServicoAtivo(servicoDTO.getServicoId());
-                    BigDecimal valorUnitario = Optional.ofNullable(servico.getCusto())
-                            .orElse(servico.getValorVenda());
-                    BigDecimal valorTotal = valorUnitario.multiply(BigDecimal.valueOf(servicoDTO.getQuantidade()));
+
+                    BigDecimal valorUnitario = Optional.ofNullable(servicoDTO.getValorUnitario())
+                            .orElseGet(() -> Optional.ofNullable(servico.getCusto())
+                                    .orElse(Optional.ofNullable(servico.getValorVenda())
+                                            .orElse(BigDecimal.ZERO)));
+
+                    BigDecimal valorTotal = valorUnitario
+                            .multiply(BigDecimal.valueOf(servicoDTO.getQuantidade()));
 
                     return CompraServico.builder()
                             .compra(compra)

--- a/src/main/java/com/AIT/Optimanage/Services/Importacao/ImportacaoExcelService.java
+++ b/src/main/java/com/AIT/Optimanage/Services/Importacao/ImportacaoExcelService.java
@@ -495,9 +495,13 @@ public class ImportacaoExcelService {
                         );
                         compra.dto.getProdutos().add(produto);
                     } else {
-                        CompraServicoDTO servico = new CompraServicoDTO(
-                                reader.getRequiredInteger(row, "servicoId"),
-                                reader.getRequiredInteger(row, "quantidade"));
+                        Integer servicoId = reader.getRequiredInteger(row, "servicoId");
+                        Integer quantidade = reader.getRequiredInteger(row, "quantidade");
+                        BigDecimal valorUnitario = reader.getBigDecimal(row, "valorUnitario");
+
+                        CompraServicoDTO servico = valorUnitario == null
+                                ? new CompraServicoDTO(servicoId, quantidade)
+                                : new CompraServicoDTO(servicoId, quantidade, valorUnitario);
                         compra.dto.getServicos().add(servico);
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
## Summary
- allow purchase service DTOs to carry a unit price and propagate it when creating entities
- fall back to service cost or sale value when the price is omitted so totals stay consistent
- update Excel import to accept optional service prices alongside quantity

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e6610675288324b16c4e2ce0c75ec4